### PR TITLE
[FLINK-10219] remove the IRC mention from the website

### DIFF
--- a/community.md
+++ b/community.md
@@ -6,7 +6,8 @@ title: "Community & Project Info"
 
 {% toc %}
 
-There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. If you want to talk with the Flink committers and users in a chat, there is an [IRC channel](#irc). Some committers are also monitoring [Stack Overflow](http://stackoverflow.com/questions/tagged/apache-flink). Please remember to tag your questions with the *[apache-flink](http://stackoverflow.com/questions/tagged/apache-flink)* tag. Bugs and feature requests can either be discussed on the *dev mailing list* or on [Jira]({{ site.jira }}). Those interested in contributing to Flink should check out the [contribution guide](how-to-contribute.html).
+
+There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. For user support and questions use the *user mailing list*. Some committers are also monitoring [Stack Overflow](http://stackoverflow.com/questions/tagged/apache-flink). Please remember to tag your questions with the *[apache-flink](http://stackoverflow.com/questions/tagged/apache-flink)* tag. Bugs and feature requests can either be discussed on the *dev mailing list* or on [Jira]({{ site.jira }}). Those interested in contributing to Flink should check out the [contribution guide](how-to-contribute.html).
 
 ## Mailing Lists
 

--- a/content/community.html
+++ b/content/community.html
@@ -181,7 +181,7 @@
 
 </div>
 
-<p>There are many ways to get help from the Apache Flink community. The <a href="#mailing-lists">mailing lists</a> are the primary place where all Flink committers are present. If you want to talk with the Flink committers and users in a chat, there is an <a href="#irc">IRC channel</a>. Some committers are also monitoring <a href="http://stackoverflow.com/questions/tagged/apache-flink">Stack Overflow</a>. Please remember to tag your questions with the <em><a href="http://stackoverflow.com/questions/tagged/apache-flink">apache-flink</a></em> tag. Bugs and feature requests can either be discussed on the <em>dev mailing list</em> or on <a href="https://issues.apache.org/jira/browse/FLINK">Jira</a>. Those interested in contributing to Flink should check out the <a href="how-to-contribute.html">contribution guide</a>.</p>
+<p>There are many ways to get help from the Apache Flink community. The <a href="#mailing-lists">mailing lists</a> are the primary place where all Flink committers are present. For user support and questions use the <em>user mailing list</em>. Some committers are also monitoring <a href="http://stackoverflow.com/questions/tagged/apache-flink">Stack Overflow</a>. Please remember to tag your questions with the <em><a href="http://stackoverflow.com/questions/tagged/apache-flink">apache-flink</a></em> tag. Bugs and feature requests can either be discussed on the <em>dev mailing list</em> or on <a href="https://issues.apache.org/jira/browse/FLINK">Jira</a>. Those interested in contributing to Flink should check out the <a href="how-to-contribute.html">contribution guide</a>.</p>
 
 <h2 id="mailing-lists">Mailing Lists</h2>
 

--- a/content/how-to-contribute.html
+++ b/content/how-to-contribute.html
@@ -162,7 +162,7 @@
 
 <h2 id="ask-questions">Ask questions!</h2>
 
-<p>The Apache Flink community is eager to help and to answer your questions. We have a <a href="/community.html#mailing-lists">user mailing list</a>, hang out in an <a href="/community.html#irc">IRC channel</a>, and watch Stack Overflow on the <a href="http://stackoverflow.com/questions/tagged/apache-flink">[apache-flink]</a> tag.</p>
+<p>The Apache Flink community is eager to help and to answer your questions. We have a <a href="/community.html#mailing-lists">user mailing list</a> and watch Stack Overflow on the <a href="http://stackoverflow.com/questions/tagged/apache-flink">[apache-flink]</a> tag.</p>
 
 <hr />
 
@@ -201,7 +201,7 @@ discussions on existing proposals.</p>
   <li>The development mailing list <code>dev@flink.apache.org</code> is the place where Flink developers exchange ideas and discuss new features, upcoming releases, and the development process in general. If you are interested in contributing code to Flink, you should join this mailing list.</li>
 </ul>
 
-<p>You are very welcome to <a href="/community.html#mailing-lists">subscribe to both mailing lists</a>. In addition to the user list, there is also a <a href="/community.html#irc">Flink IRC</a> channel that you can join to talk to other users and contributors.</p>
+<p>You are very welcome to <a href="/community.html#mailing-lists">subscribe to both mailing lists</a>.</p>
 
 <hr />
 

--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -10,7 +10,7 @@ Apache Flink is developed by an open and friendly community. Everybody is cordia
 
 ## Ask questions!
 
-The Apache Flink community is eager to help and to answer your questions. We have a [user mailing list]({{ site.baseurl }}/community.html#mailing-lists ), hang out in an [IRC channel]({{ site.baseurl }}/community.html#irc), and watch Stack Overflow on the [[apache-flink]](http://stackoverflow.com/questions/tagged/apache-flink) tag.
+The Apache Flink community is eager to help and to answer your questions. We have a [user mailing list]({{ site.baseurl }}/community.html#mailing-lists ) and watch Stack Overflow on the [[apache-flink]](http://stackoverflow.com/questions/tagged/apache-flink) tag.
 
 -----
 
@@ -46,7 +46,7 @@ Most communication in the Apache Flink community happens on two mailing lists:
 - The user mailing list `user@flink.apache.org` is the place where users of Apache Flink ask questions and seek help or advice. Joining the user list and helping other users is a very good way to contribute to Flink's community. Furthermore, there is the [[apache-flink]](http://stackoverflow.com/questions/tagged/apache-flink) tag on Stack Overflow if you'd like to help Flink users (and harvest some points) there.
 - The development mailing list `dev@flink.apache.org` is the place where Flink developers exchange ideas and discuss new features, upcoming releases, and the development process in general. If you are interested in contributing code to Flink, you should join this mailing list.
 
-You are very welcome to [subscribe to both mailing lists]({{ site.baseurl }}/community.html#mailing-lists). In addition to the user list, there is also a [Flink IRC]({{ site.baseurl }}/community.html#irc) channel that you can join to talk to other users and contributors.
+You are very welcome to [subscribe to both mailing lists]({{ site.baseurl }}/community.html#mailing-lists).
 
 -----
 


### PR DESCRIPTION
@zentol the IRC channel is dead, can we remove it so that new users are instructed to use the mailing lists?