### PR TITLE
Add post to announce 2017 Apache Flink user survey

### DIFF
--- a/_posts/2017-11-22-apache-flink-user-survey-2017.md
+++ b/_posts/2017-11-22-apache-flink-user-survey-2017.md
@@ -1,17 +1,18 @@
 ---
 layout: post
 title:  "Share Your Feedback: Apache Flink User Survey 2017"
+excerpt: <p>All members of the Apache Flink community are invited to participate in the <a href="http://www.surveygizmo.com/s3/3166399/Apache-Flink-User-Survey-f2c5ebace72c" target='_blank'>second-annual Flink user survey.  </a><small><span class="glyphicon glyphicon-new-window"></span></small><br></p>
 date:   2017-11-22 15:00:00
 categories: news
 ---
-<p>All members of the Apache Flink community are invited to participate in the <a href="http://www.surveygizmo.com/s3/3166399/Apache-Flink-User-Survey-f2c5ebace72c" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small>second-annual Flink user survey.</a>
+All members of the Apache Flink community are invited to participate in the <a href="http://www.surveygizmo.com/s3/3166399/Apache-Flink-User-Survey-f2c5ebace72c" target='_blank'>second-annual Flink user survey.  </a><small><span class="glyphicon glyphicon-new-window"></span></small><br><br>
 
-This survey will help the community to shape the Flink roadmap and to make Flink the best that it can be for users.
+This survey will help the community to shape the Flink roadmap and to make Flink the best that it can be for users.<br><br>
 
-A report with a summary of findings will be published at the conclusion of the survey. All of your responses will remain confidential, and only aggregate statistics will be shared.
+A report with a summary of findings will be published at the conclusion of the survey. All of your responses will remain confidential, and only aggregate statistics will be shared.<br><br>
 
-The survey will take approximately 5-10 minutes to complete, and almost all questions are optional--we appreciate any feedback that you're willing to provide. We plan to keep the survey open for responses until next Monday, November 27.
+The survey will take approximately 5-10 minutes to complete, and almost all questions are optional--we appreciate any feedback that you're willing to provide. Anonymous responses are welcomed. The survey will be open for responses until next Monday, November 27.<br><br>
 
-As a thank you, respondents can be entered in a drawing to win one of 10 passes to Flink Forward 2018 (your choice of the second-annual San Francisco event on April 9-10 or the Berlin event on September 3-5).
+As a thank you, respondents can choose to be entered in a drawing to win one of 10 passes to Flink Forward 2018 (your choice of the second-annual San Francisco event on April 9-10 or the Berlin event on September 3-5).<br><br>
 
 We hope to hear from you.

--- a/_posts/2017-11-22-apache-flink-user-survey-2017.md
+++ b/_posts/2017-11-22-apache-flink-user-survey-2017.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title:  "Share Your Feedback: Apache Flink User Survey 2017"
+date:   2017-11-22 15:00:00
+categories: news
+---
+<p>All members of the Apache Flink community are invited to participate in the <a href="http://www.surveygizmo.com/s3/3166399/Apache-Flink-User-Survey-f2c5ebace72c" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small>second-annual Flink user survey.</a>
+
+This survey will help the community to shape the Flink roadmap and to make Flink the best that it can be for users.
+
+A report with a summary of findings will be published at the conclusion of the survey. All of your responses will remain confidential, and only aggregate statistics will be shared.
+
+The survey will take approximately 5-10 minutes to complete, and almost all questions are optional--we appreciate any feedback that you're willing to provide. We plan to keep the survey open for responses until next Monday, November 27.
+
+As a thank you, respondents can be entered in a drawing to win one of 10 passes to Flink Forward 2018 (your choice of the second-annual San Francisco event on April 9-10 or the Berlin event on September 3-5).
+
+We hope to hear from you.


### PR DESCRIPTION
The 2017 Apache Flink user survey is open for responses, and this short post announces the survey on the Flink project site. @aljoscha 