### PR TITLE
Restyle "JIRA" as "Jira"

### DIFF
--- a/community.md
+++ b/community.md
@@ -3,7 +3,7 @@ title: "Community & Project Info"
 ---
 {% toc %}
 
-There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. If you want to talk with the Flink committers and users in a chat, there is a [IRC channel](#irc). Some committers are also monitoring [Stack Overflow](http://stackoverflow.com/questions/tagged/flink). Please remember to tag your questions with the *[flink](http://stackoverflow.com/questions/tagged/flink)* tag. Bugs and feature requests can either be discussed on *dev mailing list* or on [JIRA]({{ site.jira }}). Those interested in contributing to Flink should check out the [contribution guide](how-to-contribute.html).
+There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. If you want to talk with the Flink committers and users in a chat, there is a [IRC channel](#irc). Some committers are also monitoring [Stack Overflow](http://stackoverflow.com/questions/tagged/flink). Please remember to tag your questions with the *[flink](http://stackoverflow.com/questions/tagged/flink)* tag. Bugs and feature requests can either be discussed on *dev mailing list* or on [Jira]({{ site.jira }}). Those interested in contributing to Flink should check out the [contribution guide](how-to-contribute.html).
 
 ## Mailing Lists
 
@@ -74,7 +74,7 @@ There are many ways to get help from the Apache Flink community. The [mailing li
     <td>
       <strong>issues</strong>@flink.apache.org
       <br>
-      <small>Mirror of all JIRA activity</small>
+      <small>Mirror of all Jira activity</small>
     </td>
     <td class="text-center"><i class="fa fa-pencil-square-o"></i> <a href="mailto:issues-subscribe@flink.apache.org">Subscribe</a></td>
     <td class="text-center"><i class="fa fa-pencil-square-o"></i> <a href="mailto:issues-digest-subscribe@flink.apache.org">Subscribe</a></td>
@@ -112,7 +112,7 @@ Make sure to tag your questions there accordingly to get answers from the Flink 
 
 ## Issue Tracker
 
-We use JIRA to track all code related issues: [{{ site.jira }}]({{ site.jira }}).
+We use Jira to track all code related issues: [{{ site.jira }}]({{ site.jira }}).
 
 All issue activity is also mirrored to the issues mailing list.
 

--- a/contribute-code.md
+++ b/contribute-code.md
@@ -6,7 +6,7 @@ Apache Flink is maintained, improved, and extended by code contributions of volu
 
 This document contains everything you need to know about contributing code to Apache Flink. It describes the process of preparing, testing and submitting a contribution, explains coding guidelines and code style of Flink's code base, and gives instructions to setup a development environment.
 
-**IMPORTANT**: Please read this document carefully before starting to work on a code contribution. It is important to follow the process and guidelines explained below. Otherwise, your pull request might not be accepted or might require substantial rework. In particular, before opening a pull request that implements a **new feature**, you need to open a JIRA ticket and reach consensus with the community on whether this feature is needed.
+**IMPORTANT**: Please read this document carefully before starting to work on a code contribution. It is important to follow the process and guidelines explained below. Otherwise, your pull request might not be accepted or might require substantial rework. In particular, before opening a pull request that implements a **new feature**, you need to open a Jira ticket and reach consensus with the community on whether this feature is needed.
 
 
 
@@ -16,9 +16,9 @@ This document contains everything you need to know about contributing code to Ap
 
 ### Before you start coding...
 
-... please make sure there is a JIRA issue that corresponds to your contribution. This is a *general rule* that the Flink community follows for all code contributions, including bug fixes, improvements, or new features, with an exception for *trivial* hot fixes. If you would like to fix a bug that you found or if you would like to add a new feature or improvement to Flink, please follow the [File a bug report]({{ site.baseurl }}/how-to-contribute.html#file-a-bug-report) or [Propose an improvement or a new feature]({{ site.baseurl }}/how-to-contribute.html#propose-an-improvement-or-a-new-feature) guidelines to open an issue in [Flink's JIRA](http://issues.apache.org/jira/browse/FLINK) before starting with the implementation.
+... please make sure there is a Jira issue that corresponds to your contribution. This is a *general rule* that the Flink community follows for all code contributions, including bug fixes, improvements, or new features, with an exception for *trivial* hot fixes. If you would like to fix a bug that you found or if you would like to add a new feature or improvement to Flink, please follow the [File a bug report]({{ site.baseurl }}/how-to-contribute.html#file-a-bug-report) or [Propose an improvement or a new feature]({{ site.baseurl }}/how-to-contribute.html#propose-an-improvement-or-a-new-feature) guidelines to open an issue in [Flink's Jira](http://issues.apache.org/jira/browse/FLINK) before starting with the implementation.
 
-If the description of a JIRA issue indicates that its resolution will touch sensible parts of the code base, be sufficiently complex, or add significant amounts of new code, the Flink community might request a design document (most contributions should not require a design document). The purpose of this document is to ensure that the overall approach to address the issue is sensible and agreed upon by the community. JIRA issues that require a design document are tagged with the **`requires-design-doc`** label. The label can be attached by any community member who feels that a design document is necessary. A good description helps to decide whether a JIRA issue requires a design document or not. The design document must be added or attached to or link from the JIRA issue and cover the following aspects:
+If the description of a Jira issue indicates that its resolution will touch sensible parts of the code base, be sufficiently complex, or add significant amounts of new code, the Flink community might request a design document (most contributions should not require a design document). The purpose of this document is to ensure that the overall approach to address the issue is sensible and agreed upon by the community. Jira issues that require a design document are tagged with the **`requires-design-doc`** label. The label can be attached by any community member who feels that a design document is necessary. A good description helps to decide whether a Jira issue requires a design document or not. The design document must be added or attached to or link from the Jira issue and cover the following aspects:
 
 - Overview of the general approach
 - List of API changes (changed interfaces, new and deprecated configuration parameters, changed behavior, ...)
@@ -27,19 +27,19 @@ If the description of a JIRA issue indicates that its resolution will touch sens
 
 A design document can be added by anybody, including the reporter of the issue or the person working on it.
 
-Contributions for JIRA issues that require a design document will not be added to Flink's code base before a design document has been accepted by the community with [lazy consensus](http://www.apache.org/foundation/glossary.html#LazyConsensus). Please check if a design document is required before starting to code.
+Contributions for Jira issues that require a design document will not be added to Flink's code base before a design document has been accepted by the community with [lazy consensus](http://www.apache.org/foundation/glossary.html#LazyConsensus). Please check if a design document is required before starting to code.
 
 
 ### While coding...
 
 ... please respect the following rules:
 
-- Take any discussion or requirement that is recorded in the JIRA issue into account.
+- Take any discussion or requirement that is recorded in the Jira issue into account.
 - Follow the design document (if a design document is required) as close as possible. Please update the design document and seek consensus, if your implementation deviates too much from the solution proposed by the design document. Minor variations are OK but should be pointed out when the contribution is submitted.
 - Closely follow the [coding guidelines]( {{site.base}}/contribute-code.html#coding-guidelines) and the [code style]({{ site.base }}/contribute-code.html#code-style).
 - Do not mix unrelated issues into one contribution.
 
-**Please feel free to ask questions at any time.** Either send a mail to the [dev mailing list]( {{ site.base }}/community.html#mailing-lists ) or comment on the JIRA issue.
+**Please feel free to ask questions at any time.** Either send a mail to the [dev mailing list]( {{ site.base }}/community.html#mailing-lists ) or comment on the Jira issue.
 
 The following instructions will help you to [setup a development environment]( {{ site.base }}/contribute-code.html#setup-a-development-environment).
 
@@ -61,7 +61,7 @@ You can build the code, run the tests, and check (parts of) the code style by ca
 mvn clean verify
 ```
 
-Please note, that some tests in Flink's code base are flaky and can fail by chance. The Flink community is working hard on improving these tests but sometimes this is not possible, e.g., when tests include external dependencies. We maintain all tests that are known to be flaky in JIRA and attach the **`test-stability`** label. Please check (and extend) this list of [known flaky tests](https://issues.apache.org/jira/issues/?jql=project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20test-stability%20ORDER%20BY%20priority%20DESC) if you encounter a test failure that seems to be unrelated to your changes.
+Please note, that some tests in Flink's code base are flaky and can fail by chance. The Flink community is working hard on improving these tests but sometimes this is not possible, e.g., when tests include external dependencies. We maintain all tests that are known to be flaky in Jira and attach the **`test-stability`** label. Please check (and extend) this list of [known flaky tests](https://issues.apache.org/jira/issues/?jql=project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20test-stability%20ORDER%20BY%20priority%20DESC) if you encounter a test failure that seems to be unrelated to your changes.
 
 Please note, that we run additional build profiles for different combinations of Java, Scala, and Hadoop versions to validate your contribution. We encourage every contributor to use a *continuous integration* service that will automatically test the code in your repository whenever you push a change. The [Best practices]( {{site.base}}/contribute-code.html#best-practices ) guide shows how to integrate [Travis](https://travis-ci.org/) with your Github repository.
 
@@ -84,7 +84,7 @@ git push origin myBranch
 
 Go the website of your repository fork (`https://github.com/<your-user-name>/flink`) and use the *"Create Pull Request"* button to start creating a pull request. Make sure that the base fork is `apache/flink master` and the head fork selects the branch with your changes. Give the pull request a meaningful description and send it.
 
-It is also possible to attach a patch to a [JIRA]({{site.FLINK_ISSUES_URL}}) issue.
+It is also possible to attach a patch to a [Jira]({{site.FLINK_ISSUES_URL}}) issue.
 
 -----
 
@@ -93,11 +93,11 @@ It is also possible to attach a patch to a [JIRA]({{site.FLINK_ISSUES_URL}}) iss
 ### Pull requests and commit message
 {:.no_toc}
 
-- **Single change per PR**. Please do not combine various unrelated changes in a single pull request. Rather, open multiple individual pull requests where each PR refers to a JIRA issue. This ensures that pull requests are *topic related*, can be merged more easily, and typically result in topic-specific merge conflicts only.
+- **Single change per PR**. Please do not combine various unrelated changes in a single pull request. Rather, open multiple individual pull requests where each PR refers to a Jira issue. This ensures that pull requests are *topic related*, can be merged more easily, and typically result in topic-specific merge conflicts only.
 
 - **No WIP pull requests**. We consider pull requests as requests to merge the referenced code *as is* into the current *stable* master branch. Therefore, a pull request should not be "work in progress". Open a pull request if you are confident that it can be merged into the current master branch without problems. If you rather want comments on your code, post a link to your working branch.
 
-- **Commit message**. A pull request must relate to a JIRA issue; create an issue if none exists for the change you want to make. The latest commit message should reference that issue. An example commit message would be *[FLINK-633] Fix NullPointerException for empty UDF parameters*. That way, the pull request automatically gives a description of what it does, for example what bug does it fix in what way.
+- **Commit message**. A pull request must relate to a Jira issue; create an issue if none exists for the change you want to make. The latest commit message should reference that issue. An example commit message would be *[FLINK-633] Fix NullPointerException for empty UDF parameters*. That way, the pull request automatically gives a description of what it does, for example what bug does it fix in what way.
 
 - **Append review commits**. When you get comments on the pull request asking for changes, append commits for these changes. *Do not rebase and squash them.* It allows people to review the cleanup work independently. Otherwise reviewers have to go through the entire set of diffs again.
 

--- a/contribute-documentation.md
+++ b/contribute-documentation.md
@@ -22,7 +22,7 @@ The documentation is located in the `docs/` subdirectory of the Flink code base.
 
 ## Before you start working on the documentation ...
 
-... please make sure there exists a [JIRA](https://issues.apache.org/jira/browse/FLINK) issue that corresponds to your contribution. We require all documentation changes to refer to a JIRA issue, except for trivial fixes such as typos. 
+... please make sure there exists a [Jira](https://issues.apache.org/jira/browse/FLINK) issue that corresponds to your contribution. We require all documentation changes to refer to a Jira issue, except for trivial fixes such as typos. 
 
 ## Update or extend the documentation
 
@@ -45,7 +45,7 @@ The Flink project accepts documentation contributions through the [GitHub Mirror
 
 To prepare and submit a pull request follow these steps.
 
-1. Commit your changes to your local git repository. The commit message should point to the corresponding JIRA issue by starting with `[FLINK-XXXX]`. 
+1. Commit your changes to your local git repository. The commit message should point to the corresponding Jira issue by starting with `[FLINK-XXXX]`. 
 
 2. Push your committed contribution to your fork of the Flink repository at Github.
 
@@ -55,7 +55,7 @@ To prepare and submit a pull request follow these steps.
 
 3. Go the website of your repository fork (`https://github.com/<your-user-name>/flink`) and use the "Create Pull Request" button to start creating a pull request. Make sure that the base fork is `apache/flink master` and the head fork selects the branch with your changes. Give the pull request a meaningful description and submit it.
 
-It is also possible to attach a patch to a [JIRA]({{site.FLINK_ISSUES_URL}}) issue.
+It is also possible to attach a patch to a [Jira]({{site.FLINK_ISSUES_URL}}) issue.
 
 
 

--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -13,13 +13,13 @@ The Apache Flink community is eager to help and to answer your questions. We hav
 
 ## File a bug report
 
-Please let us know if you experienced a problem with Flink and file a bug report. Open [Flink's JIRA](http://issues.apache.org/jira/browse/FLINK) and click on the blue **Create** button at the top. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem. Thank you very much.
+Please let us know if you experienced a problem with Flink and file a bug report. Open [Flink's Jira](http://issues.apache.org/jira/browse/FLINK) and click on the blue **Create** button at the top. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem. Thank you very much.
 
 -----
 
 ## Propose an improvement or a new feature
 
-Our community is constantly looking for feedback to improve Apache Flink. If you have an idea how to improve Flink or have a new feature in mind that would be beneficial for Flink users, please open an issue in [Flink's JIRA](http://issues.apache.org/jira/browse/FLINK). The improvement or new feature should be described in appropriate detail and include the scope and its requirements if possible. Detailed information is important for a few reasons:
+Our community is constantly looking for feedback to improve Apache Flink. If you have an idea how to improve Flink or have a new feature in mind that would be beneficial for Flink users, please open an issue in [Flink's Jira](http://issues.apache.org/jira/browse/FLINK). The improvement or new feature should be described in appropriate detail and include the scope and its requirements if possible. Detailed information is important for a few reasons:
 
 - It ensures your requirements are met when the improvement or feature is implemented.
 - It helps to estimate the effort and to design a solution that addresses your needs.
@@ -70,7 +70,7 @@ Please do also read the [Submit a Contributor License Agreement]({{ site.baseurl
 ### Looking for an issue to work on?
 {:.no_toc}
 
-We maintain a list of all known bugs, proposed improvements and suggested features in [Flink's JIRA](https://issues.apache.org/jira/browse/FLINK/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel). Issues that we believe are good tasks for new contributors are tagged with a special "starter" tag. Those tasks are supposed to be rather easy to solve and will help you to become familiar with the project and the contribution process.
+We maintain a list of all known bugs, proposed improvements and suggested features in [Flink's Jira](https://issues.apache.org/jira/browse/FLINK/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel). Issues that we believe are good tasks for new contributors are tagged with a special "starter" tag. Those tasks are supposed to be rather easy to solve and will help you to become familiar with the project and the contribution process.
 
 Please have a look at the list of [starter issues](https://issues.apache.org/jira/issues/?jql=project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20starter%20ORDER%20BY%20priority%20DESC), if you are looking for an issue to work on. You can of course also choose [any other issue](https://issues.apache.org/jira/issues/?jql=project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC) to work on. Feel free to ask questions about issues that you would be interested in working on.
 
@@ -80,7 +80,7 @@ Please have a look at the list of [starter issues](https://issues.apache.org/jir
 
 Good documentation is crucial for any kind of software. This is especially true for sophisticated software systems such as distributed data processing engines like Apache Flink. The Apache Flink community aims to provide concise, precise, and complete documentation and welcomes any contribution to improve Apache Flink's documentation.
 
-- Please report missing, incorrect, or out-dated documentation as a [JIRA issue](http://issues.apache.org/jira/browse/FLINK).
+- Please report missing, incorrect, or out-dated documentation as a [Jira issue](http://issues.apache.org/jira/browse/FLINK).
 - Flink's documentation is written in Markdown and located in the `docs` folder in [Flink's source code repository]({{ site.baseurl }}/community.html#main-source-repositories). See the [Contribute documentation]({{ site.base }}/contribute-documentation.html) guidelines for detailed instructions for how to update and improve the documentation and to contribute your changes.
 
 -----
@@ -95,7 +95,7 @@ The [Apache Flink website](http://flink.apache.org) presents Apache Flink and it
 
 We welcome any contribution to improve our website.
 
-- Please open a [JIRA issue](http://issues.apache.org/jira/browse/FLINK) if you think our website could be improved.
+- Please open a [Jira issue](http://issues.apache.org/jira/browse/FLINK) if you think our website could be improved.
 - Please follow the [Improve the website]({{ site.baseurl }}/improve-website.html) guidelines if you would like to update and improve the website.
 
 -----


### PR DESCRIPTION
Hi, Flink folks.

Atlassian has changed their styling of "JIRA" and now capitalize it as "Jira". (Their [trademark page](https://www.atlassian.com/legal/trademark) makes this explicit.) Want to restyle it in the web page to match their current usage? It's a bit more readable, too, IMHO.