### PR TITLE
Update Slides.md

### DIFF
--- a/community.md
+++ b/community.md
@@ -242,6 +242,12 @@ Note: Flink does not build with Oracle JDK 6. It runs with Oracle JDK 6.
     <td class="text-center">PMC, Committer</td>
     <td class="text-center">warneke</td>
   </tr>
+  <tr>
+    <td class="text-center"><img src="https://avatars1.githubusercontent.com/u/4425616?s=50"></td>
+    <td class="text-center">ChengXiang Li</td>
+    <td class="text-center">Committer</td>
+    <td class="text-center">chengxiang</td>
+  </tr>
 </table>
 
 You can reach committers directly at `<apache-id>@apache.org`. A list of all contributors can be found on our [GitHub Contributors]({{ site.FLINK_GITHUB_CONTRIBUTORS_URL }}) page.


### PR DESCRIPTION
Updated the Slides.md section --> there is one typo: 
- Robert Metzger: **Keynote -The maturing data streaming ecosystem and Apache Flink’s accelerated growth** *Flink Forward, Berlin September 2016*: [SlideShare] (http://www.slideshare.net/FlinkForward/kostas-tzoumasstpehan-ewen-keynote-the-maturing-data-streaming-ecosystem-and-apache-flinks-accelerated-growth)
Instead of Robert it has to be Kostas Tzoumas & Stephan Ewen
