### PR TITLE
[hotfix] [contributing-code] Add org.apache.flink.shaded.* to import order section

### DIFF
--- a/content/contribute-code.html
+++ b/content/contribute-code.html
@@ -332,6 +332,7 @@
   <li><strong>Import order.</strong> Imports must be ordered alphabetically, grouped into the following blocks, with each block separated by an empty line:
     <ul>
       <li>&lt;imports from org.apache.flink.*&gt;</li>
+      <li>&lt;imports from org.apache.flink.shaded.*&gt;</li>
       <li>&lt;imports from other libraries&gt;</li>
       <li>&lt;imports from javax.*&gt;</li>
       <li>&lt;imports from java.*&gt;</li>

--- a/contribute-code.md
+++ b/contribute-code.md
@@ -147,6 +147,7 @@ It is also possible to attach a patch to a [JIRA]({{site.FLINK_ISSUES_URL}}) iss
 - **No wildcard imports.** They can cause problems when adding to the code and in some cases even during refactoring.
 - **Import order.** Imports must be ordered alphabetically, grouped into the following blocks, with each block separated by an empty line:
 	- &lt;imports from org.apache.flink.*&gt;
+	- &lt;imports from org.apache.flink.shaded.*&gt;
 	- &lt;imports from other libraries&gt;
 	- &lt;imports from javax.*&gt;
 	- &lt;imports from java.*&gt;


### PR DESCRIPTION
Checkstyle requires `org.apache.flink.shaded` to be in a separate group. See https://github.com/apache/flink/blob/master/tools/maven/checkstyle.xml#L200