### PR TITLE
 [FLINK-11269] Support listing optional components 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,61 @@ FLINK_GITHUB_URL: https://github.com/apache/flink
 FLINK_CONTRIBUTORS_URL: https://cwiki.apache.org/confluence/display/FLINK/List+of+contributors
 FLINK_GITHUB_REPO_NAME: flink
 
+optional_components:
+  -
+    name: "Avro"
+    category: "SQL Formats"
+    scala_dependent: false
+    versions:
+      -
+        version: "1.7.1"
+        id: 171-sql-format-avro
+        url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar
+        asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar.asc
+        sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar.sha1
+  -
+    name: "Json"
+    category: "SQL Formats"
+    scala_dependent: false
+    versions:
+      -
+        version: "1.7.1"
+        id: 171-sql-format-json
+        url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar
+        asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar.asc
+        sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar.sha1
+
+# Example for scala dependent component:
+#  -
+#    name: "Prometheus MetricReporter"
+#    category: "Reporters"
+#    scala_dependent: true
+#    versions:
+#      -
+#        version: "1.7.1"
+#        scala_211:
+#          id: 171-prometheus-211
+#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
+#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
+#          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
+#        scala_212:
+#          id: 171-prometheus-212
+#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
+#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
+#          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
+#      -
+#        version: "1.6.1"
+#        scala_211:
+#          id: 171-prometheus-211
+#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
+#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
+#          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
+#        scala_212:
+#          id: 171-prometheus-212
+#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
+#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
+#          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
+
 source_releases:
   -
       name: "Apache Flink 1.7.1"

--- a/content/css/flink.css
+++ b/content/css/flink.css
@@ -162,6 +162,18 @@ img {
                                  Various
 =============================================================================*/
 
+.collapsible {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 12px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
 .stack img {
 	width: 480px;
 	height: 280px;

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -158,6 +158,7 @@ $( document ).ready(function() {
   <li><a href="#latest-stable-release-v171" id="markdown-toc-latest-stable-release-v171">Latest stable release (v1.7.1)</a>    <ul>
       <li><a href="#binaries" id="markdown-toc-binaries">Binaries</a></li>
       <li><a href="#source" id="markdown-toc-source">Source</a></li>
+      <li><a href="#optional-components" id="markdown-toc-optional-components">Optional components</a></li>
     </ul>
   </li>
   <li><a href="#release-notes" id="markdown-toc-release-notes">Release Notes</a></li>
@@ -403,6 +404,61 @@ bundles the matching Hadoop version, or use the Hadoop free version and
     <p>Review the source code or build Flink on your own, using this package</p>
   </a>
    (<a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.asc">asc</a>, <a href="https://dist.apache.org/repos/dist/release/flink/flink-shaded-5.0/flink-shaded-5.0-src.tgz.sha512">sha512</a>)
+</div>
+
+<h3 id="optional-components">Optional components</h3>
+
+<p><button class="collapsible" data-toggle="collapse" data-target="#sql-formats" aria-hidden="true">SQL Formats<span class="glyphicon glyphicon-plus" style="float: right; font-size: 20px;"></span></button></p>
+<div id="sql-formats" class="collapse">
+
+
+
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th><strong>Avro</strong></th>
+      
+      <th></th>
+      
+    </tr>
+  </thead>
+  <tbody>
+    
+      <tr>
+        
+          <td>1.7.1</td>
+          <td><a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar" class="ga-track" id="171-sql-format-avro">Download</a> (<a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar.asc">asc</a>, <a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.1/flink-avro-1.7.1.jar.sha1">sha1</a>)</td>
+        
+      </tr>
+    
+  </tbody>
+</table>
+
+
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th><strong>Json</strong></th>
+      
+      <th></th>
+      
+    </tr>
+  </thead>
+  <tbody>
+    
+      <tr>
+        
+          <td>1.7.1</td>
+          <td><a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar" class="ga-track" id="171-sql-format-json">Download</a> (<a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar.asc">asc</a>, <a href="https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.1/flink-json-1.7.1.jar.sha1">sha1</a>)</td>
+        
+      </tr>
+    
+  </tbody>
+</table>
+
+
 </div>
 
 <h2 id="release-notes">Release Notes</h2>

--- a/css/flink.css
+++ b/css/flink.css
@@ -162,6 +162,18 @@ img {
                                  Various
 =============================================================================*/
 
+.collapsible {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 12px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
 .stack img {
 	width: 480px;
 	height: 280px;

--- a/downloads.md
+++ b/downloads.md
@@ -70,7 +70,57 @@ bundles the matching Hadoop version, or use the Hadoop free version and
   </a>
    (<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
 </div>
+{% endfor %}
 
+### Optional components
+
+{% assign categories = site.optional_components | group_by: 'category' | sort: 'name' %}
+{% for category in categories %}
+
+<button class="collapsible" data-toggle="collapse" data-target="#{{category.name | slugify}}" aria-hidden="true">{{category.name}}<span class="glyphicon glyphicon-plus" style="float: right; font-size: 20px;"></span></button>
+<div id="{{category.name | slugify}}" class="collapse">
+
+{% assign components = category.items | | sort: 'name' %}
+{% for component in components %}
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th><strong>{{ component.name }}</strong></th>
+      {% if component.scala_dependent %}
+      <th>Scala 2.11</th>
+      <th>Scala 2.12</th>
+      {% else %}
+      <th></th>
+      {% endif %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for version in component.versions %}
+      <tr>
+        {% if component.scala_dependent %}
+          <td>{{ version.version }}</td>
+          {% if version.scala_211 %}
+            <td><a href="{{ version.scala_211.url }}" class="ga-track" id="{{ version.scala_211.id }}">Download</a> (<a href="{{ version.scala_211.asc_url }}">asc</a>, <a href="{{ version.scala_211.sha512_url }}">sha1</a>)</td>
+          {% else %}
+            <td>Not supported.</td>
+          {% endif %}
+          {% if version.scala_212 %}
+            <td><a href="{{ version.scala_212.url }}" class="ga-track" id="{{ version.scala_212.id }}">Download</a> (<a href="{{ version.scala_212.asc_url }}">asc</a>, <a href="{{ version.scala_212.sha512_url }}">sha1</a>)</td>
+          {% else %}
+            <td>Not supported.</td>
+          {% endif %}
+        {% else %}
+          <td>{{ version.version }}</td>
+          <td><a href="{{ version.url }}" class="ga-track" id="{{ version.id }}">Download</a> (<a href="{{ version.asc_url }}">asc</a>, <a href="{{ version.sha_url }}">sha1</a>)</td>
+        {% endif %}
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% endfor %}
+</div>
 {% endfor %}
 
 ## Release Notes


### PR DESCRIPTION
This PR adds support for listing optional components. We can use this to provide convenient access to metric reporters, sql formats/connector and shaded-hadoop jars.

Previews:

**Collapsed**:
![optional_collapsed](https://user-images.githubusercontent.com/5725237/50848996-115eb980-1376-11e9-88ed-ac14fc8418c3.png)
**Expanded**:
![optional_expanded](https://user-images.githubusercontent.com/5725237/50848998-115eb980-1376-11e9-8b2f-d3ad9bf6270e.png)

As seen components are grouped by their category in a collapsible block. Each component has it's own table, listing all artifacts for each Flink version. Components may be scala dependent.

Components are defined in _config.yml. This PR adds the SQL formats to the list of optional components as an example of non-scala dependent artifacts. The _config.yml also contains an commented-out example for a scala-dependent component.