### PR TITLE
[hotfix] Deduplicate note for source releases 

### DIFF
--- a/content/downloads.html
+++ b/content/downloads.html
@@ -299,13 +299,13 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 </table>
 
 <h3 id="source">Source</h3>
+<p>Review the source code or build Flink on your own, using one of these packages:</p>
 
 <div class="list-group">
   <!-- Source -->
   <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.1/flink-1.7.1-src.tgz" class="list-group-item ga-track" id="170-download-source">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.7.1</strong> Source Release</h4>
-    <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz.sha512">sha512</a>)
 </div>
@@ -315,7 +315,6 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.6.3/flink-1.6.3-src.tgz" class="list-group-item ga-track" id="163-download-source">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.6.3</strong> Source Release</h4>
-    <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz.sha512">sha512</a>)
 </div>
@@ -325,7 +324,6 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-src.tgz" class="list-group-item ga-track" id="156-download-source">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink 1.5.6</strong> Source Release</h4>
-    <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.sha512">sha512</a>)
 </div>
@@ -335,7 +333,6 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   <a href="https://www.apache.org/dyn/closer.lua/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz" class="list-group-item ga-track" id="s50-download-source">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>Apache Flink-shaded 5.0</strong> Source Release</h4>
-    <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.asc">asc</a>, <a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.sha512">sha512</a>)
 </div>

--- a/downloads.md
+++ b/downloads.md
@@ -49,6 +49,7 @@ bundles the matching Hadoop version, or use the Hadoop free version and
 </table>
 
 ### Source
+<p>Review the source code or build Flink on your own, using one of these packages:</p>
 
 {% for source_release in site.source_releases %}
 <div class="list-group">
@@ -56,7 +57,6 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   <a href="{{ source_release.url }}" class="list-group-item ga-track" id="{{ source_release.id }}">
     <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
     <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>{{ source_release.name }}</strong> Source Release</h4>
-    <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
 </div>


### PR DESCRIPTION
Small cleanup to deduplicate `Review the source code or build Flink on your own, using this package`.