### PR TITLE
get the poweredby page to render properly

### DIFF
--- a/poweredby.md
+++ b/poweredby.md
@@ -12,6 +12,7 @@ title: "Powered by Flink"
    th, td {
    padding: 10px;
    }
+   .height > img {min-height: 137px};
 </style>
 </head>
 
@@ -21,43 +22,55 @@ Would you like to be included on this page? Please reach out to the [Flink user 
 
 <div class="row-fluid">
 
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
       <img src="{{ site.baseurl }}/img/poweredby/alibaba-logo.png" width="175"  alt="Alibaba" /><br />
       Alibaba, the world's largest retailer, uses a fork of Flink called Blink to optimize search rankings in real time. <br><br><a href="http://data-artisans.com/blink-flink-alibaba-search/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Flink's role at Alibaba</a>
    </div>
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
       <img src="{{ site.baseurl }}/img/poweredby/bouygues-logo.jpg" width="175"  alt="Bouygues" /><br />
       Bouygues Telecom is running 30 production applications powered by Flink and is processing 10 billion raw events per day. <br><br><a href="http://flink-forward.org/kb_sessions/a-brief-history-of-time-with-apache-flink-real-time-monitoring-and-analysis-with-flink-kafka-hb/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See Bouygues Telcom at Flink Forward 2016</a>
    </div>
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
       <img src="{{ site.baseurl }}/img/poweredby/capital-one-logo.png" width="175"  alt="Capital One" /><br />
       Capital One, a Fortune 500 financial services company, uses Flink for real-time activity monitoring and alerting. <br><br><a href="http://www.slideshare.net/FlinkForward/flink-case-study-capital-one" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See Capital One's case study slides</a>
    </div>
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
       <img src="{{ site.baseurl }}/img/poweredby/ericsson-logo.png" width="175"  alt="Ericsson" /><br />
       Ericsson used Flink to build a real-time anomaly detector with machine learning over large infrastructures. <br><br><a href="https://www.oreilly.com/ideas/applying-the-kappa-architecture-in-the-telco-industry" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read a detailed overview on O'Reilly Ideas</a>
    </div>
 
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
    <img src="{{ site.baseurl }}/img/poweredby/king-logo.png" width="175" alt="King" />
          <br />
          King, the creators of Candy Crush Saga, uses Flink to provide data science teams a real-time analytics dashboard. <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about King's Flink implementation</a>
    </div>
 
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
    <img src="{{ site.baseurl }}/img/poweredby/otto-group-logo.png" width="175" alt="King" />
          <br />
          Otto Group, the world's second-largest online retailer, uses Flink for business intelligence stream processing. <br><br><a href="http://flink-forward.org/kb_sessions/flinkspector-taming-the-squirrel/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See Otto at Flink Forward 2016</a>
    </div>
 
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
    <img src="{{ site.baseurl }}/img/poweredby/researchgate-logo.png" width="175" alt="ResearchGate" /><br />
          ResearchGate, a social network for scientists, uses Flink for network analysis and near-duplicate detection. <br><br><a href="http://flink-forward.org/kb_sessions/joining-infinity-windowless-stream-processing-with-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See ResearchGate at Flink Forward 2016</a>
    </div>
 
-   <div class="col-md-3 col-sm-4 col-xs-6">
+   <div class="height col-md-3 col-sm-4 col-xs-6">
    <img src="{{ site.baseurl }}/img/poweredby/zalando-logo.jpg" width="175" alt="Zalando" /><br />
          Zalando, one of the largest ecommerce companies in Europe, uses Flink for real-time process monitoring and ETL. <br><br><a href="https://tech.zalando.de/blog/apache-showdown-flink-vs.-spark/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more on the Zalando Tech Blog</a>
    </div>
 
 </div>
+
+<script>
+$( document ).ready(function() {
+    var heights = $(".height").map(function() {
+        return $(this).height();
+    }).get(),
+
+    maxHeight = Math.max.apply(null, heights);
+
+    $(".height").height(maxHeight);
+});
+</script>


### PR DESCRIPTION
The poweredby page often looks something like this, which makes me sad:

![screen shot 2017-02-15 at 6 13 51 pm](https://cloud.githubusercontent.com/assets/43608/22986267/3b4787aa-f3ab-11e6-9983-a89b7dbc7073.png)

As best I can tell, there's no way to fix this with CSS, but a bit of JS does the trick. This finds the tallest of the company blurbs and sets all of their heights to that max height, allowing everything to float properly.