### PR TITLE
List past 2 releases in the stable section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,41 +21,82 @@ FLINK_GITHUB_URL: https://github.com/apache/flink
 FLINK_CONTRIBUTORS_URL: https://cwiki.apache.org/confluence/display/FLINK/List+of+contributors
 FLINK_GITHUB_REPO_NAME: flink
 
-FLINK_DOWNLOAD_URL_SOURCE: https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-src.tgz
-FLINK_DOWNLOAD_URL_SOURCE_ASC: https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.asc
-FLINK_DOWNLOAD_URL_SOURCE_SHA512: https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.sha512
+source_releases:
+  -
+      name: "Apache Flink 1.6.2"
+      id: "162-download-source"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-src.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.sha512"
+  -
+      name: "Apache Flink 1.5.5"
+      id: "155-download-source"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-src.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.sha512"
+
 
 stable_releases:
   -
-      name: "Apache Flink only"
-      id: "download-hadoopfree_211"
+      name: "Apache Flink 1.6.2 only"
+      id: "162-ownload-hadoopfree_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.sha512"
   -
-      name: "Flink with Hadoop® 2.8"
-      id: "download-hadoop28_211"
+      name: "Flink 1.6.2 with Hadoop® 2.8"
+      id: "162-download-hadoop28_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.sha512"
   -
-      name: "Flink with Hadoop® 2.7"
-      id: "download-hadoop27_211"
+      name: "Flink 1.6.2 with Hadoop® 2.7"
+      id: "162-download-hadoop27_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.sha512"
   -
-      name: "Flink with Hadoop® 2.6"
-      id: "download-hadoop26_211"
+      name: "Flink 1.6.2 with Hadoop® 2.6"
+      id: "162-download-hadoop26_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.sha512"
   -
-      name: "Flink with Hadoop® 2.4"
-      id: "download-hadoop24_211"
+      name: "Flink 1.6.2 with Hadoop® 2.4"
+      id: "162-download-hadoop24_211"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.sha512"
+  -
+      name: "Apache 1.5.5 Flink only"
+      id: "155-download-hadoopfree_211"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz.sha512"
+  -
+      name: "Flink 1.5.5 with Hadoop® 2.8"
+      id: "155-download-hadoop28_211"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz.sha512"
+  -
+      name: "Flink 1.5.5 with Hadoop® 2.7"
+      id: "155-download-hadoop27_211"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz.sha512"
+  -
+      name: "Flink 1.5.5 with Hadoop® 2.6"
+      id: "155-download-hadoop26_211"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz.sha512"
+  -
+      name: "Flink 1.5.5 with Hadoop® 2.4"
+      id: "155-download-hadoop24_211"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz"
+      asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz.asc"
+      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz.sha512"
 
 FLINK_DOWNLOAD_URL_HADOOP_2_LATEST: https://s3.amazonaws.com/flink-nightly/flink-1.7-SNAPSHOT-bin-hadoop2.tgz
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -193,28 +193,53 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 <tbody>
     
     <tr>
-    <th>Apache Flink only</th>
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz" class="ga-track" id="download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <th>Apache Flink 1.6.2 only</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz" class="ga-track" id="162-ownload-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Flink with Hadoop® 2.8</th>
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <th>Flink 1.6.2 with Hadoop® 2.8</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="162-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Flink with Hadoop® 2.7</th>
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <th>Flink 1.6.2 with Hadoop® 2.7</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="162-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Flink with Hadoop® 2.6</th>
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <th>Flink 1.6.2 with Hadoop® 2.6</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="162-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
     <tr>
-    <th>Flink with Hadoop® 2.4</th>
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <th>Flink 1.6.2 with Hadoop® 2.4</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="162-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
+    </tr>
+    
+    <tr>
+    <th>Apache 1.5.5 Flink only</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz" class="ga-track" id="155-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
+    </tr>
+    
+    <tr>
+    <th>Flink 1.5.5 with Hadoop® 2.8</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="155-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
+    </tr>
+    
+    <tr>
+    <th>Flink 1.5.5 with Hadoop® 2.7</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="155-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
+    </tr>
+    
+    <tr>
+    <th>Flink 1.5.5 with Hadoop® 2.6</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="155-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
+    </tr>
+    
+    <tr>
+    <th>Flink 1.5.5 with Hadoop® 2.4</th>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="155-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
     </tr>
     
 </tbody>
@@ -224,11 +249,22 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 
 <div class="list-group">
   <!-- Source -->
-  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-src.tgz" class="list-group-item ga-track" id="download-source">
-    <h4><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink® 1.6.2</strong> Source Release</h4>
+  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.2/flink-1.6.2-src.tgz" class="list-group-item ga-track" id="162-download-source">
+    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
+    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.6.2</strong> Source Release</h4>
     <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz.sha512">sha512</a>)
+</div>
+
+<div class="list-group">
+  <!-- Source -->
+  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-src.tgz" class="list-group-item ga-track" id="155-download-source">
+    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
+    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.5.5</strong> Source Release</h4>
+    <p>Review the source code or build Flink on your own, using this package</p>
+  </a>
+   (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.sha512">sha512</a>)
 </div>
 
 <h2 id="release-notes">Release Notes</h2>

--- a/downloads.md
+++ b/downloads.md
@@ -50,14 +50,18 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 
 ### Source
 
+{% for source_release in site.source_releases %}
 <div class="list-group">
   <!-- Source -->
-  <a href="{{ site.FLINK_DOWNLOAD_URL_SOURCE }}" class="list-group-item ga-track" id="download-source">
-    <h4><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink® {{ site.FLINK_VERSION_STABLE }}</strong> Source Release</h4>
+  <a href="{{ source_release.url }}" class="list-group-item ga-track" id="{{ source_release.id }}">
+    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
+    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>{{ source_release.name }}</strong> Source Release</h4>
     <p>Review the source code or build Flink on your own, using this package</p>
   </a>
-   (<a href="{{ site.FLINK_DOWNLOAD_URL_SOURCE_ASC }}">asc</a>, <a href="{{ site.FLINK_DOWNLOAD_URL_SOURCE_SHA512 }}">sha512</a>)
+   (<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
 </div>
+
+{% endfor %}
 
 ## Release Notes
 


### PR DESCRIPTION
This PR modifies the download page to prominently list the stable version of both supported versions (i.e. right now 1.5.5 and 1.6.2) instead of just the latest stable version.

This change is made in response to a rejection of our 1.5.5 announcement mail, due to
a) distributing a new release (1.5.5) using `archive.apache.org` links instead of mirrors
b) not explicitly linking any asc/sha512 links for the binary releases.

![quick_fix](https://user-images.githubusercontent.com/5725237/47648255-c6f0dd80-db79-11e8-839b-e0eefa1007f1.png)


