### PR TITLE
Sync features on startpage

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -88,10 +88,10 @@
             </li>
 
             <li class="dropdown{% if page.url == '/material.html' %} active{% endif %} hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="{{ site.baseurl }}/material.html">Material</a></li>
                 <li><a href="{{ site.twitter }}"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="{{ site.github }}"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/coding-guidelines.html
+++ b/content/coding-guidelines.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/community.html
+++ b/content/community.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>
@@ -147,17 +147,17 @@
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#mailing-lists">Mailing Lists</a></li>
-  <li><a href="#irc">IRC</a></li>
-  <li><a href="#stack-overflow">Stack Overflow</a></li>
-  <li><a href="#issue-tracker">Issue Tracker</a></li>
-  <li><a href="#source-code">Source Code</a>    <ul>
-      <li><a href="#main-source-repositories">Main source repositories</a></li>
-      <li><a href="#website-repositories">Website repositories</a></li>
+  <li><a href="#mailing-lists" id="markdown-toc-mailing-lists">Mailing Lists</a></li>
+  <li><a href="#irc" id="markdown-toc-irc">IRC</a></li>
+  <li><a href="#stack-overflow" id="markdown-toc-stack-overflow">Stack Overflow</a></li>
+  <li><a href="#issue-tracker" id="markdown-toc-issue-tracker">Issue Tracker</a></li>
+  <li><a href="#source-code" id="markdown-toc-source-code">Source Code</a>    <ul>
+      <li><a href="#main-source-repositories" id="markdown-toc-main-source-repositories">Main source repositories</a></li>
+      <li><a href="#website-repositories" id="markdown-toc-website-repositories">Website repositories</a></li>
     </ul>
   </li>
-  <li><a href="#people">People</a></li>
-  <li><a href="#former-mentors">Former mentors</a></li>
+  <li><a href="#people" id="markdown-toc-people">People</a></li>
+  <li><a href="#former-mentors" id="markdown-toc-former-mentors">Former mentors</a></li>
 </ul>
 
 </div>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/faq.html
+++ b/content/faq.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>
@@ -190,6 +190,7 @@ under the License.
       <li><a href="#i-cant-stop-flink-with-the-provided-stop-scripts-what-can-i-do" id="markdown-toc-i-cant-stop-flink-with-the-provided-stop-scripts-what-can-i-do">I can’t stop Flink with the provided stop-scripts. What can I do?</a></li>
       <li><a href="#i-got-an-outofmemoryexception-what-can-i-do" id="markdown-toc-i-got-an-outofmemoryexception-what-can-i-do">I got an OutOfMemoryException. What can I do?</a></li>
       <li><a href="#why-do-the-taskmanager-log-files-become-so-huge" id="markdown-toc-why-do-the-taskmanager-log-files-become-so-huge">Why do the TaskManager log files become so huge?</a></li>
+      <li><a href="#the-slot-allocated-for-my-task-manager-has-been-released-what-should-i-do" id="markdown-toc-the-slot-allocated-for-my-task-manager-has-been-released-what-should-i-do">The slot allocated for my task manager has been released. What should I do?</a></li>
     </ul>
   </li>
   <li><a href="#yarn-deployment" id="markdown-toc-yarn-deployment">YARN Deployment</a>    <ul>
@@ -473,6 +474,14 @@ but may cause data processing tasks to go to disk more often.</p>
 <p>Check the logging behavior of your jobs. Emitting logging per or tuple may be
 helpful to debug jobs in small setups with tiny data sets, it becomes very
 inefficient and disk space consuming if used for large input data.</p>
+
+<h3 id="the-slot-allocated-for-my-task-manager-has-been-released-what-should-i-do">The slot allocated for my task manager has been released. What should I do?</h3>
+
+<p>A <code>java.lang.Exception: The slot in which the task was executed has been released. Probably loss of TaskManager</code> usually occurs when there are big garbage collection stalls.
+In this case, a quick fix would be to use the G1 garbage collector. It works incrementally and it often leads to lower pauses. Furthermore, you can dedicate more memory to the user code (e.g. 0.4 per system and 0.6 per user).</p>
+
+<p>If both of these approaches fail and the error persists, simply increase the TaskManager’s heartbeat pause by setting AKKA_WATCH_HEARTBEAT_PAUSE (akka.watch.heartbeat.pause) to a greater value (e.g. 600s).
+This will cause the JobManager to wait for a heartbeat for a longer time interval before considering the TaskManager lost.</p>
 
 <h2 id="yarn-deployment">YARN Deployment</h2>
 

--- a/content/features.html
+++ b/content/features.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>
@@ -148,7 +148,7 @@
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>Streaming</b></h1>
+    <h1 id="streaming"><b>Streaming</b></h1>
   </div>
 </div>
 
@@ -234,7 +234,7 @@
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>Batch and Streaming in One System</b></h1>
+    <h1 id="batch-on-streaming"><b>Batch and Streaming in One System</b></h1>
   </div>
 </div>
 
@@ -317,7 +317,7 @@
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>APIs and Libraries</b></h1>
+    <h1 id="apis-and-libs"><b>APIs and Libraries</b></h1>
   </div>
 </div>
 

--- a/content/how-to-contribute.html
+++ b/content/how-to-contribute.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/index.html
+++ b/content/index.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>
@@ -138,11 +138,11 @@
       
 
 <div class="row">
-  <div class="col-sm-12"><p class="lead"><strong>Apache Flink</strong> is an open source platform for scalable batch and stream data processing.</p></div>
+  <div class="col-sm-12"><p class="lead"><strong>Apache Flink</strong> is an open source platform for distributed stream and batch data processing.</p></div>
 </div>
 
 <div class="row">
-  <div class="col-sm-6">
+  <div class="col-md-6">
 
     <p><strong>Flink’s core</strong> is a <a href="features.html#unified-stream-amp-batch-processing">streaming dataflow engine</a> that provides data distribution, communication, and fault tolerance for distributed computations over data streams.</p>
 
@@ -162,10 +162,8 @@
     </ol>
 
     <p>You can <strong>integrate</strong> Flink easily with other well-known open source systems both for <a href="features.html#deployment-and-integration">data input and output</a> as well as <a href="features.html#deployment-and-integration">deployment</a>.</p>
-
-    <p><strong>Check out the <a href="features.html">features</a> page to get a tour of all major Flink features.</strong></p>
   </div>
-  <div class="col-sm-6 stack text-center">
+  <div class="col-md-6 stack text-center">
     <img src="/img/flink-stack-small.png" alt="Apache Flink Stack" width="385px" height="300px" />
   </div>
 </div>
@@ -175,32 +173,20 @@
 <div class="frontpage-tags">
   <div class="row">
     <div class="col-md-4 text-center">
-       <h2><span class="glyphicon glyphicon-flash"></span> <a href="features.html#fast">Fast</a></h2>
-      <p>State-of-the art performance exploiting in-memory processing and data streaming.</p>
+      <h2><span class="glyphicon glyphicon-send"></span> <a href="features.html#streaming">Streaming First</a></h2>
+      <p>High throughput and low latency stream processing with exactly-once guarantees.</p>
     </div>
     <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-plane"></span> <a href="features.html#reliable-and-scalable">Reliable</a></h2>
-      <p>Flink is designed to perform very well even when the cluster's memory runs out.</p>
+      <h2><span class="glyphicon glyphicon-flash"></span> <a href="features.html#batch-on-streaming">Batch on Streaming</a></h2>
+      <p>Batch processing applications run efficiently as special cases of stream processing applications.</p>
     </div>
     <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-cutlery"></span> <a href="features.html#expressive">Expressive</a></h2>
-      <p>Write beautiful, type-safe code in Java and Scala. Execute it on a cluster.</p>
+      <h2><span class="glyphicon glyphicon-fire"></span> <a href="features.html#apis-and-libs">APIs, Libraries, and Ecosystem</a></h2>
+      <p>DataSet, DataStream, and more. Integrated with the Apache Big Data stack.</p>
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-send"></span> <a href="features.html#easy-to-use">Easy to use</a></h2>
-      <p>Few configuration parameters required. Cost-based optimizer built in.</p>
-    </div>
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-sort"></span> <a href="features.html#reliable-and-scalable">Scalable</a></h2>
-      <p>Tested on clusters of 100s of machines, Google Compute Engine, and Amazon EC2.</p>
-    </div>
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-refresh"></span> <a href="features.html#hadoop">Hadoop-compatible</a></h2>
-      <p>Flink runs on YARN and HDFS and has a Hadoop compatibility package.</p>
-    </div>
+  <div class="row" style="margin-top: 1em">
+    <div class="col-md-12"><p class="text-center"><strong>Check out the <a href="/features.html">Features</a> page to get a tour of all major Flink features.</strong></p></div>
   </div>
 </div>
 

--- a/content/material.html
+++ b/content/material.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown active hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2012/08/21/release02.html
+++ b/content/news/2012/08/21/release02.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2012/10/15/icde2013.html
+++ b/content/news/2012/10/15/icde2013.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2012/11/12/btw2013demo.html
+++ b/content/news/2012/11/12/btw2013demo.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2012/11/21/previewICDE2013.html
+++ b/content/news/2012/11/21/previewICDE2013.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2013/03/27/www-demo-paper.html
+++ b/content/news/2013/03/27/www-demo-paper.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2013/10/21/cikm2013-paper.html
+++ b/content/news/2013/10/21/cikm2013-paper.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2013/12/13/humboldt-innovation-award.html
+++ b/content/news/2013/12/13/humboldt-innovation-award.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/01/10/stratosphere-hadoop-summit.html
+++ b/content/news/2014/01/10/stratosphere-hadoop-summit.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/01/12/0.4-migration-guide.html
+++ b/content/news/2014/01/12/0.4-migration-guide.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/01/13/stratosphere-release-0.4.html
+++ b/content/news/2014/01/13/stratosphere-release-0.4.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/01/26/optimizer_plan_visualization_tool.html
+++ b/content/news/2014/01/26/optimizer_plan_visualization_tool.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/01/28/querying_mongodb.html
+++ b/content/news/2014/01/28/querying_mongodb.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/02/18/amazon-elastic-mapreduce-cloud-yarn.html
+++ b/content/news/2014/02/18/amazon-elastic-mapreduce-cloud-yarn.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/02/24/stratosphere-google-summer-of-code-2014.html
+++ b/content/news/2014/02/24/stratosphere-google-summer-of-code-2014.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/04/16/stratosphere-goes-apache-incubator.html
+++ b/content/news/2014/04/16/stratosphere-goes-apache-incubator.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/05/31/release-0.5.html
+++ b/content/news/2014/05/31/release-0.5.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/content/project.html
+++ b/content/project.html
@@ -117,10 +117,10 @@
             </li>
 
             <li class="dropdown hidden-md hidden-sm">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Project <span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Media <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <!-- Project -->
-                <li role="presentation" class="dropdown-header"><strong>Project</strong></li>
+                <li role="presentation" class="dropdown-header"><strong>Media</strong></li>
                 <li><a href="/material.html">Material</a></li>
                 <li><a href="https://twitter.com/apacheflink"><small><span class="glyphicon glyphicon-new-window"></span></small> Twitter</a></li>
                 <li><a href="https://github.com/apache/flink"><small><span class="glyphicon glyphicon-new-window"></span></small> GitHub</a></li>

--- a/features.md
+++ b/features.md
@@ -12,7 +12,7 @@ layout: features
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>Streaming</b></h1>
+    <h1 id="streaming"><b>Streaming</b></h1>
   </div>
 </div>
 
@@ -98,7 +98,7 @@ layout: features
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>Batch and Streaming in One System</b></h1>
+    <h1 id="batch-on-streaming"><b>Batch and Streaming in One System</b></h1>
   </div>
 </div>
 
@@ -182,7 +182,7 @@ layout: features
 
 <div class="row" style="padding: 0 0 0 0">
   <div class="col-sm-12" style="text-align: center;">
-    <h1><b>APIs and Libraries</b></h1>
+    <h1 id="apis-and-libs"><b>APIs and Libraries</b></h1>
   </div>
 </div>
 

--- a/index.md
+++ b/index.md
@@ -4,11 +4,11 @@ layout: base
 ---
 
 <div class="row">
-  <div class="col-sm-12"><p class="lead" markdown="span">**Apache Flink** is an open source platform for scalable batch and stream data processing.</p></div>
+  <div class="col-sm-12"><p class="lead" markdown="span">**Apache Flink** is an open source platform for distributed stream and batch data processing.</p></div>
 </div>
 
 <div class="row">
-  <div class="col-sm-6" markdown="1">
+  <div class="col-md-6" markdown="1">
 
 **Flink’s core** is a [streaming dataflow engine](features.html#unified-stream-amp-batch-processing) that provides data distribution, communication, and fault tolerance for distributed computations over data streams.
 
@@ -24,10 +24,8 @@ Flink also bundles **libraries for domain-specific use cases**:
 2. [Gelly](features.html#graph-api-amp-library-gelly), a graph processing API and library.
 
 You can **integrate** Flink easily with other well-known open source systems both for [data input and output](features.html#deployment-and-integration) as well as [deployment](features.html#deployment-and-integration).
-
-**Check out the [features](features.html) page to get a tour of all major Flink features.**
   </div>
-  <div class="col-sm-6 stack text-center">
+  <div class="col-md-6 stack text-center">
     <img src="{{ site.baseurl }}/img/flink-stack-small.png" alt="Apache Flink Stack" width="385px" height="300px">
   </div>
 </div>
@@ -37,32 +35,20 @@ You can **integrate** Flink easily with other well-known open source systems bot
 <div class="frontpage-tags">
   <div class="row">
     <div class="col-md-4 text-center">
-       <h2><span class="glyphicon glyphicon-flash"></span> <a href="features.html#fast">Fast</a></h2>
-      <p>State-of-the art performance exploiting in-memory processing and data streaming.</p>
+      <h2><span class="glyphicon glyphicon-send"></span> <a href="features.html#streaming">Streaming First</a></h2>
+      <p>High throughput and low latency stream processing with exactly-once guarantees.</p>
     </div>
     <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-plane"></span> <a href="features.html#reliable-and-scalable">Reliable</a></h2>
-      <p>Flink is designed to perform very well even when the cluster's memory runs out.</p>
+      <h2><span class="glyphicon glyphicon-flash"></span> <a href="features.html#batch-on-streaming">Batch on Streaming</a></h2>
+      <p>Batch processing applications run efficiently as special cases of stream processing applications.</p>
     </div>
     <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-cutlery"></span> <a href="features.html#expressive">Expressive</a></h2>
-      <p>Write beautiful, type-safe code in Java and Scala. Execute it on a cluster.</p>
+      <h2><span class="glyphicon glyphicon-fire"></span> <a href="features.html#apis-and-libs">APIs, Libraries, and Ecosystem</a></h2>
+      <p>DataSet, DataStream, and more. Integrated with the Apache Big Data stack.</p>
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-send"></span> <a href="features.html#easy-to-use">Easy to use</a></h2>
-      <p>Few configuration parameters required. Cost-based optimizer built in.</p>
-    </div>
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-sort"></span> <a href="features.html#reliable-and-scalable">Scalable</a></h2>
-      <p>Tested on clusters of 100s of machines, Google Compute Engine, and Amazon EC2.</p>
-    </div>
-    <div class="col-md-4 text-center">
-      <h2><span class="glyphicon glyphicon-refresh"></span> <a href="features.html#hadoop">Hadoop-compatible</a></h2>
-      <p>Flink runs on YARN and HDFS and has a Hadoop compatibility package.</p>
-    </div>
+  <div class="row" style="margin-top: 1em">
+    <div class="col-md-12"><p class="text-center"><strong>Check out the <a href="{{ site.baseurl }}/features.html">Features</a> page to get a tour of all major Flink features.</strong></p></div>
   </div>
 </div>
 


### PR DESCRIPTION
@mxm, @ktzoumas, and me want to sync the features on the startpage. They are currently out-of-sync with the features page.

![screen shot 2015-07-31 at 18 16 31](https://cloud.githubusercontent.com/assets/1756620/9011974/81a4ecfe-37b1-11e5-8f47-f7e8e1be6cd3.png)

This also changes:
- Top navbar item "Project" -> "Media"
- Tagline to have streaming first and replace scalable with distributed

We can also remove the top stack (not part of this PR):
![screen shot 2015-07-31 at 18 17 03](https://cloud.githubusercontent.com/assets/1756620/9011983/9119fe4a-37b1-11e5-93dd-ec7aabe189bb.png)



Please provide *concrete* feedback if you want something in another way.