### PR TITLE
Redirect to most recent documentation

### DIFF
--- a/content/documentation.html
+++ b/content/documentation.html
@@ -133,29 +133,30 @@
 
       </div>
       <div class="col-sm-9">
-      <div class="row-fluid">
-  <div class="col-sm-12">
-    <h1>Documentation</h1>
+      <!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-	<h2 id="latest-stable-release-flink-113">Latest stable release: Flink 1.1.3</h2>
+  http://www.apache.org/licenses/LICENSE-2.0
 
-<ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/" target="_blank">1.1 Docs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java/" target="_blank">1.1 Javadocs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html#package" target="_blank">1.1 ScalaDocs</a></li>
-</ul>
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
-<h2 id="development-snapshot-flink-12">Development snapshot: Flink 1.2</h2>
+<meta http-equiv="refresh" content="1; url=https://ci.apache.org/projects/flink/flink-docs-master/" />
 
-<ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/" target="_blank">1.2 Docs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java/" target="_blank">1.2 Javadocs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html#package" target="_blank">1.2 ScalaDocs</a></li>
-</ul>
+<h1>Documentation</h1>
 
-
-  </div>
-</div>
+<p>Redirecting to <a href="https://ci.apache.org/projects/flink/flink-docs-master/">most recent documentation</a> in 1 second.</p>
 
       </div>
     </div>

--- a/documentation.md
+++ b/documentation.md
@@ -1,18 +1,28 @@
 ---
 title: "Documentation"
+layout: base
 ---
-## Latest stable release: Flink 1.1.3
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-<ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/" target="_blank">1.1 Docs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java/" target="_blank">1.1 Javadocs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html#package" target="_blank">1.1 ScalaDocs</a></li>
-</ul>
+  http://www.apache.org/licenses/LICENSE-2.0
 
-## Development snapshot: Flink 1.2
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
-<ul>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/" target="_blank">1.2 Docs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java/" target="_blank">1.2 Javadocs</a></li>
-  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html#package" target="_blank">1.2 ScalaDocs</a></li>
-</ul>
+<meta http-equiv="refresh" content="1; url=https://ci.apache.org/projects/flink/flink-docs-master/" />
+
+<h1>Documentation</h1>
+
+Redirecting to <a href="https://ci.apache.org/projects/flink/flink-docs-master/">most recent documentation</a> in 1 second.


### PR DESCRIPTION
Proper `http://flink.apache.org/documentation`.