### PR TITLE
[FLINK-6860] Update apache beam info(remove incubating)

### DIFF
--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -198,9 +198,9 @@ Check out Sebastian Schelter’s <a href="http://www.slideshare.net/FlinkForward
 <a href="https://github.com/dataArtisans/cascading-flink">Cascading on Flink</a> is build by <a href="http://data-artisans.com/">dataArtisans</a> and <a href="http://www.driven.io/">Driven, Inc</a>.
 See Fabian Hueske’s <a href="http://www.slideshare.net/FlinkForward/fabian-hueske-training-cascading-on-flink">Flink Forward talk</a> for more details.</p>
 
-<p><strong>Apache Beam (incubating)</strong></p>
+<p><strong>Apache Beam</strong></p>
 
-<p><a href="http://beam.incubator.apache.org/">Apache Beam (incubating)</a> is an open source, unified programming model that you can use to create a data processing pipeline. Flink is one of the back-ends supported by the Beam programming model.</p>
+<p><a href="https://beam.apache.org/">Apache Beam</a> is an open source, unified programming model that you can use to create a data processing pipeline. Flink is one of the back-ends supported by the Beam programming model.</p>
 
 <p><strong>GRADOOP</strong></p>
 

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -57,9 +57,9 @@ Check out Sebastian Schelter's [Flink Forward talk](http://www.slideshare.net/Fl
 [Cascading on Flink](https://github.com/dataArtisans/cascading-flink) is build by [dataArtisans](http://data-artisans.com/) and [Driven, Inc](http://www.driven.io/).
 See Fabian Hueske's [Flink Forward talk](http://www.slideshare.net/FlinkForward/fabian-hueske-training-cascading-on-flink) for more details.
 
-**Apache Beam (incubating)**
+**Apache Beam**
 
-[Apache Beam (incubating)](http://beam.incubator.apache.org/) is an open source, unified programming model that you can use to create a data processing pipeline. Flink is one of the back-ends supported by the Beam programming model.
+[Apache Beam](https://beam.apache.org/) is an open source, unified programming model that you can use to create a data processing pipeline. Flink is one of the back-ends supported by the Beam programming model.
 
 **GRADOOP**
 


### PR DESCRIPTION
To remove the word incubating and update the link, --Apache Beam has graduated as a top-level project.
