### PR TITLE
[FLINK-10728] List flink-shaded on downloads page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,12 @@ source_releases:
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.5/flink-1.5.5-src.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.sha512"
+  -
+      name: "Apache Flink-shaded 5.0"
+      id: "s50-download-source"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz"
+      asc_url: "https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.asc"
+      sha512_url: "https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.sha512"
 
 
 stable_releases:

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -164,7 +164,11 @@ $( document ).ready(function() {
   <li><a href="#verifying-hashes-and-signatures" id="markdown-toc-verifying-hashes-and-signatures">Verifying Hashes and Signatures</a></li>
   <li><a href="#maven-dependencies" id="markdown-toc-maven-dependencies">Maven Dependencies</a></li>
   <li><a href="#update-policy-for-old-releases" id="markdown-toc-update-policy-for-old-releases">Update Policy for old releases</a></li>
-  <li><a href="#all-stable-releases" id="markdown-toc-all-stable-releases">All stable releases</a></li>
+  <li><a href="#all-stable-releases" id="markdown-toc-all-stable-releases">All stable releases</a>    <ul>
+      <li><a href="#flink" id="markdown-toc-flink">Flink</a></li>
+      <li><a href="#flink-shaded" id="markdown-toc-flink-shaded">Flink-shaded</a></li>
+    </ul>
+  </li>
 </ul>
 
 </div>
@@ -266,6 +270,16 @@ bundles the matching Hadoop version, or use the Hadoop free version and
    (<a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz.sha512">sha512</a>)
 </div>
 
+<div class="list-group">
+  <!-- Source -->
+  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz" class="list-group-item ga-track" id="s50-download-source">
+    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
+    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink-shaded 5.0</strong> Source Release</h4>
+    <p>Review the source code or build Flink on your own, using this package</p>
+  </a>
+   (<a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.asc">asc</a>, <a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.sha512">sha512</a>)
+</div>
+
 <h2 id="release-notes">Release Notes</h2>
 
 <p>Please have a look at the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/release-notes/flink-1.6.html">Release Notes for Flink 1.6</a> if you plan to upgrade your Flink setup from a previous version.</p>
@@ -308,6 +322,8 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 
 <p>All Flink releases are available via <a href="https://archive.apache.org/dist/flink/">https://archive.apache.org/dist/flink/</a> including checksums and cryptographic signatures. At the time of writing, this includes the following versions:</p>
 
+<h3 id="flink">Flink</h3>
+
 <ul>
   <li>Flink 1.6.2 - 2018-10-29 (<a href="https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/flink/flink-1.6.2/">Binaries</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/">Docs</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">ScalaDocs</a>)</li>
   <li>Flink 1.6.1 - 2018-09-19 (<a href="https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/flink/flink-1.6.1/">Binaries</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/">Docs</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">ScalaDocs</a>)</li>
@@ -348,6 +364,15 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   <li>Flink 0.7.0-incubating - 2014-11-04 (<a href="https://archive.apache.org/dist/incubator/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/incubator/flink/flink-0.7.0-incubating/">Binaries</a>)</li>
   <li>Flink 0.6.1-incubating - 2014-09-26 (<a href="https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/">Binaries</a>)</li>
   <li>Flink 0.6-incubating - 2014-08-26 (<a href="https://archive.apache.org/dist/incubator/flink/flink-0.6-incubating-src.tgz">Source</a>, <a href="https://archive.apache.org/dist/incubator/flink/">Binaries</a>)</li>
+</ul>
+
+<h3 id="flink-shaded">Flink-shaded</h3>
+<ul>
+  <li>Flink-shaded 5.0 - 2018-10-15 (<a href="https://archive.apache.org/dist/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz">Source</a>)</li>
+  <li>Flink-shaded 4.0 - 2018-06-06 (<a href="https://archive.apache.org/dist/flink/flink-shaded-4.0/flink-shaded-4.0-src.tgz">Source</a>)</li>
+  <li>Flink-shaded 3.0 - 2018-02-28 (<a href="https://archive.apache.org/dist/flink/flink-shaded-3.0/flink-shaded-3.0-src.tgz">Source</a>)</li>
+  <li>Flink-shaded 2.0 - 2017-10-30 (<a href="https://archive.apache.org/dist/flink/flink-shaded-2.0/flink-shaded-2.0-src.tgz">Source</a>)</li>
+  <li>Flink-shaded 1.0 - 2017-07-27 (<a href="https://archive.apache.org/dist/flink/flink-shaded-1.0/flink-shaded-1.0-src.tgz">Source</a>)</li>
 </ul>
 
 

--- a/downloads.md
+++ b/downloads.md
@@ -106,6 +106,8 @@ Note that the community is always open to discussing bugfix releases for even ol
 
 All Flink releases are available via [https://archive.apache.org/dist/flink/](https://archive.apache.org/dist/flink/) including checksums and cryptographic signatures. At the time of writing, this includes the following versions:
 
+### Flink
+
 - Flink 1.6.2 - 2018-10-29 ([Source](https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz), [Binaries](https://archive.apache.org/dist/flink/flink-1.6.2/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/scala/index.html))
 - Flink 1.6.1 - 2018-09-19 ([Source](https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz), [Binaries](https://archive.apache.org/dist/flink/flink-1.6.1/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/scala/index.html))
 - Flink 1.6.0 - 2018-08-08 ([Source](https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-src.tgz), [Binaries](https://archive.apache.org/dist/flink/flink-1.6.0/), [Docs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/), [Javadocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/java), [ScalaDocs]({{site.DOCS_BASE_URL}}flink-docs-release-1.6/api/scala/index.html))
@@ -145,3 +147,10 @@ All Flink releases are available via [https://archive.apache.org/dist/flink/](ht
 - Flink 0.7.0-incubating - 2014-11-04 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/flink-0.7.0-incubating/))
 - Flink 0.6.1-incubating - 2014-09-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/flink-0.6.1-incubating/))
 - Flink 0.6-incubating - 2014-08-26 ([Source](https://archive.apache.org/dist/incubator/flink/flink-0.6-incubating-src.tgz), [Binaries](https://archive.apache.org/dist/incubator/flink/))
+
+### Flink-shaded
+- Flink-shaded 5.0 - 2018-10-15 ([Source](https://archive.apache.org/dist/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz))
+- Flink-shaded 4.0 - 2018-06-06 ([Source](https://archive.apache.org/dist/flink/flink-shaded-4.0/flink-shaded-4.0-src.tgz))
+- Flink-shaded 3.0 - 2018-02-28 ([Source](https://archive.apache.org/dist/flink/flink-shaded-3.0/flink-shaded-3.0-src.tgz))
+- Flink-shaded 2.0 - 2017-10-30 ([Source](https://archive.apache.org/dist/flink/flink-shaded-2.0/flink-shaded-2.0-src.tgz))
+- Flink-shaded 1.0 - 2017-07-27 ([Source](https://archive.apache.org/dist/flink/flink-shaded-1.0/flink-shaded-1.0-src.tgz))


### PR DESCRIPTION
This PR adds flink-shaded to the download page in accordance with [ASF policy](http://www.apache.org/dev/release-distribution#download-links).

> The website documentation for any Apache product MUST provide public download links where current official source releases and accompanying cryptographic files may be obtained.

Specifically it lists all past releases in the `All stable releases` section and the 5.0 source release in the `Latest stable release#Source` secton.

![shade1](https://user-images.githubusercontent.com/5725237/47787997-ce96ba80-dd10-11e8-9a99-c0e39048055a.png)
![shade2](https://user-images.githubusercontent.com/5725237/47787998-ce96ba80-dd10-11e8-8189-ea077f45617e.png)
