### PR TITLE
[FLINK-11558] Translate "Ecosystem" page into Chinese

### DIFF
--- a/ecosystem.md
+++ b/ecosystem.md
@@ -42,7 +42,7 @@ Please let us know on the [user/dev mailing list](#mailing-lists).
 **Apache Zeppelin**
 
 [Apache Zeppelin](https://zeppelin.incubator.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
-[Flink as an execution engine](https://zeppelin.incubator.apache.org/docs/interpreter/flink.html) (next to other engines).
+[Flink as an execution engine](https://zeppelin.apache.org/docs/latest/interpreter/flink.html).
 See also Jim Dowling's [Flink Forward talk](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin) about Zeppelin on Flink.
 
 **Apache Mahout**

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -37,11 +37,11 @@ This is a list of third party packages (i.e., libraries, system extensions, or e
 The Flink community collects links to these packages but does not maintain them.
 Thus, they do not belong to the Apache Flink project, and the community cannot give any support for them.
 **Is your project missing?**
-Please let us know on the [user/dev mailing list](#mailing-lists).
+Please let us know on the [user/dev mailing list]({{ site.baseurl }}/community.html#mailing-lists).
 
 **Apache Zeppelin**
 
-[Apache Zeppelin](https://zeppelin.incubator.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
+[Apache Zeppelin](https://zeppelin.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
 [Flink as an execution engine](https://zeppelin.apache.org/docs/latest/interpreter/flink.html).
 See also Jim Dowling's [Flink Forward talk](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin) about Zeppelin on Flink.
 

--- a/ecosystem.zh.md
+++ b/ecosystem.zh.md
@@ -2,16 +2,15 @@
 title: "生态系统"
 ---
 <br>
-Apache Flink supports a broad ecosystem and works seamlessly with
-many other data processing projects and frameworks.
+Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项目和框架无缝协作。
 <br>
 {% toc %}
 
 ## Connectors
 
-<p>Connectors provide code for interfacing with various third-party systems.</p>
+<p>Connectors 提供用于与各种第三方系统连接的代码。</p>
 
-<p>Currently these systems are supported:</p>
+<p>目前支持这些系统：</p>
 
 <ul>
   <li><a href="{{site.docs-stable}}/dev/connectors/kafka.html" target="_blank">Apache Kafka</a> (sink/source)</li>
@@ -25,78 +24,70 @@ many other data processing projects and frameworks.
   <li><a href="https://github.com/apache/bahir-flink" target="_blank">Redis, Flume, and ActiveMQ (via Apache Bahir)</a> (sink)</li>
 </ul>
 
-To run an application using one of these connectors, additional third party
-components are usually required to be installed and launched, e.g., the servers
-for the message queues. Further instructions for these can be found in the
-corresponding subsections.
+要使用其中的某个 connector 来运行应用程序，用户通常需要额外安装和启动第三方组件，例如消息队列服务器。有关第三方组件的进一步说明，请参阅相应的小节。
 
+## 第三方项目
 
-## Third-Party Projects
-
-This is a list of third party packages (i.e., libraries, system extensions, or examples) built on Flink.
-The Flink community collects links to these packages but does not maintain them.
-Thus, they do not belong to the Apache Flink project, and the community cannot give any support for them.
-**Is your project missing?**
-Please let us know on the [user/dev mailing list](#mailing-lists).
+这是基于 Flink 构建的第三方软件包（包括库，系统扩展或示例）的列表。
+ Flink 社区收集这些包的链接，但不维护它们。
+因此，它们不属于 Apache Flink 项目，社区无法为它们提供任何支持。
+**是否遗漏了您的项目？**
+请通过 [user/dev mailing list](#mailing-lists) 告诉我们。
 
 **Apache Zeppelin**
 
-[Apache Zeppelin](https://zeppelin.incubator.apache.org/) is a web-based notebook that enables interactive data analytics and can be used with
-[Flink as an execution engine](https://zeppelin.incubator.apache.org/docs/interpreter/flink.html) (next to other engines).
-See also Jim Dowling's [Flink Forward talk](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin) about Zeppelin on Flink.
+[Apache Zeppelin](https://zeppelin.incubator.apache.org/) 是一个 Web 笔记形式的交互式数据查询分析工具，它可以使用 [Flink作为执行引擎](https://zeppelin.apache.org/docs/latest/interpreter/flink.html)。可以查看 Jim Dowling 在 Flink Forward 会议上关于在 Flink 上使用 Zeppelin 的[演讲](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin)。
 
 **Apache Mahout**
 
-[Apache Mahout](https://mahout.apache.org/) is a machine learning library that will feature Flink as an execution engine soon.
-Check out Sebastian Schelter's [Flink Forward talk](http://www.slideshare.net/FlinkForward/sebastian-schelter-distributed-machine-learing-with-the-samsara-dsl) about Mahout-Samsara DSL.
+[Apache Mahout](https://mahout.apache.org/) 是一个机器学习库，很快会将 Flink 作为执行引擎。可以查看 Sebastian Schelter 在 Flink Forward 会议上关于 Mahout-Samsara DSL 的[演讲](http://www.slideshare.net/FlinkForward/sebastian-schelter-distributed-machine-learing-with-the-samsara-dsl)。
 
 **Cascading**
 
-[Cascading](http://www.cascading.org/cascading-flink/) enables a user to build complex workflows easily on Flink and other execution engines.
-[Cascading on Flink](https://github.com/dataArtisans/cascading-flink) is built by [dataArtisans](http://data-artisans.com/) and [Driven, Inc](http://www.driven.io/).
-See Fabian Hueske's [Flink Forward talk](http://www.slideshare.net/FlinkForward/fabian-hueske-training-cascading-on-flink) for more details.
+[Cascading](http://www.cascading.org/cascading-flink/) 使用户可以在 Flink 和其他执行引擎上轻松构建复杂的工作流。
+[Cascading on Flink](https://github.com/dataArtisans/cascading-flink) 项目是由 [dataArtisans](http://data-artisans.com/) 和 [Driven, Inc](http://www.driven.io/) 建立。请参阅 Fabian Hueske 在 [Flink Forward 会议上的演讲](http://www.slideshare.net/FlinkForward/fabian-hueske-training-cascading-on-flink)以获取更多细节。
 
 **Apache Beam**
 
-[Apache Beam](https://beam.apache.org/) is an open-source, unified programming model that you can use to create a data processing pipeline. Flink is one of the back-ends supported by the Beam programming model.
+[Apache Beam](https://beam.apache.org/) 是一种开源统一的编程模型，可用于创建数据处理管道。 Flink 是 Beam 编程模型支持的后端引擎之一。
 
 **GRADOOP**
 
-[GRADOOP](http://dbs.uni-leipzig.de/en/research/projects/gradoop) enables scalable graph analytics on top of Flink and is developed at Leipzig University. Check out Martin Junghanns’ [Flink Forward talk](http://www.slideshare.net/FlinkForward/martin-junghans-gradoop-scalable-graph-analytics-with-apache-flink).
+[GRADOOP](http://dbs.uni-leipzig.de/en/research/projects/gradoop) 是在 Leipzig 大学开发的，用于在 Flink 之上实现可扩展的图形分析。请参阅 Martin Junghanns 在 [Flink Forward 会议上的演讲](http://www.slideshare.net/FlinkForward/martin-junghans-gradoop-scalable-graph-analytics-with-apache-flink)。
 
 **BigPetStore**
 
-[BigPetStore](https://github.com/apache/bigtop/tree/master/bigtop-bigpetstore) is a benchmarking suite including a data generator and will be available for Flink soon.
-See Suneel Marthi's [Flink Forward talk](http://www.slideshare.net/FlinkForward/suneel-marthi-bigpetstore-flink-a-comprehensive-blueprint-for-apache-flink?ref=http://flink-forward.org/?session=tbd-3) as preview.
+[BigPetStore](https://github.com/apache/bigtop/tree/master/bigtop-bigpetstore) 是一个包含数据生成器的基准测试套件，很快就可以用于 Flink 。 请参阅 Suneel Marthi 在 [Flink Forward 会议上的演讲](http://www.slideshare.net/FlinkForward/suneel-marthi-bigpetstore-flink-a-comprehensive-blueprint-for-apache-flink?ref=http://flink-forward.org/?session=tbd-3)。
 
 **FastR**
 
-[FastR](https://github.com/oracle/fastr) is an implemenation of the R language in Java. [FastR Flink](https://bitbucket.org/allr/fastr-flink/src/3535a9b7c7f208508d6afbcdaf1de7d04fa2bf79/README_FASTR_FLINK.md?at=default&fileviewer=file-view-default) executes R workloads on top of Flink.
+[FastR](https://github.com/oracle/fastr) 是 Java 中 R 语言的实现。 [FastR Flink](https://bitbucket.org/allr/fastr-flink/src/3535a9b7c7f208508d6afbcdaf1de7d04fa2bf79/README_FASTR_FLINK.md?at=default&fileviewer=file-view-default) 在 Flink 之上执行 R 任务。
 
 **Apache SAMOA**
 
-[Apache SAMOA (incubating)](https://samoa.incubator.apache.org/) is a streaming ML library featuring Flink as an execution engine soon. Albert Bifet introduced SAMOA on Flink at his [Flink Forward talk](http://www.slideshare.net/FlinkForward/albert-bifet-apache-samoa-mining-big-data-streams-with-apache-flink?ref=http://flink-forward.org/?session=apache-samoa-mining-big-data-streams-with-apache-flink).
+[Apache SAMOA (incubating)](https://samoa.incubator.apache.org/) 是一个流式的机器学习库，很快将支持 Flink 作为执行引擎。 Albert Bifet 在 [Flink Forward 会议上的演讲](http://www.slideshare.net/FlinkForward/albert-bifet-apache-samoa-mining-big-data-streams-with-apache-flink?ref=http://flink-forward.org/?session=apache-samoa-mining-big-data-streams-with-apache-flink)中介绍了 SAMOA。
 
 **Alluxio**
 
-[Alluxio](http://www.alluxio.org/) is an open-source memory-speed virtual distributed storage that enables applications to efficiently share data and access data across different storage systems in a [unified namespace](http://www.alluxio.org/docs/master/en/Unified-and-Transparent-Namespace.html). Here is an example of [using Flink to access data through Alluxio](http://www.alluxio.org/docs/master/en/Running-Flink-on-Alluxio.html).
+[Alluxio](http://www.alluxio.org/) 是一个开源的，能匹配内存速度的虚拟分布式存储，使应用程序能够在[统一的命名空间](http://www.alluxio.org/docs/master/en/Unified-and-Transparent-Namespace.html)中有效地共享数据并跨不同存储系统访问数据。以下是[使用 Flink 通过 Alluxio 访问数据的示例](http://www.alluxio.org/docs/master/en/Running-Flink-on-Alluxio.html)。
 
 **Python Examples on Flink**
 
-A [collection of examples](https://github.com/wdm0006/flink-python-examples) using Apache Flink's Python API.
+使用 Apache Flink 的 Python API 的[一组示例](https://github.com/wdm0006/flink-python-examples)。
 
 **WordCount Example in Clojure**
 
-A small [WordCount example](https://github.com/mjsax/flink-external/tree/master/flink-clojure) on how to write a Flink program in Clojure.
+关于如何在 Clojure 中编写 Flink 程序的 [WordCount示例](https://github.com/mjsax/flink-external/tree/master/flink-clojure)。
 
 **Anomaly Detection and Prediction in Flink**
 
-[flink-htm](https://github.com/nupic-community/flink-htm) is a library for anomaly detection and prediction in Apache Flink. The algorithms are based on Hierarchical Temporal Memory (HTM) as implemented by the Numenta Platform for Intelligent Computing (NuPIC).
+[flink-htm](https://github.com/nupic-community/flink-htm) 是 Apache Flink 中用于异常检测和预测的库。该算法基于由 Numenta 智能计算平台（NuPIC）实现的 Hierarchical Temporal Memory（HTM）。
 
 **Apache Ignite**
 
-[Apache Ignite](https://ignite.apache.org) is a high-performance, integrated and distributed in-memory platform for computing and transacting on large-scale data sets in real-time. See [Flink sink streaming connector](https://github.com/apache/ignite/tree/master/modules/flink) to inject data into Ignite cache.
+[Apache Ignite](https://ignite.apache.org) 是一个高性能，集成和分布式的内存计算和事务平台，用于实时处理大规模数据集。请参阅 [Flink sink streaming connector](https://github.com/apache/ignite/tree/master/modules/flink) 以将数据写入 Ignite 缓存。
 
 **Tink temporal graph library**
 
-[Tink](https://github.com/otherwise777/Temporal_Graph_library) is a temporal graph library built on top of Flink. It allows for temporal graph analytics like different interpretations of the shortest temporal path algorithm and metrics like temporal betweenness and temporal closeness. This library was the result of the [Thesis](http://www.win.tue.nl/~gfletche/ligtenberg2017.pdf) of Wouter Ligtenberg.
+[Tink](https://github.com/otherwise777/Temporal_Graph_library) 
+是一个建立在 Flink 之上的时态图库。它可以分析时态图，如对最短时间路径算法的不同解释，以及诸如时间间隔和时间紧密度之类的度量。这里是 Wouter Ligtenberg 的[论文](http://www.win.tue.nl/~gfletche/ligtenberg2017.pdf)。

--- a/ecosystem.zh.md
+++ b/ecosystem.zh.md
@@ -8,7 +8,7 @@ Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项�
 
 ## Connectors
 
-<p>Connectors 提供用于与各种第三方系统连接的代码。</p>
+<p>Connectors 提供了用于与各种第三方系统连接的代码。</p>
 
 <p>目前支持这些系统：</p>
 
@@ -29,14 +29,14 @@ Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项�
 ## 第三方项目
 
 这是基于 Flink 构建的第三方软件包（包括库，系统扩展或示例）的列表。
- Flink 社区收集这些包的链接，但不维护它们。
+ Flink 社区收集了这些包的链接，但不负责维护它们。
 因此，它们不属于 Apache Flink 项目，社区无法为它们提供任何支持。
 **是否遗漏了您的项目？**
-请通过 [user/dev mailing list](#mailing-lists) 告诉我们。
+请通过[用户或开发者邮件列表]({{ site.baseurl }}/zh/community.html#mailing-lists)告诉我们。
 
 **Apache Zeppelin**
 
-[Apache Zeppelin](https://zeppelin.incubator.apache.org/) 是一个 Web 笔记形式的交互式数据查询分析工具，它可以使用 [Flink作为执行引擎](https://zeppelin.apache.org/docs/latest/interpreter/flink.html)。可以查看 Jim Dowling 在 Flink Forward 会议上关于在 Flink 上使用 Zeppelin 的[演讲](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin)。
+[Apache Zeppelin](https://zeppelin.apache.org/) 是一个 Web 笔记形式的交互式数据查询分析工具，它可以使用 [Flink作为执行引擎](https://zeppelin.apache.org/docs/latest/interpreter/flink.html)。可以查看 Jim Dowling 在 Flink Forward 会议上关于在 Flink 上使用 Zeppelin 的[演讲](http://www.slideshare.net/FlinkForward/jim-dowling-interactive-flink-analytics-with-hopsworks-and-zeppelin)。
 
 **Apache Mahout**
 
@@ -61,7 +61,7 @@ Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项�
 
 **FastR**
 
-[FastR](https://github.com/oracle/fastr) 是 Java 中 R 语言的实现。 [FastR Flink](https://bitbucket.org/allr/fastr-flink/src/3535a9b7c7f208508d6afbcdaf1de7d04fa2bf79/README_FASTR_FLINK.md?at=default&fileviewer=file-view-default) 在 Flink 之上执行 R 任务。
+[FastR](https://github.com/oracle/fastr) 是 Java 中 R 语言的实现。 [FastR Flink](https://bitbucket.org/allr/fastr-flink/src/3535a9b7c7f208508d6afbcdaf1de7d04fa2bf79/README_FASTR_FLINK.md?at=default&fileviewer=file-view-default) 可以在 Flink 之上执行 R 任务。
 
 **Apache SAMOA**
 
@@ -71,15 +71,15 @@ Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项�
 
 [Alluxio](http://www.alluxio.org/) 是一个开源的，能匹配内存速度的虚拟分布式存储，使应用程序能够在[统一的命名空间](http://www.alluxio.org/docs/master/en/Unified-and-Transparent-Namespace.html)中有效地共享数据并跨不同存储系统访问数据。以下是[使用 Flink 通过 Alluxio 访问数据的示例](http://www.alluxio.org/docs/master/en/Running-Flink-on-Alluxio.html)。
 
-**Python Examples on Flink**
+**Python示例**
 
 使用 Apache Flink 的 Python API 的[一组示例](https://github.com/wdm0006/flink-python-examples)。
 
-**WordCount Example in Clojure**
+**使用 Clojure 编写的 WordCount 示例**
 
 关于如何在 Clojure 中编写 Flink 程序的 [WordCount示例](https://github.com/mjsax/flink-external/tree/master/flink-clojure)。
 
-**Anomaly Detection and Prediction in Flink**
+**异常检测与预测**
 
 [flink-htm](https://github.com/nupic-community/flink-htm) 是 Apache Flink 中用于异常检测和预测的库。该算法基于由 Numenta 智能计算平台（NuPIC）实现的 Hierarchical Temporal Memory（HTM）。
 
@@ -87,7 +87,7 @@ Apache Flink 支持广泛的生态系统，并能与许多其他数据处理项�
 
 [Apache Ignite](https://ignite.apache.org) 是一个高性能，集成和分布式的内存计算和事务平台，用于实时处理大规模数据集。请参阅 [Flink sink streaming connector](https://github.com/apache/ignite/tree/master/modules/flink) 以将数据写入 Ignite 缓存。
 
-**Tink temporal graph library**
+**Tink 时态图库**
 
 [Tink](https://github.com/otherwise777/Temporal_Graph_library) 
 是一个建立在 Flink 之上的时态图库。它可以分析时态图，如对最短时间路径算法的不同解释，以及诸如时间间隔和时间紧密度之类的度量。这里是 Wouter Ligtenberg 的[论文](http://www.win.tue.nl/~gfletche/ligtenberg2017.pdf)。


### PR DESCRIPTION
Translate "Ecosystem" page into Chinese.

The markdown file is located in: flink-web/ecosystem.zh.md
The url link is: https://flink.apache.org/zh/ecosystem.html
