### PR TITLE
[hotfix] [faq] Remove faulty line break in heading

### DIFF
--- a/content/faq.html
+++ b/content/faq.html
@@ -179,7 +179,7 @@ under the License.
       <li><a href="#my-job-fails-early-with-a-javaioeofexception-what-could-be-the-cause" id="markdown-toc-my-job-fails-early-with-a-javaioeofexception-what-could-be-the-cause">My job fails early with a java.io.EOFException. What could be the cause?</a></li>
       <li><a href="#my-job-fails-with-various-exceptions-from-the-hdfshadoop-code-what-can-i-do" id="markdown-toc-my-job-fails-with-various-exceptions-from-the-hdfshadoop-code-what-can-i-do">My job fails with various exceptions from the HDFS/Hadoop code. What can I do?</a></li>
       <li><a href="#in-eclipse-i-get-compilation-errors-in-the-scala-projects" id="markdown-toc-in-eclipse-i-get-compilation-errors-in-the-scala-projects">In Eclipse, I get compilation errors in the Scala projects</a></li>
-      <li><a href="#my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types" id="markdown-toc-my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types">My program does not compute the correct result. Why are my custom key types</a></li>
+      <li><a href="#my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types-not-groupedjoined-correctly" id="markdown-toc-my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types-not-groupedjoined-correctly">My program does not compute the correct result. Why are my custom key types not grouped/joined correctly?</a></li>
       <li><a href="#i-get-a-javalanginstantiationexception-for-my-data-type-what-is-wrong" id="markdown-toc-i-get-a-javalanginstantiationexception-for-my-data-type-what-is-wrong">I get a java.lang.InstantiationException for my data type, what is wrong?</a></li>
       <li><a href="#i-cant-stop-flink-with-the-provided-stop-scripts-what-can-i-do" id="markdown-toc-i-cant-stop-flink-with-the-provided-stop-scripts-what-can-i-do">I can’t stop Flink with the provided stop-scripts. What can I do?</a></li>
       <li><a href="#i-got-an-outofmemoryexception-what-can-i-do" id="markdown-toc-i-got-an-outofmemoryexception-what-can-i-do">I got an OutOfMemoryException. What can I do?</a></li>
@@ -399,8 +399,7 @@ need to manually configure the <em>flink-scala</em> project to use a <em>compile
   <li>NOTE: You have to build Flink with Maven on the command line first, to make sure the plugin is downloaded.</li>
 </ul>
 
-<h3 id="my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types">My program does not compute the correct result. Why are my custom key types</h3>
-<p>are not grouped/joined correctly?</p>
+<h3 id="my-program-does-not-compute-the-correct-result-why-are-my-custom-key-types-not-groupedjoined-correctly">My program does not compute the correct result. Why are my custom key types not grouped/joined correctly?</h3>
 
 <p>Keys must correctly implement the methods <code>java.lang.Object#hashCode()</code>,
 <code>java.lang.Object#equals(Object o)</code>, and <code>java.util.Comparable#compareTo(...)</code>.

--- a/faq.md
+++ b/faq.md
@@ -216,8 +216,7 @@ need to manually configure the *flink-scala* project to use a *compiler plugin*:
 - In the field "Xplugin", put the path "/home/<user-name>/.m2/repository/org/scalamacros/paradise_2.10.4/2.0.1/paradise_2.10.4-2.0.1.jar"
 - NOTE: You have to build Flink with Maven on the command line first, to make sure the plugin is downloaded.
 
-### My program does not compute the correct result. Why are my custom key types
-are not grouped/joined correctly?
+### My program does not compute the correct result. Why are my custom key types not grouped/joined correctly?
 
 Keys must correctly implement the methods `java.lang.Object#hashCode()`,
 `java.lang.Object#equals(Object o)`, and `java.util.Comparable#compareTo(...)`.


### PR DESCRIPTION
This removes a faulty line break in a heading on the FAQ page.