### PR TITLE
Remove S3 recoverable writer from 1.6.2 release nores.

### DIFF
--- a/_posts/2018-10-29-release-1.6.2.md
+++ b/_posts/2018-10-29-release-1.6.2.md
@@ -38,8 +38,6 @@ List of resolved issues:
 <h2>        Sub-task
 </h2>
 <ul>
-<li>[<a href='https://issues.apache.org/jira/browse/FLINK-9752'>FLINK-9752</a>] -         Add an S3 RecoverableWriter
-</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-10242'>FLINK-10242</a>] -         Latency marker interval should be configurable
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-10243'>FLINK-10243</a>] -         Add option to reduce latency metrics granularity


### PR DESCRIPTION
@aljoscha or @tillrohrmann could you have a look? 