### PR TITLE
[FLINK-7361] explicitely require yajl-ruby 1.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ gem 'jekyll', '2.5.3'
 gem 'kramdown', '1.10.0'
 gem 'pygments.rb', '0.6.3'
 gem 'therubyracer', '0.12.2'
+# explicitly require yajl-ruby (dependency of jekyll) in a version that works with Ruby 2.4
+gem 'yajl-ruby', '1.2.2'


### PR DESCRIPTION
This fixes a potential build failure with Ruby 2.4 and offers a "lighter" change than #76.

See
- https://issues.apache.org/jira/browse/FLINK-7361 (`flink-web`)
- https://issues.apache.org/jira/browse/FLINK-6302 (`flink`)