### PR TITLE
FF16 announcement for community

### DIFF
--- a/_posts/2016-08-24-ff16-keynotes-panels.md
+++ b/_posts/2016-08-24-ff16-keynotes-panels.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title:  "Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion"
+date:   2016-08-24 9:00:00
+categories: news
+---
+
+<p>An update for the Flink community: the<a href="http://flink-forward.org/kb_day/day-1/" target='_blank'> Flink Forward 2016 schedule</a> is now available online. This year's event will include 2 days of talks from stream processing experts at Google, MapR, Alibaba, Netflix, Cloudera, and more. Following the talks is a full day of hands-on Flink training.</p>
+
+<p>Ted Dunning has been announced as a keynote speaker at the event. Ted is the VP of Incubator at <a href="http://www.apache.org" target='_blank'> Apache Software Foundation</a>, the Chief Application Architect at <a href="http://www.mapr.com" target='_blank'> MapR Technologies</a>, and a mentor on many recent projects. He'll present <a href="http://flink-forward.org/kb_sessions/keynote-tba/" target='_blank'> "How Can We Take Flink Forward?"</a> on the second day of the conference.</p>
+
+<p>Following Ted's keynote, there will be a panel discussion on <a href="http://flink-forward.org/kb_sessions/panel-large-scale-streaming-in-production/" target='_blank'> "Large Scale Streaming in Production"</a>. As stream processing systems become more mainstream, companies are looking to empower their users to take advantage of this technology. We welcome leading stream processing experts Xiaowei Jiang <a href="http://www.alibaba.com" target='_blank'>(Alibaba)</a>, Monal Daxini <a href="http://www.netflix.com" target='_blank'>(Netflix)</a>, Maxim Fateev <a href="http://www.uber.com" target='_blank'>(Uber)</a>, and Ted Dunning <a href="http://www.mapr.com" target='_blank'>(MapR Technologies)</a> on stage to talk about the challenges they have faced and the solutions they have discovered while implementing stream processing systems at very large scale. The panel will be moderated by Jamie Grier <a href="http://www.data-artisans.com" target='_blank'> (data Artisans)</a>.</p>
+
+<p>The welcome keynote on Monday, September 12, will be presented by data Artisans' co-founders Kostas Tzoumas and Stephan Ewen. They will talk about <a href="http://flink-forward.org/kb_sessions/keynote-tba-2/" target='_blank'> "The maturing data streaming ecosystem and Apache Flink’s accelerated growth"</a>. In this talk, Kostas and Stephan discuss several large-scale stream processing use cases that the data Artisans team has seen over the past year.</p>
+
+<p>And one more recent addition to the program: Maxim Fateev of Uber will present <a href="http://flink-forward.org/kb_sessions/beyond-the-watermark-on-demand-backfilling-in-flink/" target='_blank'>"Beyond the Watermark: On-Demand Backfilling in Flink"</a>. Flink’s time-progress model is built around a single watermark, which is incompatible with Uber’s business need for generating aggregates retroactively. Maxim's talk covers Uber's solution for on-demand backfilling.</p>
+
+<p>We hope to see many community members at Flink Forward 2016. Registration is available online: <a href="http://flink-forward.org/registration/" target='_blank'> flink-forward.org/registration</a>


### PR DESCRIPTION
This is an announcement informing the Flink community of the Flink Forward 2016 schedule and providing some detail on the event's programming. The event serves as an opportunity for the Flink community to gather in person and to discuss experiences with Flink.

@ktzoumas @fhueske 
