### PR TITLE
add Gelly changes to release 1.1.0 announcement

### DIFF
--- a/_posts/2016-08-04-release-1.1.0.md
+++ b/_posts/2016-08-04-release-1.1.0.md
@@ -112,6 +112,12 @@ Flink 1.0 added the initial version of the CEP library. The core of the library 
 
 A more detailed introduction can be found in the [Flink blog]( http://flink.apache.org/news/2016/04/06/cep-monitoring.html) and the [CEP documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/libs/cep.html).
 
+## Graph generators and new Gelly library algorithms
+
+This release includes many enhancements and new features for graph processing. Gelly now provides a collection of scalable graph generators for common graph types, such as complete, cycle, grid, hypercube, and RMat graphs. A variety of new graph algorithms have been added to the Gelly library, including Global and Local Clustering Coefficient, HITS, and similarity measures (Jaccard and Adamic-Adar).
+
+For a full list of new graph processing features, check out the [Gelly documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/batch/libs/gelly.html).
+
 ## Metrics
 
 Flink’s new metrics system allows you to easily gather and expose metrics from your user application to external systems. You can add counters, gauges, and histograms to your application via the runtime context:


### PR DESCRIPTION
I've added a short mention about new Gelly features in the 1.1.0 release post.