### PR TITLE
[FLINK-10766] Add a link to flink-china.org in Flink website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,6 +120,7 @@ stackoverflow: "https://stackoverflow.com/search?q=flink"
 twitter: "https://twitter.com/apacheflink"
 github: "https://github.com/apache/flink"
 wiki: "https://cwiki.apache.org/confluence/display/FLINK/Apache+Flink+Home"
+chinese: "https://flink-china.org/"
 
 twitter-handle: "ApacheFlink"
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -90,6 +90,8 @@
             <!-- Visualizer -->
             <li class="{% if page.url contains '/visualizer/' %} active{% endif %} hidden-md hidden-sm"><a href="{{ site.baseurl }}/visualizer/" target="_blank">Plan Visualizer <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
 
+            <!-- Chinese -->
+            <li><a href="{{ site.chinese }}" target="_blank">中文站 <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
           </ul>
         </div><!-- /.navbar-collapse -->
     </nav>


### PR DESCRIPTION
This add a link to flink-china.org in flink website. 

![image](https://user-images.githubusercontent.com/5378924/47983253-adb5d700-e10d-11e8-92aa-04fecf99954f.png)

The "中文站" means "Chinese site".