### PR TITLE
[FLINK-11566] Translate "Powered by Flink" page into Chinese

### DIFF
--- a/poweredby.zh.md
+++ b/poweredby.zh.md
@@ -8,98 +8,99 @@ title: "Flink 用户"
 
 <hr />
 
-Apache Flink powers business-critical applications in many companies and enterprises around the globe. On this page, we present a few notable Flink users that run interesting use cases in production and link to resources that discuss their applications in more detail.
+Apache Flink支持全球许多公司和企业的关键业务应用程序。在这个页面上，我们展示了一些在生产环境中运行有趣用例的Flink用户，并链接到更详细地讨论其应用程序的资源。
 
-More Flink users are listed in the <a href="https://cwiki.apache.org/confluence/display/FLINK/Powered+by+Flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Powered by Flink directory</a> in the project wiki. Please note that the list is *not* comprehensive. We only add users that explicitly ask to be listed.
+更多Flink用户列在<a href="https://cwiki.apache.org/confluence/display/FLINK/Powered+by+Flink" target='_blank'> <small><span class ="glyphicon glyphicon-new-window"></span> </small>由维基项目中的Flink目录</a>提供支持。 请注意，列表*不全面。 我们只添加明确要求列出的用户。
 
-If you would you like to be included on this page, please reach out to the [Flink user mailing list]({{ site.baseurl }}/community.html#mailing-lists) and let us know.
+如果您希望加入此页面，请访问[Flink用户邮件列表]({{site.baseurl}} / community.html #fmail-list)并告知我们。
 
 <div class="row-fluid">
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/alibaba-logo.png" alt="Alibaba" /><br />
-      Alibaba, the world's largest retailer, uses a fork of Flink called Blink to optimize search rankings in real time. <br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Flink's role at Alibaba</a>
+      全球最大的零售商阿里巴巴(Alibaba)使用名为Blink的Flink分支实时优化搜索排名。 <br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多有关Flink在阿里巴巴扮演角色的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/bettercloud-logo.png" alt="BetterCloud" /><br />
-      BetterCloud, a multi-SaaS management platform, uses Flink to surface near real-time intelligence from SaaS application activity. <br><br><a href="https://www.youtube.com/watch?v=_yHds9SvMfE&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2&index=10" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See BetterCloud at Flink Forward SF 2017</a>
+     BetterCloud是一个多SaaS管理平台，它使用Flink从SaaS应用程序活动中获取近乎实时的智能。 <br><br><a href="https://www.youtube.com/watch?v=_yHds9SvMfE&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2&index=10" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward SF 2017的BetterCloud</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/bouygues-logo.jpg" alt="Bouygues" /><br />
-      Bouygues Telecom is running 30 production applications powered by Flink and is processing 10 billion raw events per day. <br><br><a href="http://2016.flink-forward.org/kb_sessions/a-brief-history-of-time-with-apache-flink-real-time-monitoring-and-analysis-with-flink-kafka-hb/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See Bouygues Telcom at Flink Forward 2016</a>
+      Bouygues Telecom正在运行由Flink提供支持的30个生产应用程序，每天处理100亿个原始事件。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/a-brief-history-of-time-with-apache-flink-real-time-monitoring-and-analysis-with-flink-kafka-hb/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的Bouygues Telecom</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/capital-one-logo.png" alt="Capital One" /><br />
-      Capital One, a Fortune 500 financial services company, uses Flink for real-time activity monitoring and alerting. <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-andrew-gao-jeff-sharpe-finding-bad-acorns" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn about Capital One's fraud detection use case</a>
+      财富500强金融服务公司Capital One使用Flink进行实时活动监控和报警。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-andrew-gao-jeff-sharpe-finding-bad-acorns" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Capital One的欺诈检测用例</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/comcast-logo.png" alt="Comcast" /><br />
-      Comcast, a global media and technology company, uses Flink for operationalizing machine learning models and near-real-time event stream processing. <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-dave-torok-sameer-wadkar-embedding-flink-throughout-an-operationalized-streaming-ml-lifecycle" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn about Flink at Comcast</a>
+      康卡斯特(Comcast)是一家全球媒体和技术公司，它使用Flink来实现机器学习模型和近实时事件流处理。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-dave-torok-sameer-wadkar-embedding-flink-throughout-an-operationalized-streaming-ml-lifecycle" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解康卡斯特的Flink</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/criteo-logo.png" alt="Criteo" /><br />
-      Criteo is the advertising platform for the open internet and uses Flink for real-time revenue monitoring and near-real-time event processing. <br><br><a href="https://medium.com/criteo-labs/criteo-streaming-flink-31816c08da50" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn about Criteo's Flink use case</a>
+      Criteo是开放互联网的广告平台，使用Flink进行实时收入监控和近实时事件处理。 <br><br><a href="https://medium.com/criteo-labs/criteo-streaming-flink-31816c08da50" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Criteo的Flink用例</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/dtrb-logo.png" alt="Drivetribe" /><br />
-      Drivetribe, a digital community founded by the former hosts of “Top Gear”, uses Flink for metrics and content recommendations. <br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about Flink in the Drivetribe stack</a>
+     Drivetribe是由前“Top Gear”主持人创建的数字社区，它使用Flink作为指标和内容推荐。 <br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读Drivetribe stack的Flink</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ebay-logo.png" alt="Ebay" /><br />
-      Ebay's monitoring platform is powered by Flink and evaluates thousands of customizable alert rules on metrics and log streams. <br><br><a href="https://vimeo.com/265025956/c7d5576622" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn more about Flink at Ebay</a>
+      Ebay的监控平台由Flink提供支持，可评估数千条关于指标和日志流的可自定义报警规则。 <br><br><a href="https://vimeo.com/265025956/c7d5576622" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 在Ebay上了解更多关于Flink的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ericsson-logo.png" alt="Ericsson" /><br />
-      Ericsson used Flink to build a real-time anomaly detector with machine learning over large infrastructures. <br><br><a href="https://www.oreilly.com/ideas/applying-the-kappa-architecture-in-the-telco-industry" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read a detailed overview on O'Reilly Ideas</a>
+      爱立信使用Flink构建了一个实时异常检测器，通过大型基础设施进行机器学习。 <br><br><a href="https://www.oreilly.com/ideas/applying-the-kappa-architecture-in-the-telco-industry" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读关于O'Reilly想法的详细概述</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/huawei-logo.png" alt="Huawei" /><br />
-      Huawei is a leading global provider of ICT infrastructure and smart devices. Huawei Cloud provides Cloud Service based on Flink. <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-jinkui-shi-and-radu-tudoran-flink-realtime-analysis-in-cloudstream-service-of-huawei-cloud" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn about how Flink powers Cloud Service</a>
+      华为是全球领先的ICT基础设施和智能设备供应商。 华为云提供基于Flink的云服务。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-jinkui-shi-and-radu-tudoran-flink-realtime-analysis-in-cloudstream-service-of-huawei-cloud" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Flink如何为云服务提供动力</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/king-logo.png" alt="King" /><br />
-      King, the creators of Candy Crush Saga, uses Flink to provide data science teams a real-time analytics dashboard. <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about King's Flink implementation</a>
+      King，Candy Crush Saga的创建者，使用Flink为数据科学团队提供实时分析仪表板。 <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读King的Flink实现</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/lyft-logo.png" alt="King" /><br />
-      Lyft uses Flink as processing engine for its streaming platform, for example to consistently generate features for machine learning. <br><br><a href="https://www.slideshare.net/SeattleApacheFlinkMeetup/streaminglyft-greg-fee-seattle-apache-flink-meetup-104398613" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Streaming at Lyft</a>
+      Lyft使用Flink作为其流媒体平台的处理引擎，例如为机器学习持续生成特征。 <br><br><a href="https://www.slideshare.net/SeattleApacheFlinkMeetup/streaminglyft-greg-fee-seattle-apache-flink-meetup-104398613" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多关于Lyft的流媒体</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/mediamath-logo.png" alt="MediaMath" /><br />
-      MediaMath, a programmatic marketing company, uses Flink to power its real-time reporting infrastructure. <br><br><a href="https://www.youtube.com/watch?v=mSLesPzWplA&index=13&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See MediaMath at Flink Forward SF 2017</a>
+      MediaMath是一家程序化营销公司，它使用Flink为其实时报告基础架构提供支持。 <br><br><a href="https://www.youtube.com/watch?v=mSLesPzWplA&index=13&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward SF 2017的MediaMath</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/mux-logo.png" alt="Mux" /><br />
-      Mux, an analytics company for streaming video providers, uses Flink for real-time anomaly detection and alerting. <br><br><a href="https://mux.com/blog/discovering-anomalies-in-real-time-with-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about how Mux is using Flink</a>
+      Mux是一家流媒体视频提供商的分析公司，它使用Flink进行实时异常检测和报警。 <br><br><a href="https://mux.com/blog/discovering-anomalies-in-real-time-with-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 详细了解Mux如何使用Flink</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/otto-group-logo.png" alt="Otto Group" /><br />
-      Otto Group, the world's second-largest online retailer, uses Flink for business intelligence stream processing. <br><br><a href="http://2016.flink-forward.org/kb_sessions/flinkspector-taming-the-squirrel/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See Otto at Flink Forward 2016</a>
+      全球第二大在线零售商奥托集团(Otto Group)使用Flink进行商业智能流处理。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/flinkspector-taming-the-squirrel/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的Otto</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/researchgate-logo.png" alt="ResearchGate" /><br />
-      ResearchGate, a social network for scientists, uses Flink for network analysis and near-duplicate detection. <br><br><a href="http://2016.flink-forward.org/kb_sessions/joining-infinity-windowless-stream-processing-with-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> See ResearchGate at Flink Forward 2016</a>
+      ResearchGate是科学家的社交网络，它使用Flink进行网络分析和近似重复检测。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/joining-infinity-windowless-stream-processing-with-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的ResearchGate</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/telefonica-next-logo.png" alt="Telefonica Next" /><br />
-      Telefónica NEXT's TÜV-certified Data Anonymization Platform is powered by Flink. <br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Telefónica NEXT</a>
+      Telefónica NEXT的TÜV认证数据匿名平台由Flink提供支持。 <br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关于Telefónica NEXT的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/tencent-logo.png" alt="Tencent" /><br />
-      Tencent, one of the largest Internet companies, built an in-house platform with Apache Flink to improve the efficiency of developing and operating real-time applications. <br><br><a href="https://data.qq.com/article?id=3853" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Tencent's platform.</a>
+      作为最大的互联网公司之一，腾讯利用Apache Flink构建了一个内部平台，以提高开发和操作实时应用程序的效率。 <br><br><a href="https://data.qq.com/article?id=3853" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读有关腾讯平台的更多信息。</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/uber-logo.png" alt="Uber" /><br />
-      Uber built their internal SQL-based, open-source streaming analytics platform AthenaX on Apache Flink. <br><br><a href="https://eng.uber.com/athenax/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more on the Uber engineering blog</a>
+      Uber在Apache Flink上构建了基于sql的开源流媒体分析平台AthenaX。 <br><br><a href="https://eng.uber.com/athenax/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问Uber工程博客</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/yelp-logo.png" alt="Yelp" /><br />
-      Yelp utilizes Flink to power its data connectors ecosystem and stream processing infrastructure. <br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Find out more watching a Flink Forward talk</a>
+      Yelp利用Flink为其数据连接器生态系统和流处理基础架构提供支持。 <br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关注Flink Forward的演讲</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/zalando-logo.jpg" alt="Zalando" /><br />
-      Zalando, one of the largest e-commerce companies in Europe, uses Flink for real-time process monitoring and ETL. <br><br><a href="https://jobs.zalando.com/tech/blog/complex-event-generation-for-business-process-monitoring-using-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more on the Zalando Tech Blog</a>
+      Zalando是欧洲最大的电子商务公司之一，它使用Flink进行实时过程监控和ETL。 <br><br><a href="https://jobs.zalando.com/tech/blog/complex-event-generation-for-business-process-monitoring-using-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问Zalando技术博客</a>
   </div>
 </div>
+
 
 <script>
 $(document).ready(function() {

--- a/poweredby.zh.md
+++ b/poweredby.zh.md
@@ -8,98 +8,99 @@ title: "Flink 用户"
 
 <hr />
 
-Apache Flink支持全球许多公司和企业的关键业务应用程序。在这个页面上，我们展示了一些在生产环境中运行有趣用例的Flink用户，并链接到更详细地讨论其应用程序的资源。
+Apache Flink 为全球许多公司和企业的业务关键型应用程序提供支持。 在这个页面上，我们展示了一些著名的 Flink 用户，他们在生产中运行着有意思的用例，并提供了展示更详细信息的链接。
 
-更多Flink用户列在<a href="https://cwiki.apache.org/confluence/display/FLINK/Powered+by+Flink" target='_blank'> <small><span class ="glyphicon glyphicon-new-window"></span> </small>由维基项目中的Flink目录</a>提供支持。 请注意，列表*不全面。 我们只添加明确要求列出的用户。
+在项目的 wiki 页面中有一个 <a href="https://cwiki.apache.org/confluence/display/FLINK/Powered+by+Flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 谁在使用 Flink </a> 的页面，展示了更多的 Flink 用户。请注意，该列表*并不全面*。我们只添加明确要求列出的用户。
 
-如果您希望加入此页面，请访问[Flink用户邮件列表]({{site.baseurl}} / community.html #fmail-list)并告知我们。
+如果您希望加入此页面，请访问[Flink用户邮件列表]({{site.baseurl}}/zh/community.html#mailing-lists)并告知我们。
 
 <div class="row-fluid">
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/alibaba-logo.png" alt="Alibaba" /><br />
-      全球最大的零售商阿里巴巴(Alibaba)使用名为Blink的Flink分支实时优化搜索排名。 <br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多有关Flink在阿里巴巴扮演角色的信息</a>
+      全球最大的零售商阿里巴巴(Alibaba)使用名为 Blink 的 Flink 分支实时优化搜索排名。 <br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多有关 Flink 在阿里巴巴扮演角色的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/bettercloud-logo.png" alt="BetterCloud" /><br />
-     BetterCloud是一个多SaaS管理平台，它使用Flink从SaaS应用程序活动中获取近乎实时的智能。 <br><br><a href="https://www.youtube.com/watch?v=_yHds9SvMfE&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2&index=10" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward SF 2017的BetterCloud</a>
+     BetterCloud 是一个多 SaaS 管理平台，它使用 Flink 从 SaaS 应用程序活动中获取近乎实时的智能。 <br><br><a href="https://www.youtube.com/watch?v=_yHds9SvMfE&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2&index=10" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 BetterCloud 在 Flink Forward SF 2017 上的分享</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/bouygues-logo.jpg" alt="Bouygues" /><br />
-      Bouygues Telecom正在运行由Flink提供支持的30个生产应用程序，每天处理100亿个原始事件。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/a-brief-history-of-time-with-apache-flink-real-time-monitoring-and-analysis-with-flink-kafka-hb/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的Bouygues Telecom</a>
+      Bouygues Telecom 正在运行由 Flink 提供支持的30个生产应用程序，每天处理100亿个原始事件。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/a-brief-history-of-time-with-apache-flink-real-time-monitoring-and-analysis-with-flink-kafka-hb/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 Bouygues Telecom 在 Flink Forward 2016 上的分享</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/capital-one-logo.png" alt="Capital One" /><br />
-      财富500强金融服务公司Capital One使用Flink进行实时活动监控和报警。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-andrew-gao-jeff-sharpe-finding-bad-acorns" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Capital One的欺诈检测用例</a>
+      财富500强金融服务公司 Capital One 使用 Flink 进行实时活动监控和报警。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-andrew-gao-jeff-sharpe-finding-bad-acorns" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解 Capital One 的欺诈检测用例</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/comcast-logo.png" alt="Comcast" /><br />
-      康卡斯特(Comcast)是一家全球媒体和技术公司，它使用Flink来实现机器学习模型和近实时事件流处理。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-dave-torok-sameer-wadkar-embedding-flink-throughout-an-operationalized-streaming-ml-lifecycle" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解康卡斯特的Flink</a>
+      康卡斯特(Comcast)是一家全球媒体和技术公司，它使用 Flink 来实现机器学习模型和近实时事件流处理。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-dave-torok-sameer-wadkar-embedding-flink-throughout-an-operationalized-streaming-ml-lifecycle" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解 Flink 在康卡斯特的应用</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/criteo-logo.png" alt="Criteo" /><br />
-      Criteo是开放互联网的广告平台，使用Flink进行实时收入监控和近实时事件处理。 <br><br><a href="https://medium.com/criteo-labs/criteo-streaming-flink-31816c08da50" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Criteo的Flink用例</a>
+      Criteo 是开放互联网的广告平台，使用 Flink 进行实时收入监控和近实时事件处理。 <br><br><a href="https://medium.com/criteo-labs/criteo-streaming-flink-31816c08da50" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Criteo 的 Flink 用例</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/dtrb-logo.png" alt="Drivetribe" /><br />
-     Drivetribe是由前“Top Gear”主持人创建的数字社区，它使用Flink作为指标和内容推荐。 <br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读Drivetribe stack的Flink</a>
+     Drivetribe是由前“Top Gear”主持人创建的数字社区，它使用 Flink 作为指标和内容推荐。 <br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解 Flink 在 Drivetribe stack 的应用</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ebay-logo.png" alt="Ebay" /><br />
-      Ebay的监控平台由Flink提供支持，可评估数千条关于指标和日志流的可自定义报警规则。 <br><br><a href="https://vimeo.com/265025956/c7d5576622" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 在Ebay上了解更多关于Flink的信息</a>
+      Ebay 的监控平台由 Flink 提供支持，可在指标和日志流上计算上千条自定义报警规则。 <br><br><a href="https://vimeo.com/265025956/c7d5576622" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多 Flink 在 Ebay 的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ericsson-logo.png" alt="Ericsson" /><br />
-      爱立信使用Flink构建了一个实时异常检测器，通过大型基础设施进行机器学习。 <br><br><a href="https://www.oreilly.com/ideas/applying-the-kappa-architecture-in-the-telco-industry" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读关于O'Reilly想法的详细概述</a>
+      爱立信使用 Flink 构建了一个实时异常检测器，通过大型基础设施进行机器学习。 <br><br><a href="https://www.oreilly.com/ideas/applying-the-kappa-architecture-in-the-telco-industry" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读关于O'Reilly想法的详细概述</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/huawei-logo.png" alt="Huawei" /><br />
-      华为是全球领先的ICT基础设施和智能设备供应商。 华为云提供基于Flink的云服务。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-jinkui-shi-and-radu-tudoran-flink-realtime-analysis-in-cloudstream-service-of-huawei-cloud" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Flink如何为云服务提供动力</a>
+      华为是全球领先的 ICT 基础设施和智能设备供应商。 华为云提供基于 Flink 的云服务。 <br><br><a href="https://www.slideshare.net/FlinkForward/flink-forward-san-francisco-2018-jinkui-shi-and-radu-tudoran-flink-realtime-analysis-in-cloudstream-service-of-huawei-cloud" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解Flink 如何为云服务提供动力</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/king-logo.png" alt="King" /><br />
-      King，Candy Crush Saga的创建者，使用Flink为数据科学团队提供实时分析仪表板。 <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读King的Flink实现</a>
+      King，Candy Crush Saga的创建者，使用 Flink 为数据科学团队提供实时分析仪表板。 <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读 King 的 Flink 实现</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/lyft-logo.png" alt="King" /><br />
-      Lyft使用Flink作为其流媒体平台的处理引擎，例如为机器学习持续生成特征。 <br><br><a href="https://www.slideshare.net/SeattleApacheFlinkMeetup/streaminglyft-greg-fee-seattle-apache-flink-meetup-104398613" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多关于Lyft的流媒体</a>
+      Lyft 使用 Flink 作为其流媒体平台的处理引擎，例如为机器学习持续生成特征。 <br><br><a href="https://www.slideshare.net/SeattleApacheFlinkMeetup/streaminglyft-greg-fee-seattle-apache-flink-meetup-104398613" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多关于 Lyft 的流媒体</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/mediamath-logo.png" alt="MediaMath" /><br />
-      MediaMath是一家程序化营销公司，它使用Flink为其实时报告基础架构提供支持。 <br><br><a href="https://www.youtube.com/watch?v=mSLesPzWplA&index=13&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward SF 2017的MediaMath</a>
+      MediaMath 是一家程序化营销公司，它使用 Flink 为其实时报告基础架构提供支持。 <br><br><a href="https://www.youtube.com/watch?v=mSLesPzWplA&index=13&list=PLDX4T_cnKjD2UC6wJr_wRbIvtlMtkc-n2" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 MediaMath 在 Flink Forward SF 2017 上的分享</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/mux-logo.png" alt="Mux" /><br />
-      Mux是一家流媒体视频提供商的分析公司，它使用Flink进行实时异常检测和报警。 <br><br><a href="https://mux.com/blog/discovering-anomalies-in-real-time-with-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 详细了解Mux如何使用Flink</a>
+      Mux 是一家流媒体视频提供商的分析公司，它使用 Flink 进行实时异常检测和报警。 <br><br><a href="https://mux.com/blog/discovering-anomalies-in-real-time-with-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 详细了解 Mux 如何使用 Flink </a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/otto-group-logo.png" alt="Otto Group" /><br />
-      全球第二大在线零售商奥托集团(Otto Group)使用Flink进行商业智能流处理。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/flinkspector-taming-the-squirrel/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的Otto</a>
+      全球第二大在线零售商奥托集团(Otto Group)使用 Flink 进行商业智能流处理。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/flinkspector-taming-the-squirrel/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 Otto 在 Flink Forward 2016 上的分享</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/researchgate-logo.png" alt="ResearchGate" /><br />
-      ResearchGate是科学家的社交网络，它使用Flink进行网络分析和近似重复检测。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/joining-infinity-windowless-stream-processing-with-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅Flink Forward 2016的ResearchGate</a>
+      ResearchGate 是科学家的社交网络，它使用 Flink 进行网络分析和近似重复检测。 <br><br><a href="http://2016.flink-forward.org/kb_sessions/joining-infinity-windowless-stream-processing-with-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 ResearchGate 在 Flink Forward 2016 上的分享</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/telefonica-next-logo.png" alt="Telefonica Next" /><br />
-      Telefónica NEXT的TÜV认证数据匿名平台由Flink提供支持。 <br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关于Telefónica NEXT的信息</a>
+      Telefónica NEXT 的 TÜV 认证数据匿名平台由 Flink 提供支持。 <br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关于 Telefónica NEXT 的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/tencent-logo.png" alt="Tencent" /><br />
-      作为最大的互联网公司之一，腾讯利用Apache Flink构建了一个内部平台，以提高开发和操作实时应用程序的效率。 <br><br><a href="https://data.qq.com/article?id=3853" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读有关腾讯平台的更多信息。</a>
+      作为最大的互联网公司之一，腾讯利用 Apache Flink 构建了一个内部平台，以提高开发和操作实时应用程序的效率。 <br><br><a href="https://data.qq.com/article?id=3853" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读有关腾讯平台的更多信息。</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/uber-logo.png" alt="Uber" /><br />
-      Uber在Apache Flink上构建了基于sql的开源流媒体分析平台AthenaX。 <br><br><a href="https://eng.uber.com/athenax/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问Uber工程博客</a>
+      Uber在Apache Flink 上构建了基于 SQL 的开源流媒体分析平台 AthenaX。 <br><br><a href="https://eng.uber.com/athenax/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问Uber工程博客</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/yelp-logo.png" alt="Yelp" /><br />
-      Yelp利用Flink为其数据连接器生态系统和流处理基础架构提供支持。 <br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关注Flink Forward的演讲</a>
+      Yelp 利用 Flink 为其数据连接器生态系统和流处理基础架构提供支持。 <br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 Flink Forward 上的演讲</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/zalando-logo.jpg" alt="Zalando" /><br />
-      Zalando是欧洲最大的电子商务公司之一，它使用Flink进行实时过程监控和ETL。 <br><br><a href="https://jobs.zalando.com/tech/blog/complex-event-generation-for-business-process-monitoring-using-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问Zalando技术博客</a>
+      Zalando 是欧洲最大的电子商务公司之一，它使用 Flink 进行实时过程监控和 ETL。 <br><br><a href="https://jobs.zalando.com/tech/blog/complex-event-generation-for-business-process-monitoring-using-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 更多信息请访问 Zalando 技术博客</a>
   </div>
 </div>
+
 
 
 <script>

--- a/poweredby.zh.md
+++ b/poweredby.zh.md
@@ -8,7 +8,7 @@ title: "Flink 用户"
 
 <hr />
 
-Apache Flink 为全球许多公司和企业的业务关键型应用程序提供支持。 在这个页面上，我们展示了一些著名的 Flink 用户，他们在生产中运行着有意思的用例，并提供了展示更详细信息的链接。
+为全球许多公司和企业的关键业务应用程序提供支持。 在这个页面上，我们展示了一些著名的 Flink 用户，他们在生产中运行着有意思的用例，并提供了展示更详细信息的链接。
 
 在项目的 wiki 页面中有一个 <a href="https://cwiki.apache.org/confluence/display/FLINK/Powered+by+Flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 谁在使用 Flink </a> 的页面，展示了更多的 Flink 用户。请注意，该列表*并不全面*。我们只添加明确要求列出的用户。
 


### PR DESCRIPTION
Translate "Powered by Flink" page into Chinese.

The markdown file is located in: flink-web/poweredby.zh.md
The url link is: https://flink.apache.org/zh/poweredby.html

Please adjust the links in the page to Chinese pages when translating.