### PR TITLE
Added a page that redirects to the latest stable docs. 

### DIFF
--- a/content/q/stable-docs.html
+++ b/content/q/stable-docs.html
@@ -1,0 +1,30 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<!-- 
+  Redirect to the latest stable version of the flink documentation.
+
+  This page should be updated as part of each flink release.
+-->
+<html>
+  <head>      
+    <meta http-equiv="refresh" content="0; url=https://ci.apache.org/projects/flink/flink-docs-release-1.1/" />    
+  </head>    
+</html>

--- a/q/stable-docs.html
+++ b/q/stable-docs.html
@@ -1,0 +1,30 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<!-- 
+  Redirect to the latest stable version of the flink documentation.
+
+  This page should be updated as part of each flink release.
+-->
+<html>
+  <head>      
+    <meta http-equiv="refresh" content="0; url=https://ci.apache.org/projects/flink/flink-docs-release-1.1/" />    
+  </head>    
+</html>


### PR DESCRIPTION
We can link to this page from older versions of the docs.