### PR TITLE
[FLINK-6971] Add a paragraph of Alluxio into Ecosystem page

### DIFF
--- a/ecosystem.md
+++ b/ecosystem.md
@@ -78,6 +78,10 @@ See Suneel Marthi's [Flink Forward talk](http://www.slideshare.net/FlinkForward/
 
 [Apache SAMOA (incubating)](https://samoa.incubator.apache.org/) a streaming ML library featuring Flink an execution engine soon. Albert Bifet introduced SAMOA on Flink at his [Flink Forward talk](http://www.slideshare.net/FlinkForward/albert-bifet-apache-samoa-mining-big-data-streams-with-apache-flink?ref=http://flink-forward.org/?session=apache-samoa-mining-big-data-streams-with-apache-flink).
 
+**Alluxio**
+
+[Alluxio](http://www.alluxio.org/) is an open-source memory-speed virtual distributed storage that enables applications to efficiently share data and access data across different storage systems in a [unified namespace](http://www.alluxio.org/docs/master/en/Unified-and-Transparent-Namespace.html). Here is an example of [using Flink to access data through Alluxio](http://www.alluxio.org/docs/master/en/Running-Flink-on-Alluxio.html).
+
 **Python Examples on Flink**
 
 A [collection of examples](https://github.com/wdm0006/flink-python-examples) using Apache Flink's Python API.


### PR DESCRIPTION
This pull request aims to update the ecosystem page to add a pointer to the guide of using Flink to access Alluxio.

![screen shot 2017-06-23 at 1 46 58 pm](https://user-images.githubusercontent.com/1413748/27499877-a552d3c4-581a-11e7-8d4d-a90e5d19aaa3.png)
