### PR TITLE
 [FLINK-10238] Link nightly snapshot builds from the Download page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,31 +27,31 @@ FLINK_DOWNLOAD_URL_SOURCE_SHA512: https://www.apache.org/dist/flink/flink-1.6.0/
 
 stable_releases:
   -
-      name: "Without bundled Hadoop®"
+      name: "Apache Flink only"
       id: "download-hadoopfree_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz.sha512"
   -
-      name: "Hadoop® 2.8"
+      name: "Flink with Hadoop® 2.8"
       id: "download-hadoop28_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz.sha512"
   -
-      name: "Hadoop® 2.7"
+      name: "Flink with Hadoop® 2.7"
       id: "download-hadoop27_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz.sha512"
   -
-      name: "Hadoop® 2.6"
+      name: "Flink with Hadoop® 2.6"
       id: "download-hadoop26_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz.sha512"
   -
-      name: "Hadoop® 2.4"
+      name: "Flink with Hadoop® 2.4"
       id: "download-hadoop24_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop24-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop24-scala_2.11.tgz.asc"

--- a/content/contribute-code.html
+++ b/content/contribute-code.html
@@ -174,7 +174,6 @@
     </ul>
   </li>
   <li><a href="#how-to-use-git-as-a-committer" id="markdown-toc-how-to-use-git-as-a-committer">How to use Git as a committer</a></li>
-  <li><a href="#snapshots-nightly-builds" id="markdown-toc-snapshots-nightly-builds">Snapshots (Nightly Builds)</a></li>
 </ul>
 
 </div>
@@ -520,33 +519,6 @@ Note: If you do not have the jar file, you probably did not run the command line
 
 <p>If you want to build for Hadoop 1, activate the build profile via <code>mvn clean package -DskipTests -Dhadoop.profile=1</code>.</p>
 
-<hr />
-
-<h2 id="snapshots-nightly-builds">Snapshots (Nightly Builds)</h2>
-
-<p>Apache Flink <code>1.7-SNAPSHOT</code> is our latest development version.</p>
-
-<p>You can download a packaged version of our nightly builds, which include
-the most recent development code. You can use them if you need a feature
-before its release. Only builds that pass all tests are published here.</p>
-
-<ul>
-  <li><strong>Hadoop 2 and YARN</strong>: <a href="https://s3.amazonaws.com/flink-nightly/flink-1.7-SNAPSHOT-bin-hadoop2.tgz" class="ga-track" id="download-hadoop2-nightly">flink-1.7-SNAPSHOT-bin-hadoop2.tgz</a></li>
-</ul>
-
-<p>Add the <strong>Apache Snapshot repository</strong> to your Maven <code>pom.xml</code>:</p>
-
-<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;repositories&gt;</span>
-  <span class="nt">&lt;repository&gt;</span>
-    <span class="nt">&lt;id&gt;</span>apache.snapshots<span class="nt">&lt;/id&gt;</span>
-    <span class="nt">&lt;name&gt;</span>Apache Development Snapshot Repository<span class="nt">&lt;/name&gt;</span>
-    <span class="nt">&lt;url&gt;</span>https://repository.apache.org/content/repositories/snapshots/<span class="nt">&lt;/url&gt;</span>
-    <span class="nt">&lt;releases&gt;&lt;enabled&gt;</span>false<span class="nt">&lt;/enabled&gt;&lt;/releases&gt;</span>
-    <span class="nt">&lt;snapshots&gt;&lt;enabled&gt;</span>true<span class="nt">&lt;/enabled&gt;&lt;/snapshots&gt;</span>
-  <span class="nt">&lt;/repository&gt;</span>
-<span class="nt">&lt;/repositories&gt;</span></code></pre></div>
-
-<p>You can now include Apache Flink as a Maven dependency (see above) with version <code>1.7-SNAPSHOT</code> (or `` for compatibility with old Hadoop 1.x versions).</p>
 
 
   </div>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -164,7 +164,8 @@ $( document ).ready(function() {
   <li><a href="#verifying-hashes-and-signatures" id="markdown-toc-verifying-hashes-and-signatures">Verifying Hashes and Signatures</a></li>
   <li><a href="#maven-dependencies" id="markdown-toc-maven-dependencies">Maven Dependencies</a></li>
   <li><a href="#update-policy-for-old-releases" id="markdown-toc-update-policy-for-old-releases">Update Policy for old releases</a></li>
-  <li><a href="#all-releases" id="markdown-toc-all-releases">All releases</a></li>
+  <li><a href="#all-stable-releases" id="markdown-toc-all-stable-releases">All stable releases</a></li>
+  <li><a href="#snapshots-nightly-builds" id="markdown-toc-snapshots-nightly-builds">Snapshots (Nightly Builds)</a></li>
 </ul>
 
 </div>
@@ -173,15 +174,13 @@ $( document ).ready(function() {
 
 <p>Apache Flink® 1.6.0 is our latest stable release.</p>
 
-<p>An Apache Hadoop installation is
-<a href="faq.html#do-i-have-to-install-apache-hadoop-to-use-flink">not required</a>
-to use Flink. If you plan to run Flink in YARN or process data stored in HDFS then
-select the version matching your installed Hadoop version.</p>
+<p>An Apache Hadoop installation is <a href="faq.html#how-does-flink-relate-to-the-hadoop-stack">not required</a> to use Apache Flink.
+For users that use Flink without any Hadoop components, we recommend the release without bundled Hadoop libraries.</p>
 
-<p>The binary releases marked with a Hadoop version come bundled with binaries for that Hadoop version.
-The binary release without bundled Hadoop can be used without Hadoop or with a Hadoop version
-that is installed in the environment, i.e., this version can pick up a Hadoop version from
-the classpath.</p>
+<p>If you plan to use Apache Flink together with Apache Hadoop (run Flink on YARN, connect to HDFS,
+connect to HBase, or use some Hadoop-based file system connector) then select the download that
+bundles the matching Hadoop version, or use the Hadoop free version and
+<a href="https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html">export your HADOOP_CLASSPATH</a>.</p>
 
 <h3 id="binaries">Binaries</h3>
 
@@ -194,27 +193,27 @@ the classpath.</p>
 <tbody>
     
     <tr>
-    <th>Without bundled Hadoop®</th>
+    <th>Apache Flink only</th>
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz" class="ga-track" id="download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Hadoop® 2.8</th>
+    <th>Flink with Hadoop® 2.8</th>
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Hadoop® 2.7</th>
+    <th>Flink with Hadoop® 2.7</th>
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Hadoop® 2.6</th>
+    <th>Flink with Hadoop® 2.6</th>
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Hadoop® 2.4</th>
+    <th>Flink with Hadoop® 2.4</th>
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.0/flink-1.6.0-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
@@ -270,7 +269,7 @@ the classpath.</p>
 
 <p>Note that the community is always open to discussing bugfix releases for even older versions. Please get in touch with the developers for that on the dev@flink.apache.org mailing list.</p>
 
-<h2 id="all-releases">All releases</h2>
+<h2 id="all-stable-releases">All stable releases</h2>
 
 <p>All Flink releases are available via <a href="https://archive.apache.org/dist/flink/">https://archive.apache.org/dist/flink/</a> including checksums and cryptographic signatures. At the time of writing, this includes the following versions:</p>
 
@@ -312,7 +311,30 @@ the classpath.</p>
   <li>Flink 0.6-incubating - 2014-08-26 (<a href="https://archive.apache.org/dist/incubator/flink/flink-0.6-incubating-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/incubator/flink/">Binaries</a>)</li>
 </ul>
 
-<p>Previous Stratosphere releases are available on <a href="https://github.com/stratosphere/stratosphere/releases">GitHub</a>.</p>
+<h2 id="snapshots-nightly-builds">Snapshots (Nightly Builds)</h2>
+
+<p><strong>Warning: These builds are not official releases. They are not endorsed in any way, they have not undergone a proper release process and have not undergone any license checks.
+The snapshot builds are only for developer convenience, to test features before an official release.</strong></p>
+
+<ul>
+  <li>
+    <p>Archive: <strong>Apache Flink <code>1.7-SNAPSHOT</code></strong>: <a href="https://s3.amazonaws.com/flink-nightly/flink-1.7-SNAPSHOT-bin-hadoop2.tgz" class="ga-track" id="download-hadoop2-nightly">flink-1.7-SNAPSHOT-bin-hadoop2.tgz</a></p>
+  </li>
+  <li>
+    <p>Maven: Add the <strong>Apache Snapshot repository</strong> to your <code>pom.xml</code> to use dependencies with <code>1.7-SNAPSHOT</code> version.</p>
+  </li>
+</ul>
+
+<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;repositories&gt;</span>
+  <span class="nt">&lt;repository&gt;</span>
+    <span class="nt">&lt;id&gt;</span>apache.snapshots<span class="nt">&lt;/id&gt;</span>
+    <span class="nt">&lt;name&gt;</span>Apache Development Snapshot Repository<span class="nt">&lt;/name&gt;</span>
+    <span class="nt">&lt;url&gt;</span>https://repository.apache.org/content/repositories/snapshots/<span class="nt">&lt;/url&gt;</span>
+    <span class="nt">&lt;releases&gt;&lt;enabled&gt;</span>false<span class="nt">&lt;/enabled&gt;&lt;/releases&gt;</span>
+    <span class="nt">&lt;snapshots&gt;&lt;enabled&gt;</span>true<span class="nt">&lt;/enabled&gt;&lt;/snapshots&gt;</span>
+  <span class="nt">&lt;/repository&gt;</span>
+<span class="nt">&lt;/repositories&gt;</span></code></pre></div>
+
 
 
   </div>

--- a/contribute-code.md
+++ b/contribute-code.md
@@ -317,30 +317,3 @@ Note: Flink does not build with Oracle JDK 6. It runs with Oracle JDK 6.
 
 If you want to build for Hadoop 1, activate the build profile via `mvn clean package -DskipTests -Dhadoop.profile=1`.
 
------
-
-## Snapshots (Nightly Builds)
-
-Apache Flink `{{ site.FLINK_VERSION_LATEST }}` is our latest development version.
-
-You can download a packaged version of our nightly builds, which include
-the most recent development code. You can use them if you need a feature
-before its release. Only builds that pass all tests are published here.
-
-- **Hadoop 2 and YARN**: <a href="{{ site.FLINK_DOWNLOAD_URL_HADOOP_2_LATEST }}" class="ga-track" id="download-hadoop2-nightly">{{ site.FLINK_DOWNLOAD_URL_HADOOP_2_LATEST | split:'/' | last }}</a>
-
-Add the **Apache Snapshot repository** to your Maven `pom.xml`:
-
-```xml
-<repositories>
-  <repository>
-    <id>apache.snapshots</id>
-    <name>Apache Development Snapshot Repository</name>
-    <url>https://repository.apache.org/content/repositories/snapshots/</url>
-    <releases><enabled>false</enabled></releases>
-    <snapshots><enabled>true</enabled></snapshots>
-  </repository>
-</repositories>
-```
-
-You can now include Apache Flink as a Maven dependency (see above) with version `{{ site.FLINK_VERSION_LATEST }}` (or `{{ site.FLINK_VERSION_HADOOP_1_LATEST }}` for compatibility with old Hadoop 1.x versions).

--- a/downloads.md
+++ b/downloads.md
@@ -98,7 +98,7 @@ As of March 2017, the Flink community [decided](http://apache-flink-mailing-list
 Note that the community is always open to discussing bugfix releases for even older versions. Please get in touch with the developers for that on the dev@flink.apache.org mailing list.
 
 
-## All releases
+## All stable releases
 
 All Flink releases are available via [https://archive.apache.org/dist/flink/](https://archive.apache.org/dist/flink/) including checksums and cryptographic signatures. At the time of writing, this includes the following versions:
 
@@ -138,4 +138,24 @@ All Flink releases are available via [https://archive.apache.org/dist/flink/](ht
 - Flink 0.6.1-incubating - 2014-09-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/))
 - Flink 0.6-incubating - 2014-08-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/))
 
+## Snapshots (Nightly Builds)
+
+**Warning: These builds are not official releases. They are not endorsed in any way, they have not undergone a proper release process and have not undergone any license checks.
+The snapshot builds are only for developer convenience, to test features before an official release.**
+
+- Archive: **Apache Flink `{{ site.FLINK_VERSION_LATEST }}`**: <a href="{{ site.FLINK_DOWNLOAD_URL_HADOOP_2_LATEST }}" class="ga-track" id="download-hadoop2-nightly">{{ site.FLINK_DOWNLOAD_URL_HADOOP_2_LATEST | split:'/' | last }}</a>
+
+- Maven: Add the **Apache Snapshot repository** to your `pom.xml` to use dependencies with `{{ site.FLINK_VERSION_LATEST }}` version.
+
+```xml
+<repositories>
+  <repository>
+    <id>apache.snapshots</id>
+    <name>Apache Development Snapshot Repository</name>
+    <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled></snapshots>
+  </repository>
+</repositories>
+```
 

--- a/downloads.md
+++ b/downloads.md
@@ -23,7 +23,7 @@ $( document ).ready(function() {
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} is our latest stable release.
 
 An Apache Hadoop installation is
-[not required](faq.html#do-i-have-to-install-apache-hadoop-to-use-flink)
+[not required](faq.html#how-does-flink-relate-to-the-hadoop-stack)
 to use Flink. If you plan to run Flink in YARN or process data stored in HDFS then
 select the version matching your installed Hadoop version.
 

--- a/downloads.md
+++ b/downloads.md
@@ -138,4 +138,4 @@ All Flink releases are available via [https://archive.apache.org/dist/flink/](ht
 - Flink 0.6.1-incubating - 2014-09-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/))
 - Flink 0.6-incubating - 2014-08-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/))
 
-Previous Stratosphere releases are available on [GitHub](https://github.com/stratosphere/stratosphere/releases).
+

--- a/downloads.md
+++ b/downloads.md
@@ -22,15 +22,13 @@ $( document ).ready(function() {
 
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} is our latest stable release.
 
-An Apache Hadoop installation is
-[not required](faq.html#how-does-flink-relate-to-the-hadoop-stack)
-to use Flink. If you plan to run Flink in YARN or process data stored in HDFS then
-select the version matching your installed Hadoop version.
+An Apache Hadoop installation is [not required](faq.html#how-does-flink-relate-to-the-hadoop-stack) to use Apache Flink.
+For users that use Flink without any Hadoop components, we recommend the release without bundled Hadoop libraries.
 
-The binary releases marked with a Hadoop version come bundled with binaries for that Hadoop version.
-The binary release without bundled Hadoop can be used without Hadoop or with a Hadoop version
-that is installed in the environment, i.e., this version can pick up a Hadoop version from
-the classpath.
+If you plan to use Apache Flink together with Apache Hadoop (run Flink on YARN, connect to HDFS,
+connect to HBase, or use some Hadoop-based file system connector) then select the download that
+bundles the matching Hadoop version, or use the Hadoop free version and
+[export your HADOOP_CLASSPATH](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html).
 
 ### Binaries
 


### PR DESCRIPTION
How to access the nightly builds is described in a bit of a hidden place, but is a question frequently popping up.

This adds the nightly builds to the download page, with a prominent disclaimer that they are not endorsed releases.

This also removes broken references to no longer existing builds bundling Hadoop v1.x.