### PR TITLE
[FLINK-11252] Add scala 2.12 download column 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ source_releases:
 
 stable_releases:
   -
-      name: "Apache 1.7.1 Flink only"
+      name: "Apache Flink 1.7.1 only"
       scala_211:
           id: "170-download-hadoopfree_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz"
@@ -62,7 +62,7 @@ stable_releases:
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.8"
+      name: "Apache Flink 1.7.1 with Hadoop® 2.8"
       scala_211:
           id: "170-download-hadoop28_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz"
@@ -74,7 +74,7 @@ stable_releases:
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.7"
+      name: "Apache Flink 1.7.1 with Hadoop® 2.7"
       scala_211:
           id: "170-download-hadoop27_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz"
@@ -86,7 +86,7 @@ stable_releases:
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.6"
+      name: "Apache Flink 1.7.1 with Hadoop® 2.6"
       scala_211:
           id: "170-download-hadoop26_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz"
@@ -98,7 +98,7 @@ stable_releases:
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.4"
+      name: "Apache Flink 1.7.1 with Hadoop® 2.4"
       scala_211:
           id: "170-download-hadoop24_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz"

--- a/_config.yml
+++ b/_config.yml
@@ -50,125 +50,135 @@ source_releases:
 
 stable_releases:
   -
-      name: "Apache 1.7.1 Flink only Scala 2.11"
-      id: "170-download-hadoopfree_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512"
+      name: "Apache 1.7.1 Flink only"
+      scala_211:
+          id: "170-download-hadoopfree_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512"
+      scala_212:
+          id: "170-download-hadoopfree_212"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.sha512"
   -
-      name: "Apache 1.7.1 Flink only Scala 2.12"
-      id: "170-download-hadoopfree_212"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.sha512"
+      name: "Flink 1.7.1 with Hadoop® 2.8"
+      scala_211:
+          id: "170-download-hadoop28_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512"
+      scala_212:
+          id: "170-download-hadoop28_212"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.8 Scala 2.11"
-      id: "170-download-hadoop28_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512"
+      name: "Flink 1.7.1 with Hadoop® 2.7"
+      scala_211:
+          id: "170-download-hadoop27_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512"
+      scala_212:
+          id: "170-download-hadoop27_212"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.8 Scala 2.12"
-      id: "170-download-hadoop28_212"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512"
+      name: "Flink 1.7.1 with Hadoop® 2.6"
+      scala_211:
+          id: "170-download-hadoop26_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512"
+      scala_212:
+          id: "170-download-hadoop26_212"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512"
   -
-      name: "Flink 1.7.1 with Hadoop® 2.7 Scala 2.11"
-      id: "170-download-hadoop27_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.7.1 with Hadoop® 2.7 Scala 2.12"
-      id: "170-download-hadoop27_212"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512"
-  -
-      name: "Flink 1.7.1 with Hadoop® 2.6 Scala 2.11"
-      id: "170-download-hadoop26_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.7.1 with Hadoop® 2.6 Scala 2.12"
-      id: "170-download-hadoop26_212"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512"
-  -
-      name: "Flink 1.7.1 with Hadoop® 2.4 Scala 2.11"
-      id: "170-download-hadoop24_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.7.1 with Hadoop® 2.4 Scala 2.12"
-      id: "170-download-hadoop24_212"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512"
+      name: "Flink 1.7.1 with Hadoop® 2.4"
+      scala_211:
+          id: "170-download-hadoop24_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512"
+      scala_212:
+          id: "170-download-hadoop24_212"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512"
   -
       name: "Apache Flink 1.6.3 only"
-      id: "163-download-hadoopfree_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "163-download-hadoopfree_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.6.3 with Hadoop® 2.8"
-      id: "163-download-hadoop28_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "163-download-hadoop28_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.6.3 with Hadoop® 2.7"
-      id: "163-download-hadoop27_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "163-download-hadoop27_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.6.3 with Hadoop® 2.6"
-      id: "163-download-hadoop26_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "163-download-hadoop26_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.6.3 with Hadoop® 2.4"
-      id: "163-download-hadoop24_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "163-download-hadoop24_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.sha512"
   -
       name: "Apache 1.5.6 Flink only"
-      id: "156-download-hadoopfree_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "156-download-hadoopfree_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.5.6 with Hadoop® 2.8"
-      id: "156-download-hadoop28_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "156-download-hadoop28_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.5.6 with Hadoop® 2.7"
-      id: "156-download-hadoop27_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "156-download-hadoop27_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.5.6 with Hadoop® 2.6"
-      id: "156-download-hadoop26_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "156-download-hadoop26_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512"
   -
       name: "Flink 1.5.6 with Hadoop® 2.4"
-      id: "156-download-hadoop24_211"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512"
+      scala_211:
+          id: "156-download-hadoop24_211"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512"
 
 FLINK_DOWNLOAD_URL_HADOOP_2_LATEST: https://s3.amazonaws.com/flink-nightly/flink-1.8-SNAPSHOT-bin-hadoop2.tgz
 

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ FLINK_GITHUB_REPO_NAME: flink
 source_releases:
   -
       name: "Apache Flink 1.7.1"
-      id: "170-download-source"
+      id: "171-download-source"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-src.tgz"
       asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz.asc"
       sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz.sha512"
@@ -52,7 +52,7 @@ stable_releases:
   -
       name: "Apache Flink 1.7.1 only"
       scala_211:
-          id: "170-download-hadoopfree_211"
+          id: "171-download-hadoopfree_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512"
@@ -64,48 +64,48 @@ stable_releases:
   -
       name: "Apache Flink 1.7.1 with Hadoop® 2.8"
       scala_211:
-          id: "170-download-hadoop28_211"
+          id: "171-download-hadoop28_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512"
       scala_212:
-          id: "170-download-hadoop28_212"
+          id: "171-download-hadoop28_212"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512"
   -
       name: "Apache Flink 1.7.1 with Hadoop® 2.7"
       scala_211:
-          id: "170-download-hadoop27_211"
+          id: "171-download-hadoop27_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512"
       scala_212:
-          id: "170-download-hadoop27_212"
+          id: "171-download-hadoop27_212"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512"
   -
       name: "Apache Flink 1.7.1 with Hadoop® 2.6"
       scala_211:
-          id: "170-download-hadoop26_211"
+          id: "171-download-hadoop26_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512"
       scala_212:
-          id: "170-download-hadoop26_212"
+          id: "171-download-hadoop26_212"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512"
   -
       name: "Apache Flink 1.7.1 with Hadoop® 2.4"
       scala_211:
-          id: "170-download-hadoop24_211"
+          id: "171-download-hadoop24_211"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512"
       scala_212:
-          id: "170-download-hadoop24_212"
+          id: "171-download-hadoop24_212"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz"
           asc_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc"
           sha512_url: "https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512"

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -196,7 +196,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 <tbody>
     
     <tr>
-    <th>Apache 1.7.1 Flink only</th>
+    <th>Apache Flink 1.7.1 only</th>
     
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz" class="ga-track" id="170-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
     
@@ -207,7 +207,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.8</th>
+    <th>Apache Flink 1.7.1 with Hadoop® 2.8</th>
     
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="170-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
     
@@ -218,7 +218,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.7</th>
+    <th>Apache Flink 1.7.1 with Hadoop® 2.7</th>
     
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="170-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
     
@@ -229,7 +229,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.6</th>
+    <th>Apache Flink 1.7.1 with Hadoop® 2.6</th>
     
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="170-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
     
@@ -240,7 +240,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.4</th>
+    <th>Apache Flink 1.7.1 with Hadoop® 2.4</th>
     
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="170-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
     

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -198,7 +198,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     <tr>
     <th>Apache Flink 1.7.1 only</th>
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz" class="ga-track" id="170-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz" class="ga-track" id="171-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
     
 
     
@@ -209,44 +209,44 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     <tr>
     <th>Apache Flink 1.7.1 with Hadoop® 2.8</th>
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="170-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="171-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
     
 
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz" class="ga-track" id="170-download-hadoop28_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz" class="ga-track" id="171-download-hadoop28_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512">sha512</a>)</td>
     
     </tr>
     
     <tr>
     <th>Apache Flink 1.7.1 with Hadoop® 2.7</th>
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="170-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="171-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
     
 
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz" class="ga-track" id="170-download-hadoop27_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz" class="ga-track" id="171-download-hadoop27_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512">sha512</a>)</td>
     
     </tr>
     
     <tr>
     <th>Apache Flink 1.7.1 with Hadoop® 2.6</th>
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="170-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="171-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
     
 
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz" class="ga-track" id="170-download-hadoop26_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz" class="ga-track" id="171-download-hadoop26_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512">sha512</a>)</td>
     
     </tr>
     
     <tr>
     <th>Apache Flink 1.7.1 with Hadoop® 2.4</th>
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="170-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="171-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
     
 
     
-    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz" class="ga-track" id="170-download-hadoop24_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512">sha512</a>)</td>
+    <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz" class="ga-track" id="171-download-hadoop24_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512">sha512</a>)</td>
     
     </tr>
     
@@ -367,7 +367,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 
 <div class="list-group">
   <!-- Source -->
-  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-src.tgz" class="list-group-item ga-track" id="170-download-source">
+  <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-src.tgz" class="list-group-item ga-track" id="171-download-source">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.7.1</strong> Source Release</h4>
     <p>Review the source code or build Flink on your own, using this package</p>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -190,109 +190,174 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 <table class="table table-striped">
 <thead>
     <tr>
-    <th></th> <th>Scala 2.11</th>
+    <th></th> <th>Scala 2.11</th> <th>Scala 2.12</th>
     </tr>
 </thead>
 <tbody>
     
     <tr>
-    <th>Apache 1.7.1 Flink only Scala 2.11</th>
+    <th>Apache 1.7.1 Flink only</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz" class="ga-track" id="170-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
-    </tr>
     
-    <tr>
-    <th>Apache 1.7.1 Flink only Scala 2.12</th>
+
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz" class="ga-track" id="170-download-hadoopfree_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-scala_2.12.tgz.sha512">sha512</a>)</td>
+    
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.8 Scala 2.11</th>
+    <th>Flink 1.7.1 with Hadoop® 2.8</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="170-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
-    </tr>
     
-    <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.8 Scala 2.12</th>
+
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz" class="ga-track" id="170-download-hadoop28_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop28-scala_2.12.tgz.sha512">sha512</a>)</td>
+    
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.7 Scala 2.11</th>
+    <th>Flink 1.7.1 with Hadoop® 2.7</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="170-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
-    </tr>
     
-    <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.7 Scala 2.12</th>
+
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz" class="ga-track" id="170-download-hadoop27_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop27-scala_2.12.tgz.sha512">sha512</a>)</td>
+    
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.6 Scala 2.11</th>
+    <th>Flink 1.7.1 with Hadoop® 2.6</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="170-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
-    </tr>
     
-    <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.6 Scala 2.12</th>
+
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz" class="ga-track" id="170-download-hadoop26_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop26-scala_2.12.tgz.sha512">sha512</a>)</td>
+    
     </tr>
     
     <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.4 Scala 2.11</th>
+    <th>Flink 1.7.1 with Hadoop® 2.4</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="170-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
-    </tr>
     
-    <tr>
-    <th>Flink 1.7.1 with Hadoop® 2.4 Scala 2.12</th>
+
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz" class="ga-track" id="170-download-hadoop24_212">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-bin-hadoop24-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512">sha512</a>)</td>
+    
     </tr>
     
     <tr>
     <th>Apache Flink 1.6.3 only</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz" class="ga-track" id="163-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.6.3 with Hadoop® 2.8</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="163-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.6.3 with Hadoop® 2.7</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="163-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.6.3 with Hadoop® 2.6</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="163-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.6.3 with Hadoop® 2.4</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="163-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Apache 1.5.6 Flink only</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz" class="ga-track" id="156-download-hadoopfree_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.5.6 with Hadoop® 2.8</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz" class="ga-track" id="156-download-hadoop28_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.5.6 with Hadoop® 2.7</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz" class="ga-track" id="156-download-hadoop27_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.5.6 with Hadoop® 2.6</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz" class="ga-track" id="156-download-hadoop26_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
     <tr>
     <th>Flink 1.5.6 with Hadoop® 2.4</th>
+    
     <td><a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="156-download-hadoop24_211">Download</a> (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512">sha512</a>)</td>
+    
+
+    
+    <td>Not supported.</td>
+    
     </tr>
     
 </tbody>

--- a/downloads.md
+++ b/downloads.md
@@ -35,14 +35,24 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 <table class="table table-striped">
 <thead>
     <tr>
-    <th></th> <th>Scala 2.11</th>
+    <th></th> <th>Scala 2.11</th> <th>Scala 2.12</th>
     </tr>
 </thead>
 <tbody>
     {% for binary_release in site.stable_releases %}
     <tr>
     <th>{{ binary_release.name }}</th>
-    <td><a href="{{ binary_release.url }}" class="ga-track" id="{{ binary_release.id }}">Download</a> (<a href="{{ binary_release.asc_url }}">asc</a>, <a href="{{ binary_release.sha512_url }}">sha512</a>)</td>
+    {% if binary_release.scala_211 %}
+    <td><a href="{{ binary_release.scala_211.url }}" class="ga-track" id="{{ binary_release.scala_211.id }}">Download</a> (<a href="{{ binary_release.scala_211.asc_url }}">asc</a>, <a href="{{ binary_release.scala_211.sha512_url }}">sha512</a>)</td>
+    {% else %}
+    <td>Not supported.</td>
+    {% endif %}
+
+    {% if binary_release.scala_212 %}
+    <td><a href="{{ binary_release.scala_212.url }}" class="ga-track" id="{{ binary_release.scala_212.id }}">Download</a> (<a href="{{ binary_release.scala_212.asc_url }}">asc</a>, <a href="{{ binary_release.scala_212.sha512_url }}">sha512</a>)</td>
+    {% else %}
+    <td>Not supported.</td>
+    {% endif %}
     </tr>
     {% endfor %}
 </tbody>


### PR DESCRIPTION
This PR modifies the download page to feature Scala 2.11 / Scala 2.12 columns with their respective download links, instead of listing each scala-variant of a release as a separate item.

Scala variants are now defined in `_config.yaml` as fields of a particular release (effectively acting as Map entries) and queried in `downloads.md`.

![new_downloads](https://user-images.githubusercontent.com/5725237/50593646-6479cd80-0e99-11e9-82ac-d8dfc68bda9c.png)
