### PR TITLE
[FLINK-3737] adding note about SOCKS proxy server

### DIFF
--- a/contribute-code.md
+++ b/contribute-code.md
@@ -187,7 +187,7 @@ The code is downloaded into a directory called `flink`.
 
 If you are behind a firewall you may need to provide Proxy settings to Maven and your IDE.
 
-Some tests communicate over IRC and need a [SOCKS proxy server](http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to pass.
+For example, the WikipediaEditsSourceTest communicates over IRC and need a [SOCKS proxy server](http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to pass.
 
 ### Setup an IDE and import the source code
 {:.no_toc} 

--- a/contribute-code.md
+++ b/contribute-code.md
@@ -183,6 +183,12 @@ git clone https://github.com/<your-user-name>/flink.git
 The code is downloaded into a directory called `flink`.
 
 
+### Proxy Settings
+
+If you are behind a firewall you may need to provide Proxy settings to Maven and your IDE.
+
+Some tests communicate over IRC and need a [SOCKS proxy server](http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to pass.
+
 ### Setup an IDE and import the source code
 {:.no_toc} 
 


### PR DESCRIPTION
A test was failing because it needed a SOCKS proxy server when behind a firewall.  Adding note.