### PR TITLE
[FLINK-5760] Update links in 'Introduction', 'Download', and 'Ecosystem' pages

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -99,6 +99,7 @@ You can add the following dependencies to your `pom.xml` to include Apache Flink
 
 ## All releases
 
+- Flink 1.2.0 - 2017-02-06 ([Source](http://www.apache.org/dyn/closer.lua/flink/flink-1.2.0/flink-1.2.0-src.tgz), [Binaries](http://archive.apache.org/dist/flink/flink-1.2.0/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.2/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.2/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.2/api/scala/index.html))
 - Flink 1.1.4 - 2016-12-21 ([Source](http://archive.apache.org/dist/flink/flink-1.1.4/flink-1.1.4-src.tgz), [Binaries](http://archive.apache.org/dist/flink/flink-1.1.4/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/api/scala/index.html))
 - Flink 1.1.3 - 2016-10-13 ([Source](http://archive.apache.org/dist/flink/flink-1.1.3/flink-1.1.3-src.tgz), [Binaries](http://archive.apache.org/dist/flink/flink-1.1.3/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.1/api/scala/index.html))
 - Flink 1.1.2 - 2016-09-05 ([Source](http://archive.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-src.tgz), [Binaries](http://archive.apache.org/dist/flink/flink-1.1.2/))

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -14,15 +14,15 @@ many other data processing projects and frameworks.
 <p>Currently these systems are supported:</p>
 
 <ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/kafka.html" target="_blank">Apache Kafka</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/elasticsearch.html" target="_blank">Elasticsearch</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/elasticsearch2.html" target="_blank">Elasticsearch 2.x</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/filesystem_sink.html" target="_blank">HDFS</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/rabbitmq.html" target="_blank">RabbitMQ</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/kinesis.html" target="_blank">Amazon Kinesis Streams</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/twitter.html" target="_blank">Twitter</a> (source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/nifi.html" target="_blank">Apache NiFi</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/cassandra.html" target="_blank">Apache Cassandra</a> (sink)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/kafka.html" target="_blank">Apache Kafka</a> (sink/source)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/elasticsearch.html" target="_blank">Elasticsearch</a> (sink)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/elasticsearch2.html" target="_blank">Elasticsearch 2.x</a> (sink)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/filesystem_sink.html" target="_blank">HDFS</a> (sink)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/rabbitmq.html" target="_blank">RabbitMQ</a> (sink/source)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/kinesis.html" target="_blank">Amazon Kinesis Streams</a> (sink/source)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/twitter.html" target="_blank">Twitter</a> (source)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/nifi.html" target="_blank">Apache NiFi</a> (sink/source)</li>
+  <li><a href="{{site.docs-stable}}/dev/connectors/cassandra.html" target="_blank">Apache Cassandra</a> (sink)</li>
   <li><a href="https://github.com/apache/bahir-flink" target="_blank">Redis, Flume, and ActiveMQ (via Apache Bahir)</a> (sink)</li>
 </ul>
 

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -14,16 +14,16 @@ many other data processing projects and frameworks.
 <p>Currently these systems are supported:</p>
 
 <ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/kafka.html" target="_blank">Apache Kafka</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/elasticsearch.html" target="_blank">Elasticsearch</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/elasticsearch2.html" target="_blank">Elasticsearch 2x</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/filesystem_sink.html" target="_blank">HDFS</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/rabbitmq.html" target="_blank">RabbitMQ</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/kinesis.html" target="_blank">Amazon Kinesis Streams</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/twitter.html" target="_blank">Twitter Streaming API</a> (source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/nifi.html" target="_blank">Apache NiFi</a> (sink/source)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/cassandra.html" target="_blank">Apache Cassandra</a> (sink)</li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/connectors/redis.html" target="_blank">Redis</a> (sink)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/kafka.html" target="_blank">Apache Kafka</a> (sink/source)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/elasticsearch.html" target="_blank">Elasticsearch</a> (sink)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/elasticsearch2.html" target="_blank">Elasticsearch 2.x</a> (sink)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/filesystem_sink.html" target="_blank">HDFS</a> (sink)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/rabbitmq.html" target="_blank">RabbitMQ</a> (sink/source)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/kinesis.html" target="_blank">Amazon Kinesis Streams</a> (sink/source)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/twitter.html" target="_blank">Twitter</a> (source)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/nifi.html" target="_blank">Apache NiFi</a> (sink/source)</li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/connectors/cassandra.html" target="_blank">Apache Cassandra</a> (sink)</li>
+  <li><a href="https://github.com/apache/bahir-flink" target="_blank">Redis, Flume, and ActiveMQ (via Apache Bahir)</a> (sink)</li>
 </ul>
 
 To run an application using one of these connectors, additional third party
@@ -42,7 +42,7 @@ Please let us know on the [user/dev mailing list](#mailing-lists).
 
 **Apache Zeppelin**
 
-[Apache Zeppelin (incubator)](https://zeppelin.incubator.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
+[Apache Zeppelin](https://zeppelin.incubator.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
 [Flink as an execution engine](https://zeppelin.incubator.apache.org/docs/interpreter/flink.html) (next to others engines).
 See also Jim Dowling's [Flink Forward talk](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin) about Zeppelin on Flink.
 

--- a/introduction.md
+++ b/introduction.md
@@ -2,7 +2,7 @@
 title: "Introduction to Apache Flink®"
 ---
 <br>
-Below is a high-level overview of Apache Flink and stream processing. For a more technical introduction, we recommend the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/concepts/concepts.html" target="_blank">"Concepts" page</a> in the Flink documentation.
+Below is a high-level overview of Apache Flink and stream processing. For a more technical introduction, we recommend the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/concepts/programming-model.html" target="_blank">"Concepts" page</a> in the Flink documentation.
 <br>
 {% toc %}
 
@@ -96,13 +96,13 @@ Flink’s core is a distributed streaming dataflow engine, meaning that data is 
 
 ### APIs
 
-+ Flink’s <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/index.html" target="_blank">DataStream API</a> is for programs that implement transformations on data streams (e.g., filtering, updating state, defining windows, aggregating).
-+ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/batch/index.html" target="_blank">DataSet API</a> is for programs that implement transformations on data sets (e.g., filtering, mapping, joining, grouping).
-+ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/table.html" target="_blank">Table API</a> is a SQL-like expression language for relational stream and batch processing that can be easily embedded in Flink’s DataSet and DataStream APIs (Java and Scala).
-+ <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/table.html#sql" target="_blank">Streaming SQL</a> enables SQL queries to be executed on streaming and batch tables. The syntax is based on <a href="https://calcite.apache.org/docs/stream.html" target="_blank">Apache Calcite™</a>.
++ Flink’s <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/datastream_api.html" target="_blank">DataStream API</a> is for programs that implement transformations on data streams (e.g., filtering, updating state, defining windows, aggregating).
++ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/batch/index.html" target="_blank">DataSet API</a> is for programs that implement transformations on data sets (e.g., filtering, mapping, joining, grouping).
++ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/table_api.html#table-api" target="_blank">Table API</a> is a SQL-like expression language for relational stream and batch processing that can be easily embedded in Flink’s DataSet and DataStream APIs (Java and Scala).
++ <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/table_api.html#sql" target="_blank">Streaming SQL</a> enables SQL queries to be executed on streaming and batch tables. The syntax is based on <a href="https://calcite.apache.org/docs/stream.html" target="_blank">Apache Calcite™</a>.
 
 ### Libraries
-Flink also includes special-purpose libraries for <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/streaming/libs/cep.html" target="_blank">complex event processing</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/batch/libs/ml/index.html" target="_blank">machine learning</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/apis/batch/libs/gelly.html" target="_blank">graph processing</a>, and <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/storm_compatibility.html" target="_blank">Apache Storm compatibility</a>.
+Flink also includes special-purpose libraries for <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/cep.html" target="_blank">complex event processing</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/ml/index.html" target="_blank">machine learning</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/gelly/index.html" target="_blank">graph processing</a>, and <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/storm_compatibility.html" target="_blank">Apache Storm compatibility</a>.
 
 ## Flink and other frameworks
 
@@ -120,6 +120,6 @@ If you’re interested in learning more, we’ve collected [information about th
 
 ## Key Takeaways and Next Steps
 
-In summary, Apache Flink is an open-source stream processing framework that eliminates the "performance vs. reliability" tradeoff often associated with open-source streaming engines and performs consistently in both categories. Following this introduction, we recommend you try our <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/quickstart/setup_quickstart.html" target="_blank">quickstart</a>, [download]({{ site.baseurl }}/downloads.html) the most recent stable version of Flink, or review the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/" target="_blank">documentation</a>.
+In summary, Apache Flink is an open-source stream processing framework that eliminates the "performance vs. reliability" tradeoff often associated with open-source streaming engines and performs consistently in both categories. Following this introduction, we recommend you try our <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/quickstart/setup_quickstart.html" target="_blank">quickstart</a>, [download]({{ site.baseurl }}/downloads.html) the most recent stable version of Flink, or review the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/index.html" target="_blank">documentation</a>.
 
 And we encourage you to join the Flink user mailing list and to share your questions with the community. We’re here to help you get the most out of Flink.

--- a/introduction.md
+++ b/introduction.md
@@ -2,7 +2,7 @@
 title: "Introduction to Apache Flink®"
 ---
 <br>
-Below is a high-level overview of Apache Flink and stream processing. For a more technical introduction, we recommend the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/concepts/programming-model.html" target="_blank">"Concepts" page</a> in the Flink documentation.
+Below is a high-level overview of Apache Flink and stream processing. For a more technical introduction, we recommend the <a href="{{site.docs-stable}}/concepts/programming-model.html" target="_blank">"Concepts" page</a> in the Flink documentation.
 <br>
 {% toc %}
 
@@ -96,13 +96,13 @@ Flink’s core is a distributed streaming dataflow engine, meaning that data is 
 
 ### APIs
 
-+ Flink’s <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/datastream_api.html" target="_blank">DataStream API</a> is for programs that implement transformations on data streams (e.g., filtering, updating state, defining windows, aggregating).
-+ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/batch/index.html" target="_blank">DataSet API</a> is for programs that implement transformations on data sets (e.g., filtering, mapping, joining, grouping).
-+ The <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/table_api.html#table-api" target="_blank">Table API</a> is a SQL-like expression language for relational stream and batch processing that can be easily embedded in Flink’s DataSet and DataStream APIs (Java and Scala).
-+ <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/table_api.html#sql" target="_blank">Streaming SQL</a> enables SQL queries to be executed on streaming and batch tables. The syntax is based on <a href="https://calcite.apache.org/docs/stream.html" target="_blank">Apache Calcite™</a>.
++ Flink’s <a href="{{site.docs-stable}}/dev/datastream_api.html" target="_blank">DataStream API</a> is for programs that implement transformations on data streams (e.g., filtering, updating state, defining windows, aggregating).
++ The <a href="{{site.docs-stable}}/dev/batch/index.html" target="_blank">DataSet API</a> is for programs that implement transformations on data sets (e.g., filtering, mapping, joining, grouping).
++ The <a href="{{site.docs-stable}}/dev/table_api.html#table-api" target="_blank">Table API</a> is a SQL-like expression language for relational stream and batch processing that can be easily embedded in Flink’s DataSet and DataStream APIs (Java and Scala).
++ <a href="{{site.docs-stable}}/dev/table_api.html#sql" target="_blank">Streaming SQL</a> enables SQL queries to be executed on streaming and batch tables. The syntax is based on <a href="https://calcite.apache.org/docs/stream.html" target="_blank">Apache Calcite™</a>.
 
 ### Libraries
-Flink also includes special-purpose libraries for <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/cep.html" target="_blank">complex event processing</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/ml/index.html" target="_blank">machine learning</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/gelly/index.html" target="_blank">graph processing</a>, and <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/libs/storm_compatibility.html" target="_blank">Apache Storm compatibility</a>.
+Flink also includes special-purpose libraries for <a href="{{site.docs-stable}}/dev/libs/cep.html" target="_blank">complex event processing</a>, <a href="{{site.docs-stable}}/dev/libs/ml/index.html" target="_blank">machine learning</a>, <a href="{{site.docs-stable}}/dev/libs/gelly/index.html" target="_blank">graph processing</a>, and <a href="{{site.docs-stable}}/dev/libs/storm_compatibility.html" target="_blank">Apache Storm compatibility</a>.
 
 ## Flink and other frameworks
 
@@ -120,6 +120,6 @@ If you’re interested in learning more, we’ve collected [information about th
 
 ## Key Takeaways and Next Steps
 
-In summary, Apache Flink is an open-source stream processing framework that eliminates the "performance vs. reliability" tradeoff often associated with open-source streaming engines and performs consistently in both categories. Following this introduction, we recommend you try our <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/quickstart/setup_quickstart.html" target="_blank">quickstart</a>, [download]({{ site.baseurl }}/downloads.html) the most recent stable version of Flink, or review the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/index.html" target="_blank">documentation</a>.
+In summary, Apache Flink is an open-source stream processing framework that eliminates the "performance vs. reliability" tradeoff often associated with open-source streaming engines and performs consistently in both categories. Following this introduction, we recommend you try our <a href="{{site.docs-stable}}/quickstart/setup_quickstart.html" target="_blank">quickstart</a>, [download]({{ site.baseurl }}/downloads.html) the most recent stable version of Flink, or review the <a href="{{site.docs-stable}}/index.html" target="_blank">documentation</a>.
 
 And we encourage you to join the Flink user mailing list and to share your questions with the community. We’re here to help you get the most out of Flink.


### PR DESCRIPTION
2 changes in this PR:
• Added Flink 1.2.0 to the _All Releases_ section of the "Downloads" page
• Updated links to the documentation in the "Introduction to Flink" page to point to 1.2 docs

@rmetzger @uce 