### PR TITLE
Update Gelly documentation link

### DIFF
--- a/_posts/2015-08-24-introducing-flink-gelly.md
+++ b/_posts/2015-08-24-introducing-flink-gelly.md
@@ -322,7 +322,7 @@ certain song.
 Graph<String, NullValue, Integer> userSongGraph = Graph.fromTupleDataSet(validTriplets, env);
 ```
 
-Consult the [Gelly guide](https://ci.apache.org/projects/flink/flink-docs-master/libs/gelly_guide.html) for guidelines 
+Consult the [Gelly guide](https://ci.apache.org/projects/flink/flink-docs-master/dev/libs/gelly/) for guidelines 
 on how to create a graph from a given DataSet of edges or from a collection.
 
 To retrieve the top songs per user, we call the groupReduceOnEdges function as it perform an
@@ -452,4 +452,4 @@ Curious? Read more about our plans for Gelly in the [roadmap](https://cwiki.apac
 [Back to top](#top)
 
 ## Links
-[Gelly Documentation](https://ci.apache.org/projects/flink/flink-docs-master/libs/gelly_guide.html)
+[Gelly Documentation](https://ci.apache.org/projects/flink/flink-docs-master/dev/libs/gelly/)

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -465,7 +465,7 @@ certain song.</p>
 <span class="c1">// correspond to play counts</span>
 <span class="n">Graph</span><span class="o">&lt;</span><span class="n">String</span><span class="o">,</span> <span class="n">NullValue</span><span class="o">,</span> <span class="n">Integer</span><span class="o">&gt;</span> <span class="n">userSongGraph</span> <span class="o">=</span> <span class="n">Graph</span><span class="o">.</span><span class="na">fromTupleDataSet</span><span class="o">(</span><span class="n">validTriplets</span><span class="o">,</span> <span class="n">env</span><span class="o">);</span></code></pre></div>
 
-<p>Consult the <a href="https://ci.apache.org/projects/flink/flink-docs-master/libs/gelly_guide.html">Gelly guide</a> for guidelines 
+<p>Consult the <a href="https://ci.apache.org/projects/flink/flink-docs-master/dev/libs/gelly/">Gelly guide</a> for guidelines
 on how to create a graph from a given DataSet of edges or from a collection.</p>
 
 <p>To retrieve the top songs per user, we call the groupReduceOnEdges function as it perform an
@@ -589,7 +589,7 @@ tools, graph database systems and sampling techniques.</p>
 <p><a href="#top">Back to top</a></p>
 
 <h2 id="links">Links</h2>
-<p><a href="https://ci.apache.org/projects/flink/flink-docs-master/libs/gelly_guide.html">Gelly Documentation</a></p>
+<p><a href="https://ci.apache.org/projects/flink/flink-docs-master/dev/libs/gelly/">Gelly Documentation</a></p>
 
       </article>
     </div>


### PR DESCRIPTION
Update Gelly documentation link on the flink news web page address http://flink.apache.org/news/2015/08/24/introducing-flink-gelly.html, change to the newest documentation of Gelly.