### PR TITLE
Add Table of Contents to 1.4.0 release announcement post

### DIFF
--- a/_posts/2017-12-12-release-1.4.0.md
+++ b/_posts/2017-12-12-release-1.4.0.md
@@ -35,6 +35,8 @@ A summary of some of the features in the release is available below.
 
 For more background on the Flink 1.4.0 release and the work planned for the Flink 1.5.0 release, please refer to [this blog post](http://flink.apache.org/news/2017/11/22/release-1.4-and-1.5-timeline.html) on the Apache Flink blog.
 
+{% toc %}
+
 ## New Features and Improvements
 
 ### End-to-end Exactly Once Applications with Apache Flink and Apache Kafka and TwoPhaseCommitSinkFunction
@@ -215,5 +217,3 @@ fengyelei, godfreyhe, gosubpl, gyao, hongyuhong, huafengw, kkloudas, kl0u, linco
 lingjinjiang, mengji.fy, minwenjun, mtunique, p1tz, paul, rtudoran, shaoxuan-wang, sirko
 bretschneider, sunjincheng121, tedyu, twalthr, uybhatti, wangmiao1981, yew1eb, z00376786, zentol,
 zhangminglei, zhe li, zhouhai02, zjureel, 付典, 军长, 宝牛, 淘江, 金竹
-
-


### PR DESCRIPTION
@aljoscha One change: I added a table of contents to the release announcement so that it's easier for users to see a summary of what's covered in the post. 