### PR TITLE
Add 1.8 Release Blog Post

### DIFF
--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Apache Flink 1.8.0 Release Announcement"
-date:   2019-4-10 12:00:00
+date:   2019-4-8 12:00:00
 categories: news
 authors:
 - till:
@@ -247,6 +247,7 @@ your Flink setup to Flink 1.8.
 
 We would like to acknowledge all community members for contributing to this
 release.  Special credits go to the following members for contributing to the
-1.8.0 release (according to git):
+1.8.0 release (according to `git log --pretty="%an" release-1.7.0..release-1.8.0 | sort | uniq` without manual deduplication):
 
-Addison Higham, Aitozi, Aleksey Pak, Alexander Fedulov, Alexey Trenikhin, Aljoscha Krettek, Andrey Zagrebin, Artsem Semianenka, Asura7969, Avi, Barisa Obradovic, Benchao Li, Bo WANG, Chesnay Schepler, Congxian Qiu, Cristian, David Anderson, Dawid Wysakowicz, Dian Fu, DuBin, EAlexRojas, EronWright, Eugen Yushin, Fabian Hueske, Fokko Driesprong, Gary Yao, Hequn Cheng, Igal Shilman, Jamie Grier, JaryZhen, Jeff Zhang, Jihyun Cho, Jinhu Wu, Joerg Schad, KarmaGYZ, Kezhu Wang, Konstantin Knauf, Kostas Kloudas, Lavkesh Lahngir, Li, Shuangjiang, Mai Nakagawa, Matrix42, Matt, Maximilian Michels, Mododo, Nico Kruber, Paul Lin, Piotr Nowojski, Qi Yu, Qin, Robert, Robert Metzger, Rong Rong, Rune Skou Larsen, Seth Wiesman, Shannon Carey, Shimin Yang, Shuyi Chen, Stefan Richter, Stephan Ewen, SuXingLee, TANG Wen-hui, Tao Yang, Thomas Weise, Till Rohrmann, Timo Walther, Tony Feng, Tony Wei, Tzu-Li (Gordon) Tai, Tzu-Li Chen, Ufuk Celebi, Xingcan Cui, Xpray, XuQianJin-Stars, Xue Yu, Yangze Guo, Ying Xu, Yiqun Lin, Yu Li, Yuanyang Wu, Yun Tang, ZILI CHEN, Zhanchun Zhang, Zhijiang, ZiLi Chen, acqua.csq, alex04.wang, ap, azagrebin, blueszheng, boshu Zheng, chengjie.wu, chensq, eaglewatcherwb, hequn8128, ifndef-SleePy, intsmaze, jinhu.wjh, jparkie, jrthe42, junsheng.wu, kgorman, kkolman, klion26, lamber-ken, leesf, libenchao, lining, liuzhaokun, lzh3636, maqingxiang, mb-datadome, okidogi, park.yq, sunhaibotb, sunjincheng121, tison, wenhuitang, wind, xueyu, xuqianjin, yanghua, zhangzhanchun, zhijiang, zhuzhu.zz, zy, 仲炜, 砚田, 谢磊
+Addison Higham, Aitozi, Aleksey Pak, Alexander Fedulov, Alexey Trenikhin, Aljoscha Krettek, Andrey Zagrebin, Artsem Semianenka, Asura7969, Avi, Barisa Obradovic, Benchao Li, Bo WANG, Chesnay Schepler, Congxian Qiu, Cristian, David Anderson, Dawid Wysakowicz, Dian Fu, DuBin, EAlexRojas, EronWright, Eugen Yushin, Fabian Hueske, Fokko Driesprong, Gary Yao, Hequn Cheng, Igal Shilman, Jamie Grier, JaryZhen, Jeff Zhang, Jihyun Cho, Jinhu Wu, Joerg Schad, KarmaGYZ, Kezhu Wang, Konstantin Knauf, Kostas Kloudas, Lakshmi, Lakshmi Gururaja Rao, Lavkesh Lahngir, Li, Shuangjiang, Mai Nakagawa, Matrix42, Matt, Maximilian Michels, Mododo, Nico Kruber, Paul Lin, Piotr Nowojski, Qi Yu, Qin, Robert, Robert Metzger, Romano Vacca, Rong Rong, Rune Skou Larsen, Seth Wiesman, Shannon Carey, Shimin Yang, Shuyi Chen, Stefan Richter, Stephan Ewen, SuXingLee, TANG Wen-hui, Tao Yang, Thomas Weise, Till Rohrmann, Timo Walther, Tom Goong, Tony Feng, Tony Wei, Tzu-Li (Gordon) Tai, Tzu-Li Chen, Ufuk Celebi, Xingcan Cui, Xpray, XuQianJin-Stars, Xue Yu, Yangze Guo, Ying Xu, Yiqun Lin, Yu Li, Yuanyang Wu, Yun Tang, ZILI CHEN, Zhanchun Zhang, Zhijiang, ZiLi Chen, acqua.csq, alex04.wang, ap, azagrebin, blueszheng, boshu Zheng, chengjie.wu, chensq, chummyhe89, eaglewatcherwb, hequn8128, ifndef-SleePy, intsmaze, jackyyin, jinhu.wjh, jparkie, jrthe42, junsheng.wu, kgorman, kkloudas, kkolman, klion26, lamber-ken, leesf, libenchao, lining, liuzhaokun, lzh3636, maqingxiang, mb-datadome, okidogi, park.yq, sunhaibotb, sunjincheng121, tison, unknown, vinoyang, wenhuitang, wind, xueyu, xuqianjin, yanghua, zentol, zhangzhanchun, zhijiang, zhuzhu.zz, zy, 仲炜, 砚田, 谢磊
+

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -49,49 +49,66 @@ for more details.
 
 ## New Features and Improvements
 
-* **Schema evolution support for more data types when restoring savepoints**:
-  Back in Flink 1.7.0, we added support for changing the schema of state when
-  using Avro data types, such as `GenericRecord` or code generated
-  `SpecificRecord`s.
+* **Finalized State Schema Evolution Story**: This release completes
+  the community driven effort to provide a schema evaluation story for
+  user state managed by Flink. This has been an effort that spanned 2
+  releases, starting from 1.7.0 with the introduction for support for
+  Avro state schema evolution as well as a revamped serialization
+  compatibility abstraction.
 
-  The pool of data types that support state schema evolution have been expanded
-  to include POJOs and Java Enums. For state types that use POJOs, you can now
-  add or remove fields from your POJO while remaining backwards compatibility.
-  For state types that use Java Enums, Enum fields can also be added or
-  removed, as well as changing types of the Enum fields.
+  Flink 1.8.0 finalizes this effort by extending support for schema
+  evolution to POJOs, upgrade all Flink built-in serializers to use
+  the new serialization compatibility abstractions, as well as make it
+  easier for advanced users who use custom state serializers to
+  implement the abstractions.  These different aspects for a complete
+  out-of-the-box schema evolution story are explained in detail below:
 
-  Moreover, this applies also when you're using these data types within another
-  composite type, such as tuples, `Either`, Scala case classes, etc. For
-  example, the `MyPojo` type in `ValueState<Tuple2<Integer, MyPojo>>` or
-  `ListState<Either<Integer, MyPojo>>`, which is a POJO, is allowed to evolve
-  its schema.
+  1. Support for POJO state schema evolution: The pool of data types
+     that support state schema evolution have been expanded to include
+     POJOs. For state types that use POJOs, you can now add or remove
+     fields from your POJO while retaining backwards compatibility. For a
+     full overview of the list of data types that now support schema
+     evolution as well as their evolution specifications and limitations,
+     please refer to the State Schema Evolution documentation page.
 
-  For a full overview of the list of data types that now support schema
-  evolution as well as their evolution specifications and limitations, please
-  refer to the [State Schema
-  Evolution](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/stream/state/schema_evolution.html)
-  documentation page.
 
-* **Java-serialization-free savepoints**: Previously, when writing the metadata
-  for state in savepoints, the state serializers were also Java-serialized as
-  part of the metadata. This caused several problems, especially for state
-  schema evolution.
+  2. Upgrade all Flink serializers to use new serialization
+     compatibility asbtractions: Back in 1.7.0, we introduced the new
+     serialization compatibility abstractions `TypeSerializerSnapshot` and
+     `TypeSerializerSchemaCompatibility`. Besides providing a more
+     expressible API to reflect schema compatibility between the data
+     stored in savepoints and the data registered at runtime, another
+     important aspect about the new abstraction is that it avoids the need
+     for Flink to Java-serialize the state serializer as state metadata in
+     savepoints.
 
-  Back in Flink 1.7.0, we introduced new serialization compatibility
-  abstractions for the `TypeSerializer` interface to remove this behaviour. In
-  Flink 1.8.0, all of Flink's built-in `TypeSerializer`s have been upgraded to
-  use the new serialization compatibility abstractions, and therefore will no
-  longer be Java-serialized into savepoints.
+     In 1.8.0, all Flink's built-in serializers have been upgraded to use
+     the new abstractions, and therefore the serializers themselves are
+     no longer Java-serialized into savepoints. This greatly improves
+     interoperability of Flink savepoints, in terms of state schema
+     evolvability. For example, one outcome was the support for POJO
+     schema evolution, as previously mentioned above. Another outcome is
+     that all composite data types supported by Flink (such as `Either`,
+     Scala case classes, Flink Java `Tuple`s, etc.) are generally
+     evolve-able as well when they have a nested evolvable type such as
+     POJO. For example, the `MyPojo` type in `ValueState<Tuple2<Integer,
+     MyPojo>>` or `ListState<Either<Integer, MyPojo>>`, which is a POJO,
+     is allowed to evolve its schema.
 
-  This greatly improves Flink's savepoint interoperability and schema
-  evolvability. For users that are using custom implemented `TypeSerializer`s
-  for state serialization, this also means that they are no longer tied to the
-  serializer's implementation, as long as they have also upgraded their
-  `TypeSerializer` to the new serialization compatibility abstractions. For
-  instructions on how to do that, please refer to the [Custom State
-  Serialization](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/stream/state/custom_serialization.html)
-  documentation page, as well as the class-level Javadocs of the
-  `TypeSerializer` class.
+     For users who are using custom `TypeSerializer` implementations for
+     their state serializer and are still using the outdated abstractions
+     (i.e. `TypeSerializerConfigSnapshot` and `CompatiblityResult`), we
+     highly recommend to upgrade to the new abstractions to be future
+     proof. Please refer to the Custom State Serialization documentation
+     page for a detailed description on the new abstractions.
+
+  3. Provide pre-defined snapshot implementations for common
+     serializers: For convenience, Flink 1.8.0 comes with two predefined
+     implementations for the `TypeSerializerSnapshot` that would make the
+     task of implementing these new abstractions easier for most
+     implementations of `TypeSerializer`s - `SimpleTypeSerializerSnapshot`
+     and `CompositeTypeSerializerSnapshot`. This section in the
+     documentation provide information on how to use these classes.
 
 * **Continuous cleanup of old state based on TTL
   ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -66,48 +66,52 @@ for more details.
   1. Support for POJO state schema evolution: The pool of data types
      that support state schema evolution have been expanded to include
      POJOs. For state types that use POJOs, you can now add or remove
-     fields from your POJO while retaining backwards compatibility. For a
-     full overview of the list of data types that now support schema
-     evolution as well as their evolution specifications and limitations,
-     please refer to the State Schema Evolution documentation page.
+     fields from your POJO while retaining backwards
+     compatibility. For a full overview of the list of data types that
+     now support schema evolution as well as their evolution
+     specifications and limitations, please refer to the State Schema
+     Evolution documentation page.
 
 
   2. Upgrade all Flink serializers to use new serialization
      compatibility asbtractions: Back in 1.7.0, we introduced the new
-     serialization compatibility abstractions `TypeSerializerSnapshot` and
-     `TypeSerializerSchemaCompatibility`. Besides providing a more
+     serialization compatibility abstractions `TypeSerializerSnapshot`
+     and `TypeSerializerSchemaCompatibility`. Besides providing a more
      expressible API to reflect schema compatibility between the data
      stored in savepoints and the data registered at runtime, another
-     important aspect about the new abstraction is that it avoids the need
-     for Flink to Java-serialize the state serializer as state metadata in
-     savepoints.
+     important aspect about the new abstraction is that it avoids the
+     need for Flink to Java-serialize the state serializer as state
+     metadata in savepoints.
 
-     In 1.8.0, all Flink's built-in serializers have been upgraded to use
-     the new abstractions, and therefore the serializers themselves are
-     no longer Java-serialized into savepoints. This greatly improves
-     interoperability of Flink savepoints, in terms of state schema
-     evolvability. For example, one outcome was the support for POJO
-     schema evolution, as previously mentioned above. Another outcome is
-     that all composite data types supported by Flink (such as `Either`,
-     Scala case classes, Flink Java `Tuple`s, etc.) are generally
-     evolve-able as well when they have a nested evolvable type such as
-     POJO. For example, the `MyPojo` type in `ValueState<Tuple2<Integer,
-     MyPojo>>` or `ListState<Either<Integer, MyPojo>>`, which is a POJO,
-     is allowed to evolve its schema.
+     In 1.8.0, all Flink's built-in serializers have been upgraded to
+     use the new abstractions, and therefore the serializers
+     themselves are no longer Java-serialized into savepoints. This
+     greatly improves interoperability of Flink savepoints, in terms
+     of state schema evolvability. For example, one outcome was the
+     support for POJO schema evolution, as previously mentioned
+     above. Another outcome is that all composite data types supported
+     by Flink (such as `Either`, Scala case classes, Flink Java
+     `Tuple`s, etc.) are generally evolve-able as well when they have
+     a nested evolvable type such as POJO. For example, the `MyPojo`
+     type in `ValueState<Tuple2<Integer, MyPojo>>` or
+     `ListState<Either<Integer, MyPojo>>`, which is a POJO, is allowed
+     to evolve its schema.
 
-     For users who are using custom `TypeSerializer` implementations for
-     their state serializer and are still using the outdated abstractions
-     (i.e. `TypeSerializerConfigSnapshot` and `CompatiblityResult`), we
-     highly recommend to upgrade to the new abstractions to be future
-     proof. Please refer to the Custom State Serialization documentation
-     page for a detailed description on the new abstractions.
+     For users who are using custom `TypeSerializer` implementations
+     for their state serializer and are still using the outdated
+     abstractions (i.e. `TypeSerializerConfigSnapshot` and
+     `CompatiblityResult`), we highly recommend to upgrade to the new
+     abstractions to be future proof. Please refer to the Custom State
+     Serialization documentation page for a detailed description on
+     the new abstractions.
 
   3. Provide pre-defined snapshot implementations for common
-     serializers: For convenience, Flink 1.8.0 comes with two predefined
-     implementations for the `TypeSerializerSnapshot` that would make the
-     task of implementing these new abstractions easier for most
-     implementations of `TypeSerializer`s - `SimpleTypeSerializerSnapshot`
-     and `CompositeTypeSerializerSnapshot`. This section in the
+     serializers: For convenience, Flink 1.8.0 comes with two
+     predefined implementations for the `TypeSerializerSnapshot` that
+     would make the task of implementing these new abstractions easier
+     for most implementations of `TypeSerializer`s -
+     `SimpleTypeSerializerSnapshot` and
+     `CompositeTypeSerializerSnapshot`. This section in the
      documentation provide information on how to use these classes.
 
 * **Continuous cleanup of old state based on TTL

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -33,15 +33,15 @@ With Flink 1.8.0 we come closer to our goals of enabling fast data processing
 and building data-intensive applications for the Flink community in a seamless
 way. We do this by cleaning up and refactoring Flink under the hood to allow
 more efficient feature development in the future. This includes removal of the
-legacy runtime components that were subsumed in the major rework of Flinks
-underlying distributed system
+legacy runtime components that were subsumed in the major rework of Flink's
+underlying distributed system architecture
 ([FLIP-6](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65147077))
 as well as refactorings on the Table API that prepare it for the future
 addition of the Blink enhancements
 ([FLINK-11439](https://issues.apache.org/jira/browse/FLINK-11439)).
 
 Nevertheless, this release includes some important new features and bug fixes.
-The most interesting of those we'll highlight below. Please consult the
+The most interesting of those are highlighted below. Please consult the
 [complete changelog](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=12344274)
 and the [release notes](https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html)
 for more details.
@@ -72,7 +72,7 @@ for more details.
   Evolution](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/state/schema_evolution.html)
   documentation page.
 
-* **Java-serialization free savepoints**: Previously, when writing the metadata
+* **Java-serialization-free savepoints**: Previously, when writing the metadata
   for state in savepoints, the state serializers were also Java-serialized as
   part of the metadata. This caused several problems, especially for state
   schema evolution.
@@ -109,12 +109,13 @@ for more details.
   that old entries (according to the TTL setting) are continously being cleanup
   up.
 
-* **SQL pattern detection with user-defined functions and aggregations**: The
-  support of the MATCH_RECOGNIZE clause has been extended by multiple features.
-  User-defined function are now possible which allows for custom logic during
-  pattern detection
+* **SQL pattern detection with user-defined functions and
+  aggregations**: The support of the MATCH_RECOGNIZE clause has been
+  extended by multiple features.  The addition of user-defined
+  function allows for allows for custom logic during pattern detection
   ([FLINK-10597](https://issues.apache.org/jira/browse/FLINK-10597)).
-  Aggregations allow for more complex CEP definitions
+  while adding aggregations allows for more complex CEP definitions,
+  such as the following
   ([FLINK-7599](https://issues.apache.org/jira/browse/FLINK-7599)).
 
   ```
@@ -148,16 +149,17 @@ for more details.
 
 * **Changes to bundling of Hadoop libraries with Flink
   ([FLINK-11266](https://issues.apache.org/jira/browse/FLINK-11266))**:
-  Convenience binaries that include Hadoop are no longer released.
+  Convenience binaries that include hadoop are no longer released.
 
   If a deployment relies on `flink-shaded-hadoop2` being included in
-  `flink-dist`, then it must be manually downloaded and copied into the /lib
-  directory.  Alternatively, a Flink distribution that includes Hadoop can be
-  built by packaging `flink-dist` and activating the `include-hadoop` maven
-  profile. See [building Flink from source](https://ci.apache.org/projects/flink/flink-docs-master/flinkDev/building.html)
-  for more details about this.
+  `flink-dist`, then you must manually download a pre-packaged Hadoop
+  jar from the optional components section of the [download
+  page](https://flink.apache.org/downloads.html) and copy it into the
+  `/lib` directory.  Alternatively, a Flink distribution that includes
+  hadoop can be built by packaging `flink-dist` and activating the
+  `include-hadoop` maven profile.
 
-  As Hadoop is no longer included in `flink-dist` by default, specifying
+  As hadoop is no longer included in `flink-dist` by default, specifying
   `-DwithoutHadoop` when packaging `flink-dist` no longer impacts the build.
 
 * **FlinkKafkaConsumer will now filter restored partitions based on topic

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -171,6 +171,16 @@ for more details.
   `disableFilterRestoredPartitionsWithSubscribedTopics()` configuration method
   on the `FlinkKafkaConsumer`.
 
+  Consider this example: if you had a Kafka Consumer that was
+  consuming from topic `A`, you did a savepoint, then changed your
+  Kafka consumer to instead consume from topic `B`, and then restarted
+  your job from the savepoint. Before this change, your consumer would
+  now consume from both topic `A` and `B` because it was stored in
+  state that the consumer was consuming from topic `A`. With the
+  change, your consumer would only consume from topic `B` after
+  restore because we filter the topics that are stored in state using
+  the configured topics.
+
 ## Release Notes
 
 Please review the [release

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -50,7 +50,7 @@ for more details.
 ## New Features and Improvements
 
 * **Finalized State Schema Evolution Story**: This release completes
-  the community driven effort to provide a schema evaluation story for
+  the community driven effort to provide a schema evolution story for
   user state managed by Flink. This has been an effort that spanned 2
   releases, starting from 1.7.0 with the introduction for support for
   Avro state schema evolution as well as a revamped serialization

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -148,15 +148,16 @@ for more details.
 
 * **Changes to bundling of Hadoop libraries with Flink
   ([FLINK-11266](https://issues.apache.org/jira/browse/FLINK-11266))**:
-  Convenience binaries that include hadoop are no longer released.
+  Convenience binaries that include Hadoop are no longer released.
 
   If a deployment relies on `flink-shaded-hadoop2` being included in
   `flink-dist`, then it must be manually downloaded and copied into the /lib
-  directory.  Alternatively, a Flink distribution that includes hadoop can be
+  directory.  Alternatively, a Flink distribution that includes Hadoop can be
   built by packaging `flink-dist` and activating the `include-hadoop` maven
-  profile.
+  profile. See [building Flink from source](https://ci.apache.org/projects/flink/flink-docs-master/flinkDev/building.html)
+  for more details about this.
 
-  As hadoop is no longer included in `flink-dist` by default, specifying
+  As Hadoop is no longer included in `flink-dist` by default, specifying
   `-DwithoutHadoop` when packaging `flink-dist` no longer impacts the build.
 
 * **FlinkKafkaConsumer will now filter restored partitions based on topic

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -1,0 +1,131 @@
+---
+layout: post
+title:  "Apache Flink 1.8.0 Release Announcement"
+date:   2019-2-26 12:00:00
+categories: news
+authors:
+- till:
+  name: "Aljoscha Krettek"
+  twitter: "aljoscha"
+---
+
+The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 370 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the [complete changelog](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=12344274)
+for more details.
+
+Flink 1.8.0 is API-compatible with previous 1.x.y releases for APIs annotated
+with the `@Public` annotation.  The release is available now and we encourage
+everyone to [download the release](http://flink.apache.org/downloads.html) and
+check out the updated
+[documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.8/).
+Feedback through the Flink [mailing
+lists](http://flink.apache.org/community.html#mailing-lists) or
+[JIRA](https://issues.apache.org/jira/projects/FLINK/summary) is, as always,
+very much appreciated!
+
+You can find the binaries on the updated [Downloads page](http://flink.apache.org/downloads.html) on the Flink project site.
+
+{% toc %}
+
+With Flink 1.8.0 we come closer to our goals of enabling fast data processing
+and building data-intensive applications for the Flink community in a seamless
+way. We do this by cleaning up and refactoring Flink under the hood to allow
+more efficient feature development in the future. This includes removal of the
+legacy runtime components that were subsumed in the major rework of Flinks
+underlying distributed system
+([FLIP-6](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65147077))
+as well as refactorings on the Table API that prepare it for the future
+addition of the Blink enhancements
+([FLINK-11439](https://issues.apache.org/jira/browse/FLINK-11439)).
+
+Nevertheless, this release includes some important new features and bug fixes.
+The most interesting of those we'll highlight below. Please consult the
+[complete changelog](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=12344274)
+or the [release notes](https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html)
+for more details.
+
+
+## New Features and Improvements
+
+* **New Support for Schema Migration when restoring Savepoints**: With Flink
+  1.7.0 we added support for changing the schema of state when using the
+  `AvroSerializer`
+  ([FLINK-10605](https://issues.apache.org/jira/browse/FLINK-10605)). With
+  Flink 1.8.0 we made great progress migrating all built-in `TypeSerializers`
+  to a new serializer snapshot abstraction that theoretically allows schema
+  migration. Of the serializers that come with Flink, we now support schema
+  migration for the `PojoSerializer`
+  ([FLINK-11485](https://issues.apache.org/jira/browse/FLINK-11485)) and Java
+  `EnumSerializer`
+  ([FLINK-11334](https://issues.apache.org/jira/browse/FLINK-11334)), as well
+  as for Kryo in limited cases
+  ([FLINK-11323](https://issues.apache.org/jira/browse/FLINK-11323)).
+
+
+* **Continuous cleanup of old state based on TTL
+  ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We
+  introduced TTL (time-to-live) for Keyed state in Flink 1.6
+  ([FLINK-9510](https://issues.apache.org/jira/browse/FLINK-9510)).  This
+  feature allowed to clean up and make inaccessible keyed state entries when
+  accessing them. In addition state would now also being cleaned up when
+  writing a savepoint/checkpoint.
+
+  Flink 1.8 introduces continous cleanup of old entries for both the RocksDB
+  state backend
+  ([FLINK-10471](https://issues.apache.org/jira/browse/FLINK-10471)) and the heap
+  state backend
+  ([FLINK-10473](https://issues.apache.org/jira/browse/FLINK-10473)). This means
+  that old entries (according to the ttl setting) are continously being cleanup
+  up.
+
+* **New KafkaDeserializationSchema that give direct access to ConsumerRecord
+  ([FLINK-8354](https://issues.apache.org/jira/browse/FLINK-8354))**: For the
+  Flink `KafkaConsumers`, we introduced a new `KafkaDeserializationSchema` that
+  gives direct access to the Kafka `ConsumerRecord`. This now allows access to
+  all data that Kafka provides for a record. This
+  subsumes`KeyedSerializationSchema` functionality, which is deprecated but
+  still available for now.
+
+## Important Changes
+
+* **Changes to bundling of Hadoop libraries with Flink
+  ([FLINK-11266](https://issues.apache.org/jira/browse/FLINK-11266))**:
+  Convenience binaries that include hadoop are no longer released.
+
+  If a deployment relies on `flink-shaded-hadoop2` being included in
+  `flink-dist`, then it must be manually downloaded and copied into the /lib
+  directory.  Alternatively, a Flink distribution that includes hadoop can be
+  built by packaging `flink-dist` and activating the `include-hadoop` maven
+  profile.
+
+  As hadoop is no longer included in `flink-dist` by default, specifying
+  `-DwithoutHadoop` when packaging `flink-dist` no longer impacts the build.
+
+* **FlinkKafkaConsumer will now filter restored partitions based on topic
+  specification
+  ([FLINK-10342](https://issues.apache.org/jira/browse/FLINK-10342))**:
+  Starting from Flink 1.8.0, the `FlinkKafkaConsumer` now always filters out
+  restored partitions that are no longer associated with a specified topic to
+  subscribe to in the restored execution. This behaviour did not exist in
+  previous versions of the `FlinkKafkaConsumer`. If you wish to retain the
+  previous behaviour, please use the
+  `disableFilterRestoredPartitionsWithSubscribedTopics()` configuration method
+  on the `FlinkKafkaConsumer`.
+
+## Release Notes
+
+Please review the [release
+notes](https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html)
+for a more detailed list of changes and new features if you plan to upgrade
+your Flink setup to Flink 1.8.
+
+## List of Contributors
+
+We would like to acknowledge all community members for contributing to this
+release.  Special credits go to the following members for contributing to the
+1.8.0 release (according to git):
+
+Addison Higham, Aitozi, Aleksey Pak, Alexander Fedulov, Alexey Trenikhin, Aljoscha Krettek, Andrey Zagrebin, Artsem Semianenka, Asura7969, Avi, Barisa Obradovic, Benchao Li, Bo WANG, Chesnay Schepler, Congxian Qiu, Cristian, David Anderson, Dawid Wysakowicz, Dian Fu, DuBin, EAlexRojas, EronWright, Eugen Yushin, Fabian Hueske, Fokko Driesprong, Gary Yao, Hequn Cheng, Igal Shilman, Jamie Grier, JaryZhen, Jeff Zhang, Jihyun Cho, Jinhu Wu, Joerg Schad, KarmaGYZ, Kezhu Wang, Konstantin Knauf, Kostas Kloudas, Lavkesh Lahngir, Li, Shuangjiang, Mai Nakagawa, Matrix42, Matt, Maximilian Michels, Mododo, Nico Kruber, Paul Lin, Piotr Nowojski, Qi Yu, Qin, Robert, Robert Metzger, Rong Rong, Rune Skou Larsen, Seth Wiesman, Shannon Carey, Shimin Yang, Shuyi Chen, Stefan Richter, Stephan Ewen, SuXingLee, TANG Wen-hui, Tao Yang, Thomas Weise, Till Rohrmann, Timo Walther, Tony Feng, Tony Wei, Tzu-Li (Gordon) Tai, Tzu-Li Chen, Ufuk Celebi, Xingcan Cui, Xpray, XuQianJin-Stars, Xue Yu, Yangze Guo, Ying Xu, Yiqun Lin, Yu Li, Yuanyang Wu, Yun Tang, ZILI CHEN, Zhanchun Zhang, Zhijiang, ZiLi Chen, acqua.csq, alex04.wang, ap, azagrebin, blueszheng, boshu Zheng, chengjie.wu, chensq, eaglewatcherwb, hequn8128, ifndef-SleePy, intsmaze, jinhu.wjh, jparkie, jrthe42, junsheng.wu, kgorman, kkolman, klion26, lamber-ken, leesf, libenchao, lining, liuzhaokun, lzh3636, maqingxiang, mb-datadome, okidogi, park.yq, sunhaibotb, sunjincheng121, tison, wenhuitang, wind, xueyu, xuqianjin, yanghua, zhangzhanchun, zhijiang, zhuzhu.zz, zy, 仲炜, 砚田, 谢磊
+

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -57,14 +57,14 @@ for more details.
   compatibility abstraction.
 
   Flink 1.8.0 finalizes this effort by extending support for schema
-  evolution to POJOs, upgrade all Flink built-in serializers to use
-  the new serialization compatibility abstractions, as well as make it
+  evolution to POJOs, upgrading all Flink built-in serializers to use
+  the new serialization compatibility abstractions, as well as making it
   easier for advanced users who use custom state serializers to
   implement the abstractions.  These different aspects for a complete
   out-of-the-box schema evolution story are explained in detail below:
 
   1. Support for POJO state schema evolution: The pool of data types
-     that support state schema evolution have been expanded to include
+     that support state schema evolution has been expanded to include
      POJOs. For state types that use POJOs, you can now add or remove
      fields from your POJO while retaining backwards
      compatibility. For a full overview of the list of data types that
@@ -83,7 +83,7 @@ for more details.
      need for Flink to Java-serialize the state serializer as state
      metadata in savepoints.
 
-     In 1.8.0, all Flink's built-in serializers have been upgraded to
+     In 1.8.0, all of Flink's built-in serializers have been upgraded to
      use the new abstractions, and therefore the serializers
      themselves are no longer Java-serialized into savepoints. This
      greatly improves interoperability of Flink savepoints, in terms
@@ -92,7 +92,7 @@ for more details.
      above. Another outcome is that all composite data types supported
      by Flink (such as `Either`, Scala case classes, Flink Java
      `Tuple`s, etc.) are generally evolve-able as well when they have
-     a nested evolvable type such as POJO. For example, the `MyPojo`
+     a nested evolvable type, such as a POJO. For example, the `MyPojo`
      type in `ValueState<Tuple2<Integer, MyPojo>>` or
      `ListState<Either<Integer, MyPojo>>`, which is a POJO, is allowed
      to evolve its schema.
@@ -100,7 +100,7 @@ for more details.
      For users who are using custom `TypeSerializer` implementations
      for their state serializer and are still using the outdated
      abstractions (i.e. `TypeSerializerConfigSnapshot` and
-     `CompatiblityResult`), we highly recommend to upgrade to the new
+     `CompatiblityResult`), we highly recommend upgrading to the new
      abstractions to be future proof. Please refer to the Custom State
      Serialization documentation page for a detailed description on
      the new abstractions.
@@ -108,7 +108,7 @@ for more details.
   3. Provide pre-defined snapshot implementations for common
      serializers: For convenience, Flink 1.8.0 comes with two
      predefined implementations for the `TypeSerializerSnapshot` that
-     would make the task of implementing these new abstractions easier
+     make the task of implementing these new abstractions easier
      for most implementations of `TypeSerializer`s -
      `SimpleTypeSerializerSnapshot` and
      `CompositeTypeSerializerSnapshot`. This section in the
@@ -118,7 +118,7 @@ for more details.
   ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We
   introduced TTL (time-to-live) for Keyed state in Flink 1.6
   ([FLINK-9510](https://issues.apache.org/jira/browse/FLINK-9510)). This
-  feature enabled cleanup and making keyed state entries inaccessible after a
+  feature enabled cleanup and made keyed state entries inaccessible after a
   defined timeout. In addition state would now also be cleaned up when
   writing a savepoint/checkpoint.
 
@@ -133,8 +133,8 @@ for more details.
 * **SQL pattern detection with user-defined functions and
   aggregations**: The support of the MATCH_RECOGNIZE clause has been
   extended by multiple features.  The addition of user-defined
-  function allows for allows for custom logic during pattern detection
-  ([FLINK-10597](https://issues.apache.org/jira/browse/FLINK-10597)).
+  functions allows for custom logic during pattern detection
+  ([FLINK-10597](https://issues.apache.org/jira/browse/FLINK-10597)),
   while adding aggregations allows for more complex CEP definitions,
   such as the following
   ([FLINK-7599](https://issues.apache.org/jira/browse/FLINK-7599)).

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -166,6 +166,22 @@ for more details.
   subsumes`KeyedSerializationSchema` functionality, which is deprecated but
   still available for now.
 
+* **Per-shard watermarking option in FlinkKinesisConsumer
+  ([FLINK-5697](https://issues.apache.org/jira/browse/FLINK-5697))**: The Kinesis
+  Consumer can now emit periodic watermarks that are derived from per-shard watermarks,
+  for correct event time processing with subtasks that consume multiple Kinesis shards.
+
+* **New consumer for DynamoDB Streams to capture table changes
+  ([FLINK-4582](https://issues.apache.org/jira/browse/FLINK-4582))**: `FlinkDynamoDBStreamsConsumer`
+  is a variant of the Kinesis consumer that supports retrieval of CDC-like streams from DynamoDB tables.
+
+* **Support for global aggregates for subtask coordination
+  ([FLINK-10887](https://issues.apache.org/jira/browse/FLINK-10887))**:
+  Designed as solution for global source watermark tracking, `GlobalAggregateManager`
+  allows sharing of information between parallel subtasks. This feature will
+  be integrated into streaming connectors for watermark synchronization and
+  can be used for other purposes with a user defined aggregator.
+
 ## Important Changes
 
 * **Changes to bundling of Hadoop libraries with Flink
@@ -218,4 +234,3 @@ release.  Special credits go to the following members for contributing to the
 1.8.0 release (according to git):
 
 Addison Higham, Aitozi, Aleksey Pak, Alexander Fedulov, Alexey Trenikhin, Aljoscha Krettek, Andrey Zagrebin, Artsem Semianenka, Asura7969, Avi, Barisa Obradovic, Benchao Li, Bo WANG, Chesnay Schepler, Congxian Qiu, Cristian, David Anderson, Dawid Wysakowicz, Dian Fu, DuBin, EAlexRojas, EronWright, Eugen Yushin, Fabian Hueske, Fokko Driesprong, Gary Yao, Hequn Cheng, Igal Shilman, Jamie Grier, JaryZhen, Jeff Zhang, Jihyun Cho, Jinhu Wu, Joerg Schad, KarmaGYZ, Kezhu Wang, Konstantin Knauf, Kostas Kloudas, Lavkesh Lahngir, Li, Shuangjiang, Mai Nakagawa, Matrix42, Matt, Maximilian Michels, Mododo, Nico Kruber, Paul Lin, Piotr Nowojski, Qi Yu, Qin, Robert, Robert Metzger, Rong Rong, Rune Skou Larsen, Seth Wiesman, Shannon Carey, Shimin Yang, Shuyi Chen, Stefan Richter, Stephan Ewen, SuXingLee, TANG Wen-hui, Tao Yang, Thomas Weise, Till Rohrmann, Timo Walther, Tony Feng, Tony Wei, Tzu-Li (Gordon) Tai, Tzu-Li Chen, Ufuk Celebi, Xingcan Cui, Xpray, XuQianJin-Stars, Xue Yu, Yangze Guo, Ying Xu, Yiqun Lin, Yu Li, Yuanyang Wu, Yun Tang, ZILI CHEN, Zhanchun Zhang, Zhijiang, ZiLi Chen, acqua.csq, alex04.wang, ap, azagrebin, blueszheng, boshu Zheng, chengjie.wu, chensq, eaglewatcherwb, hequn8128, ifndef-SleePy, intsmaze, jinhu.wjh, jparkie, jrthe42, junsheng.wu, kgorman, kkolman, klion26, lamber-ken, leesf, libenchao, lining, liuzhaokun, lzh3636, maqingxiang, mb-datadome, okidogi, park.yq, sunhaibotb, sunjincheng121, tison, wenhuitang, wind, xueyu, xuqianjin, yanghua, zhangzhanchun, zhijiang, zhuzhu.zz, zy, 仲炜, 砚田, 谢磊
-

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -69,7 +69,7 @@ for more details.
   For a full overview of the list of data types that now support schema
   evolution as well as their evolution specifications and limitations, please
   refer to the [State Schema
-  Evolution](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/state/schema_evolution.html)
+  Evolution](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/stream/state/schema_evolution.html)
   documentation page.
 
 * **Java-serialization-free savepoints**: Previously, when writing the metadata
@@ -89,7 +89,7 @@ for more details.
   serializer's implementation, as long as they have also upgraded their
   `TypeSerializer` to the new serialization compatibility abstractions. For
   instructions on how to do that, please refer to the [Custom State
-  Serialization](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/state/custom_serialization.html)
+  Serialization](https://ci.apache.org/projects/flink/flink-docs-release-1.8/dev/stream/state/custom_serialization.html)
   documentation page, as well as the class-level Javadocs of the
   `TypeSerializer` class.
 

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -96,9 +96,9 @@ for more details.
 * **Continuous cleanup of old state based on TTL
   ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We
   introduced TTL (time-to-live) for Keyed state in Flink 1.6
-  ([FLINK-9510](https://issues.apache.org/jira/browse/FLINK-9510)).  This
-  feature allowed to clean up and make inaccessible keyed state entries when
-  accessing them. In addition state would now also being cleaned up when
+  ([FLINK-9510](https://issues.apache.org/jira/browse/FLINK-9510)). This
+  feature enabled cleanup and making keyed state entries inaccessible after a
+  defined timeout. In addition state would now also be cleaned up when
   writing a savepoint/checkpoint.
 
   Flink 1.8 introduces continous cleanup of old entries for both the RocksDB
@@ -106,7 +106,7 @@ for more details.
   ([FLINK-10471](https://issues.apache.org/jira/browse/FLINK-10471)) and the heap
   state backend
   ([FLINK-10473](https://issues.apache.org/jira/browse/FLINK-10473)). This means
-  that old entries (according to the ttl setting) are continously being cleanup
+  that old entries (according to the TTL setting) are continously being cleanup
   up.
 
 * **SQL pattern detection with user-defined functions and aggregations**: The
@@ -136,11 +136,11 @@ for more details.
   an RFC-4180 standard compliant CSV table format. The format might also be
   useful for general DataStream API users.
 
-* **New KafkaDeserializationSchema that give direct access to ConsumerRecord
+* **New KafkaDeserializationSchema that gives direct access to ConsumerRecord
   ([FLINK-8354](https://issues.apache.org/jira/browse/FLINK-8354))**: For the
   Flink `KafkaConsumers`, we introduced a new `KafkaDeserializationSchema` that
   gives direct access to the Kafka `ConsumerRecord`. This now allows access to
-  all data that Kafka provides for a record. This
+  all data that Kafka provides for a record, including the headers. This
   subsumes`KeyedSerializationSchema` functionality, which is deprecated but
   still available for now.
 

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -49,20 +49,49 @@ for more details.
 
 ## New Features and Improvements
 
-* **New Support for Schema Migration when restoring Savepoints**: With Flink
-  1.7.0 we added support for changing the schema of state when using the
-  `AvroSerializer`
-  ([FLINK-10605](https://issues.apache.org/jira/browse/FLINK-10605)). With
-  Flink 1.8.0 we made great progress migrating all built-in `TypeSerializers`
-  to a new serializer snapshot abstraction that theoretically allows schema
-  migration. Of the serializers that come with Flink, we now support schema
-  migration for the `PojoSerializer`
-  ([FLINK-11485](https://issues.apache.org/jira/browse/FLINK-11485)) and Java
-  `EnumSerializer`
-  ([FLINK-11334](https://issues.apache.org/jira/browse/FLINK-11334)), as well
-  as for Kryo in limited cases
-  ([FLINK-11323](https://issues.apache.org/jira/browse/FLINK-11323)).
+* **Schema evolution support for more data types when restoring savepoints**:
+  Back in Flink 1.7.0, we added support for changing the schema of state when
+  using Avro data types, such as `GenericRecord` or code generated
+  `SpecificRecord`s.
 
+  The pool of data types that support state schema evolution have been expanded
+  to include POJOs and Java Enums. For state types that use POJOs, you can now
+  add or remove fields from your POJO while remaining backwards compatibility.
+  For state types that use Java Enums, Enum fields can also be added or
+  removed, as well as changing types of the Enum fields.
+
+  Moreover, this applies also when you're using these data types within another
+  composite type, such as tuples, `Either`, Scala case classes, etc. For
+  example, the `MyPojo` type in `ValueState<Tuple2<Integer, MyPojo>>` or
+  `ListState<Either<Integer, MyPojo>>`, which is a POJO, is allowed to evolve
+  its schema.
+
+  For a full overview of the list of data types that now support schema
+  evolution as well as their evolution specifications and limitations, please
+  refer to the [State Schema
+  Evolution](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/state/schema_evolution.html)
+  documentation page.
+
+* **Java-serialization free savepoints**: Previously, when writing the metadata
+  for state in savepoints, the state serializers were also Java-serialized as
+  part of the metadata. This caused several problems, especially for state
+  schema evolution.
+
+  Back in Flink 1.7.0, we introduced new serialization compatibility
+  abstractions for the `TypeSerializer` interface to remove this behaviour. In
+  Flink 1.8.0, all of Flink's built-in `TypeSerializer`s have been upgraded to
+  use the new serialization compatibility abstractions, and therefore will no
+  longer be Java-serialized into savepoints.
+
+  This greatly improves Flink's savepoint interoperability and schema
+  evolvability. For users that are using custom implemented `TypeSerializer`s
+  for state serialization, this also means that they are no longer tied to the
+  serializer's implementation, as long as they have also upgraded their
+  `TypeSerializer` to the new serialization compatibility abstractions. For
+  instructions on how to do that, please refer to the [Custom State
+  Serialization](https://ci.apache.org/projects/flink/flink-docs-master/dev/stream/state/custom_serialization.html)
+  documentation page, as well as the class-level Javadocs of the
+  `TypeSerializer` class.
 
 * **Continuous cleanup of old state based on TTL
   ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -43,7 +43,7 @@ addition of the Blink enhancements
 Nevertheless, this release includes some important new features and bug fixes.
 The most interesting of those we'll highlight below. Please consult the
 [complete changelog](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=12344274)
-or the [release notes](https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html)
+and the [release notes](https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html)
 for more details.
 
 
@@ -79,6 +79,33 @@ for more details.
   ([FLINK-10473](https://issues.apache.org/jira/browse/FLINK-10473)). This means
   that old entries (according to the ttl setting) are continously being cleanup
   up.
+
+* **SQL pattern detection with user-defined functions and aggregations**: The
+  support of the MATCH_RECOGNIZE clause has been extended by multiple features.
+  User-defined function are now possible which allows for custom logic during
+  pattern detection
+  ([FLINK-10597](https://issues.apache.org/jira/browse/FLINK-10597)).
+  Aggregations allow for more complex CEP definitions
+  ([FLINK-7599](https://issues.apache.org/jira/browse/FLINK-7599)).
+
+  ```
+  SELECT *
+  FROM Ticker
+      MATCH_RECOGNIZE (
+          ORDER BY rowtime
+          MEASURES
+              AVG(A.price) AS avgPrice
+          ONE ROW PER MATCH
+          AFTER MATCH SKIP TO FIRST B
+          PATTERN (A+ B)
+          DEFINE
+              A AS AVG(A.price) < 15
+      ) MR;
+  ```
+
+* **RFC-compliant CSV format ([FLINK-9964](https://issues.apache.org/jira/browse/FLINK-9964))**: The SQL tables can now be read and written in
+  an RFC-4180 standard compliant CSV table format. The format might also be
+  useful for general DataStream API users.
 
 * **New KafkaDeserializationSchema that give direct access to ConsumerRecord
   ([FLINK-8354](https://issues.apache.org/jira/browse/FLINK-8354))**: For the

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -218,6 +218,17 @@ for more details.
   restore because it now filters the topics that are stored in state using the
   configured topics.
 
+## Known Issues
+
+* **Discarded checkpoint can cause Tasks to fail
+  ([FLINK-11662](https://issues.apache.org/jira/browse/FLINK-11662))**: There is
+  a race condition that can lead to erroneous checkpoint failures. This mostly
+  occurs when restarting from a savepoint or checkpoint takes a long time at the
+  sources of a job. If you see random checkpointing failures that don't seem to
+  have a good explanation you might be affected. Please see the Jira issue for
+  more details and a workaround for the problem.
+
+
 ## Release Notes
 
 Please review the [release

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -52,7 +52,7 @@ for more details.
 * **Finalized State Schema Evolution Story**: This release completes
   the community driven effort to provide a schema evolution story for
   user state managed by Flink. This has been an effort that spanned 2
-  releases, starting from 1.7.0 with the introduction for support for
+  releases, starting from 1.7.0 with the introduction of support for
   Avro state schema evolution as well as a revamped serialization
   compatibility abstraction.
 
@@ -112,7 +112,7 @@ for more details.
      for most implementations of `TypeSerializer`s -
      `SimpleTypeSerializerSnapshot` and
      `CompositeTypeSerializerSnapshot`. This section in the
-     documentation provide information on how to use these classes.
+     documentation provides information on how to use these classes.
 
 * **Continuous cleanup of old state based on TTL
   ([FLINK-7811](https://issues.apache.org/jira/browse/FLINK-7811))**: We
@@ -122,13 +122,12 @@ for more details.
   defined timeout. In addition state would now also be cleaned up when
   writing a savepoint/checkpoint.
 
-  Flink 1.8 introduces continous cleanup of old entries for both the RocksDB
+  Flink 1.8 introduces continuous cleanup of old entries for both the RocksDB
   state backend
   ([FLINK-10471](https://issues.apache.org/jira/browse/FLINK-10471)) and the heap
   state backend
   ([FLINK-10473](https://issues.apache.org/jira/browse/FLINK-10473)). This means
-  that old entries (according to the TTL setting) are continously being cleanup
-  up.
+  that old entries (according to the TTL setting) are continuously cleaned up.
 
 * **SQL pattern detection with user-defined functions and
   aggregations**: The support of the MATCH_RECOGNIZE clause has been
@@ -163,7 +162,7 @@ for more details.
   Flink `KafkaConsumers`, we introduced a new `KafkaDeserializationSchema` that
   gives direct access to the Kafka `ConsumerRecord`. This now allows access to
   all data that Kafka provides for a record, including the headers. This
-  subsumes`KeyedSerializationSchema` functionality, which is deprecated but
+  subsumes the `KeyedSerializationSchema` functionality, which is deprecated but
   still available for now.
 
 * **Per-shard watermarking option in FlinkKinesisConsumer
@@ -177,7 +176,7 @@ for more details.
 
 * **Support for global aggregates for subtask coordination
   ([FLINK-10887](https://issues.apache.org/jira/browse/FLINK-10887))**:
-  Designed as solution for global source watermark tracking, `GlobalAggregateManager`
+  Designed as a solution for global source watermark tracking, `GlobalAggregateManager`
   allows sharing of information between parallel subtasks. This feature will
   be integrated into streaming connectors for watermark synchronization and
   can be used for other purposes with a user defined aggregator.
@@ -210,15 +209,14 @@ for more details.
   `disableFilterRestoredPartitionsWithSubscribedTopics()` configuration method
   on the `FlinkKafkaConsumer`.
 
-  Consider this example: if you had a Kafka Consumer that was
-  consuming from topic `A`, you did a savepoint, then changed your
-  Kafka consumer to instead consume from topic `B`, and then restarted
-  your job from the savepoint. Before this change, your consumer would
-  now consume from both topic `A` and `B` because it was stored in
-  state that the consumer was consuming from topic `A`. With the
-  change, your consumer would only consume from topic `B` after
-  restore because we filter the topics that are stored in state using
-  the configured topics.
+  Consider this example: if you had a Kafka Consumer that was consuming from
+  topic `A`, you did a savepoint, then changed your Kafka consumer to instead
+  consume from topic `B`, and then restarted your job from the savepoint.
+  Before this change, your consumer would now consume from both topic `A` and
+  `B` because it was stored in state that the consumer was consuming from topic
+  `A`. With the change, your consumer would only consume from topic `B` after
+  restore because it now filters the topics that are stored in state using the
+  configured topics.
 
 ## Release Notes
 

--- a/_posts/2019-03-06-release-1.8.0.md
+++ b/_posts/2019-03-06-release-1.8.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Apache Flink 1.8.0 Release Announcement"
-date:   2019-2-26 12:00:00
+date:   2019-4-10 12:00:00
 categories: news
 authors:
 - till:
@@ -217,6 +217,13 @@ for more details.
   `A`. With the change, your consumer would only consume from topic `B` after
   restore because it now filters the topics that are stored in state using the
   configured topics.
+
+ * **Change in the Maven modules of Table API
+   ([FLINK-11064](https://issues.apache.org/jira/browse/FLINK-11064))**: Users
+   that had a `flink-table` dependency before, need to update their
+   dependencies to `flink-table-planner` and the correct dependency of
+   `flink-table-api-*`, depending on whether Java or Scala is used: one of
+   `flink-table-api-java-bridge` or `flink-table-api-scala-bridge`.
 
 ## Known Issues
 

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -7,6 +7,248 @@
 <atom:link href="https://flink.apache.org/blog/feed.xml" rel="self" type="application/rss+xml" />
 
 <item>
+<title>Apache Flink 1.8.0 Release Announcement</title>
+<description>&lt;p&gt;The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 370 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the &lt;a href=&quot;https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;amp;version=12344274&quot;&gt;complete changelog&lt;/a&gt;
+for more details.&lt;/p&gt;
+
+&lt;p&gt;Flink 1.8.0 is API-compatible with previous 1.x.y releases for APIs annotated
+with the &lt;code&gt;@Public&lt;/code&gt; annotation.  The release is available now and we encourage
+everyone to &lt;a href=&quot;http://flink.apache.org/downloads.html&quot;&gt;download the release&lt;/a&gt; and
+check out the updated
+&lt;a href=&quot;https://ci.apache.org/projects/flink/flink-docs-release-1.8/&quot;&gt;documentation&lt;/a&gt;.
+Feedback through the Flink &lt;a href=&quot;http://flink.apache.org/community.html#mailing-lists&quot;&gt;mailing
+lists&lt;/a&gt; or
+&lt;a href=&quot;https://issues.apache.org/jira/projects/FLINK/summary&quot;&gt;JIRA&lt;/a&gt; is, as always,
+very much appreciated!&lt;/p&gt;
+
+&lt;p&gt;You can find the binaries on the updated &lt;a href=&quot;http://flink.apache.org/downloads.html&quot;&gt;Downloads page&lt;/a&gt; on the Flink project site.&lt;/p&gt;
+
+&lt;div class=&quot;page-toc&quot;&gt;
+&lt;ul id=&quot;markdown-toc&quot;&gt;
+  &lt;li&gt;&lt;a href=&quot;#new-features-and-improvements&quot; id=&quot;markdown-toc-new-features-and-improvements&quot;&gt;New Features and Improvements&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#important-changes&quot; id=&quot;markdown-toc-important-changes&quot;&gt;Important Changes&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#release-notes&quot; id=&quot;markdown-toc-release-notes&quot;&gt;Release Notes&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#list-of-contributors&quot; id=&quot;markdown-toc-list-of-contributors&quot;&gt;List of Contributors&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;/div&gt;
+
+&lt;p&gt;With Flink 1.8.0 we come closer to our goals of enabling fast data processing
+and building data-intensive applications for the Flink community in a seamless
+way. We do this by cleaning up and refactoring Flink under the hood to allow
+more efficient feature development in the future. This includes removal of the
+legacy runtime components that were subsumed in the major rework of Flink’s
+underlying distributed system architecture
+(&lt;a href=&quot;https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65147077&quot;&gt;FLIP-6&lt;/a&gt;)
+as well as refactorings on the Table API that prepare it for the future
+addition of the Blink enhancements
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-11439&quot;&gt;FLINK-11439&lt;/a&gt;).&lt;/p&gt;
+
+&lt;p&gt;Nevertheless, this release includes some important new features and bug fixes.
+The most interesting of those are highlighted below. Please consult the
+&lt;a href=&quot;https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;amp;version=12344274&quot;&gt;complete changelog&lt;/a&gt;
+and the &lt;a href=&quot;https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html&quot;&gt;release notes&lt;/a&gt;
+for more details.&lt;/p&gt;
+
+&lt;h2 id=&quot;new-features-and-improvements&quot;&gt;New Features and Improvements&lt;/h2&gt;
+
+&lt;ul&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;Finalized State Schema Evolution Story&lt;/strong&gt;: This release completes
+the community driven effort to provide a schema evaluation story for
+user state managed by Flink. This has been an effort that spanned 2
+releases, starting from 1.7.0 with the introduction for support for
+Avro state schema evolution as well as a revamped serialization
+compatibility abstraction.&lt;/p&gt;
+
+    &lt;p&gt;Flink 1.8.0 finalizes this effort by extending support for schema
+evolution to POJOs, upgrade all Flink built-in serializers to use
+the new serialization compatibility abstractions, as well as make it
+easier for advanced users who use custom state serializers to
+implement the abstractions.  These different aspects for a complete
+out-of-the-box schema evolution story are explained in detail below:&lt;/p&gt;
+
+    &lt;ol&gt;
+      &lt;li&gt;
+        &lt;p&gt;Support for POJO state schema evolution: The pool of data types
+that support state schema evolution have been expanded to include
+POJOs. For state types that use POJOs, you can now add or remove
+fields from your POJO while retaining backwards
+compatibility. For a full overview of the list of data types that
+now support schema evolution as well as their evolution
+specifications and limitations, please refer to the State Schema
+Evolution documentation page.&lt;/p&gt;
+      &lt;/li&gt;
+      &lt;li&gt;
+        &lt;p&gt;Upgrade all Flink serializers to use new serialization
+compatibility asbtractions: Back in 1.7.0, we introduced the new
+serialization compatibility abstractions &lt;code&gt;TypeSerializerSnapshot&lt;/code&gt;
+and &lt;code&gt;TypeSerializerSchemaCompatibility&lt;/code&gt;. Besides providing a more
+expressible API to reflect schema compatibility between the data
+stored in savepoints and the data registered at runtime, another
+important aspect about the new abstraction is that it avoids the
+need for Flink to Java-serialize the state serializer as state
+metadata in savepoints.&lt;/p&gt;
+
+        &lt;p&gt;In 1.8.0, all Flink’s built-in serializers have been upgraded to
+use the new abstractions, and therefore the serializers
+themselves are no longer Java-serialized into savepoints. This
+greatly improves interoperability of Flink savepoints, in terms
+of state schema evolvability. For example, one outcome was the
+support for POJO schema evolution, as previously mentioned
+above. Another outcome is that all composite data types supported
+by Flink (such as &lt;code&gt;Either&lt;/code&gt;, Scala case classes, Flink Java
+&lt;code&gt;Tuple&lt;/code&gt;s, etc.) are generally evolve-able as well when they have
+a nested evolvable type such as POJO. For example, the &lt;code&gt;MyPojo&lt;/code&gt;
+type in &lt;code&gt;ValueState&amp;lt;Tuple2&amp;lt;Integer, MyPojo&amp;gt;&amp;gt;&lt;/code&gt; or
+&lt;code&gt;ListState&amp;lt;Either&amp;lt;Integer, MyPojo&amp;gt;&amp;gt;&lt;/code&gt;, which is a POJO, is allowed
+to evolve its schema.&lt;/p&gt;
+
+        &lt;p&gt;For users who are using custom &lt;code&gt;TypeSerializer&lt;/code&gt; implementations
+for their state serializer and are still using the outdated
+abstractions (i.e. &lt;code&gt;TypeSerializerConfigSnapshot&lt;/code&gt; and
+&lt;code&gt;CompatiblityResult&lt;/code&gt;), we highly recommend to upgrade to the new
+abstractions to be future proof. Please refer to the Custom State
+Serialization documentation page for a detailed description on
+the new abstractions.&lt;/p&gt;
+      &lt;/li&gt;
+      &lt;li&gt;
+        &lt;p&gt;Provide pre-defined snapshot implementations for common
+serializers: For convenience, Flink 1.8.0 comes with two
+predefined implementations for the &lt;code&gt;TypeSerializerSnapshot&lt;/code&gt; that
+would make the task of implementing these new abstractions easier
+for most implementations of &lt;code&gt;TypeSerializer&lt;/code&gt;s -
+&lt;code&gt;SimpleTypeSerializerSnapshot&lt;/code&gt; and
+&lt;code&gt;CompositeTypeSerializerSnapshot&lt;/code&gt;. This section in the
+documentation provide information on how to use these classes.&lt;/p&gt;
+      &lt;/li&gt;
+    &lt;/ol&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;Continuous cleanup of old state based on TTL
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-7811&quot;&gt;FLINK-7811&lt;/a&gt;)&lt;/strong&gt;: We
+introduced TTL (time-to-live) for Keyed state in Flink 1.6
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-9510&quot;&gt;FLINK-9510&lt;/a&gt;). This
+feature enabled cleanup and making keyed state entries inaccessible after a
+defined timeout. In addition state would now also be cleaned up when
+writing a savepoint/checkpoint.&lt;/p&gt;
+
+    &lt;p&gt;Flink 1.8 introduces continous cleanup of old entries for both the RocksDB
+state backend
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10471&quot;&gt;FLINK-10471&lt;/a&gt;) and the heap
+state backend
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10473&quot;&gt;FLINK-10473&lt;/a&gt;). This means
+that old entries (according to the TTL setting) are continously being cleanup
+up.&lt;/p&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;SQL pattern detection with user-defined functions and
+aggregations&lt;/strong&gt;: The support of the MATCH_RECOGNIZE clause has been
+extended by multiple features.  The addition of user-defined
+function allows for allows for custom logic during pattern detection
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10597&quot;&gt;FLINK-10597&lt;/a&gt;).
+while adding aggregations allows for more complex CEP definitions,
+such as the following
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-7599&quot;&gt;FLINK-7599&lt;/a&gt;).&lt;/p&gt;
+
+    &lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code&gt;SELECT *
+FROM Ticker
+    MATCH_RECOGNIZE (
+        ORDER BY rowtime
+        MEASURES
+            AVG(A.price) AS avgPrice
+        ONE ROW PER MATCH
+        AFTER MATCH SKIP TO FIRST B
+        PATTERN (A+ B)
+        DEFINE
+            A AS AVG(A.price) &amp;lt; 15
+    ) MR;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;RFC-compliant CSV format (&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-9964&quot;&gt;FLINK-9964&lt;/a&gt;)&lt;/strong&gt;: The SQL tables can now be read and written in
+an RFC-4180 standard compliant CSV table format. The format might also be
+useful for general DataStream API users.&lt;/p&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;New KafkaDeserializationSchema that gives direct access to ConsumerRecord
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-8354&quot;&gt;FLINK-8354&lt;/a&gt;)&lt;/strong&gt;: For the
+Flink &lt;code&gt;KafkaConsumers&lt;/code&gt;, we introduced a new &lt;code&gt;KafkaDeserializationSchema&lt;/code&gt; that
+gives direct access to the Kafka &lt;code&gt;ConsumerRecord&lt;/code&gt;. This now allows access to
+all data that Kafka provides for a record, including the headers. This
+subsumes&lt;code&gt;KeyedSerializationSchema&lt;/code&gt; functionality, which is deprecated but
+still available for now.&lt;/p&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2 id=&quot;important-changes&quot;&gt;Important Changes&lt;/h2&gt;
+
+&lt;ul&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;Changes to bundling of Hadoop libraries with Flink
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-11266&quot;&gt;FLINK-11266&lt;/a&gt;)&lt;/strong&gt;:
+Convenience binaries that include hadoop are no longer released.&lt;/p&gt;
+
+    &lt;p&gt;If a deployment relies on &lt;code&gt;flink-shaded-hadoop2&lt;/code&gt; being included in
+&lt;code&gt;flink-dist&lt;/code&gt;, then you must manually download a pre-packaged Hadoop
+jar from the optional components section of the &lt;a href=&quot;https://flink.apache.org/downloads.html&quot;&gt;download
+page&lt;/a&gt; and copy it into the
+&lt;code&gt;/lib&lt;/code&gt; directory.  Alternatively, a Flink distribution that includes
+hadoop can be built by packaging &lt;code&gt;flink-dist&lt;/code&gt; and activating the
+&lt;code&gt;include-hadoop&lt;/code&gt; maven profile.&lt;/p&gt;
+
+    &lt;p&gt;As hadoop is no longer included in &lt;code&gt;flink-dist&lt;/code&gt; by default, specifying
+&lt;code&gt;-DwithoutHadoop&lt;/code&gt; when packaging &lt;code&gt;flink-dist&lt;/code&gt; no longer impacts the build.&lt;/p&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;strong&gt;FlinkKafkaConsumer will now filter restored partitions based on topic
+specification
+(&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10342&quot;&gt;FLINK-10342&lt;/a&gt;)&lt;/strong&gt;:
+Starting from Flink 1.8.0, the &lt;code&gt;FlinkKafkaConsumer&lt;/code&gt; now always filters out
+restored partitions that are no longer associated with a specified topic to
+subscribe to in the restored execution. This behaviour did not exist in
+previous versions of the &lt;code&gt;FlinkKafkaConsumer&lt;/code&gt;. If you wish to retain the
+previous behaviour, please use the
+&lt;code&gt;disableFilterRestoredPartitionsWithSubscribedTopics()&lt;/code&gt; configuration method
+on the &lt;code&gt;FlinkKafkaConsumer&lt;/code&gt;.&lt;/p&gt;
+
+    &lt;p&gt;Consider this example: if you had a Kafka Consumer that was
+consuming from topic &lt;code&gt;A&lt;/code&gt;, you did a savepoint, then changed your
+Kafka consumer to instead consume from topic &lt;code&gt;B&lt;/code&gt;, and then restarted
+your job from the savepoint. Before this change, your consumer would
+now consume from both topic &lt;code&gt;A&lt;/code&gt; and &lt;code&gt;B&lt;/code&gt; because it was stored in
+state that the consumer was consuming from topic &lt;code&gt;A&lt;/code&gt;. With the
+change, your consumer would only consume from topic &lt;code&gt;B&lt;/code&gt; after
+restore because we filter the topics that are stored in state using
+the configured topics.&lt;/p&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2 id=&quot;release-notes&quot;&gt;Release Notes&lt;/h2&gt;
+
+&lt;p&gt;Please review the &lt;a href=&quot;https://ci.apache.org/projects/flink/flink-docs-release-1.8/release-notes/flink-1.8.html&quot;&gt;release
+notes&lt;/a&gt;
+for a more detailed list of changes and new features if you plan to upgrade
+your Flink setup to Flink 1.8.&lt;/p&gt;
+
+&lt;h2 id=&quot;list-of-contributors&quot;&gt;List of Contributors&lt;/h2&gt;
+
+&lt;p&gt;We would like to acknowledge all community members for contributing to this
+release.  Special credits go to the following members for contributing to the
+1.8.0 release (according to git):&lt;/p&gt;
+
+&lt;p&gt;Addison Higham, Aitozi, Aleksey Pak, Alexander Fedulov, Alexey Trenikhin, Aljoscha Krettek, Andrey Zagrebin, Artsem Semianenka, Asura7969, Avi, Barisa Obradovic, Benchao Li, Bo WANG, Chesnay Schepler, Congxian Qiu, Cristian, David Anderson, Dawid Wysakowicz, Dian Fu, DuBin, EAlexRojas, EronWright, Eugen Yushin, Fabian Hueske, Fokko Driesprong, Gary Yao, Hequn Cheng, Igal Shilman, Jamie Grier, JaryZhen, Jeff Zhang, Jihyun Cho, Jinhu Wu, Joerg Schad, KarmaGYZ, Kezhu Wang, Konstantin Knauf, Kostas Kloudas, Lavkesh Lahngir, Li, Shuangjiang, Mai Nakagawa, Matrix42, Matt, Maximilian Michels, Mododo, Nico Kruber, Paul Lin, Piotr Nowojski, Qi Yu, Qin, Robert, Robert Metzger, Rong Rong, Rune Skou Larsen, Seth Wiesman, Shannon Carey, Shimin Yang, Shuyi Chen, Stefan Richter, Stephan Ewen, SuXingLee, TANG Wen-hui, Tao Yang, Thomas Weise, Till Rohrmann, Timo Walther, Tony Feng, Tony Wei, Tzu-Li (Gordon) Tai, Tzu-Li Chen, Ufuk Celebi, Xingcan Cui, Xpray, XuQianJin-Stars, Xue Yu, Yangze Guo, Ying Xu, Yiqun Lin, Yu Li, Yuanyang Wu, Yun Tang, ZILI CHEN, Zhanchun Zhang, Zhijiang, ZiLi Chen, acqua.csq, alex04.wang, ap, azagrebin, blueszheng, boshu Zheng, chengjie.wu, chensq, eaglewatcherwb, hequn8128, ifndef-SleePy, intsmaze, jinhu.wjh, jparkie, jrthe42, junsheng.wu, kgorman, kkolman, klion26, lamber-ken, leesf, libenchao, lining, liuzhaokun, lzh3636, maqingxiang, mb-datadome, okidogi, park.yq, sunhaibotb, sunjincheng121, tison, wenhuitang, wind, xueyu, xuqianjin, yanghua, zhangzhanchun, zhijiang, zhuzhu.zz, zy, 仲炜, 砚田, 谢磊&lt;/p&gt;
+
+</description>
+<pubDate>Tue, 26 Feb 2019 13:00:00 +0100</pubDate>
+<link>https://flink.apache.org/news/2019/02/26/release-1.8.0.html</link>
+<guid isPermaLink="true">/news/2019/02/26/release-1.8.0.html</guid>
+</item>
+
+<item>
 <title>Monitoring Apache Flink Applications 101</title>
 <description>&lt;!-- improve style of tables --&gt;
 &lt;style&gt;

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -155,6 +155,25 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></h2>
+
+      <p>26 Feb 2019
+       Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>)</p>
+
+      <p><p>The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 370 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12344274">complete changelog</a>
+for more details.</p>
+
+</p>
+
+      <p><a href="/news/2019/02/26/release-1.8.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></h2>
 
       <p>25 Feb 2019
@@ -287,21 +306,6 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.5.5.html">Apache Flink 1.5.5 Released</a></h2>
-
-      <p>29 Oct 2018
-      </p>
-
-      <p><p>The Apache Flink community released the fifth bugfix version of the Apache Flink 1.5 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/10/29/release-1.5.5.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -333,6 +337,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.5.5.html">Apache Flink 1.5.5 Released</a></h2>
+
+      <p>29 Oct 2018
+      </p>
+
+      <p><p>The Apache Flink community released the fifth bugfix version of the Apache Flink 1.5 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/10/29/release-1.5.5.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/09/20/release-1.6.1.html">Apache Flink 1.6.1 Released</a></h2>
 
       <p>20 Sep 2018
@@ -289,19 +304,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">An Overview of End-to-End Exactly-Once Processing in Apache Flink (with Apache Kafka, too!)</a></h2>
-
-      <p>01 Mar 2018
-       Piotr Nowojski (<a href="https://twitter.com/PiotrNowojski">@PiotrNowojski</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
-
-      <p>Flink 1.4.0 introduced a new feature that makes it possible to build end-to-end exactly-once applications with Flink and data sources and sinks that support transactions.</p>
-
-      <p><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -333,6 +335,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -155,6 +155,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">An Overview of End-to-End Exactly-Once Processing in Apache Flink (with Apache Kafka, too!)</a></h2>
+
+      <p>01 Mar 2018
+       Piotr Nowojski (<a href="https://twitter.com/PiotrNowojski">@PiotrNowojski</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
+
+      <p>Flink 1.4.0 introduced a new feature that makes it possible to build end-to-end exactly-once applications with Flink and data sources and sinks that support transactions.</p>
+
+      <p><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/02/15/release-1.4.1.html">Apache Flink 1.4.1 Released</a></h2>
 
       <p>15 Feb 2018
@@ -288,21 +301,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/05/16/official-docker-image.html">Introducing Docker Images for Apache Flink</a></h2>
-
-      <p>16 May 2017 by Patrick Lucas (Data Artisans) and Ismaël Mejía (Talend) (<a href="https://twitter.com/">@iemejia</a>)
-      </p>
-
-      <p><p>For some time, the Apache Flink community has provided scripts to build a Docker image to run Flink. Now, starting with version 1.2.1, Flink will have a <a href="https://hub.docker.com/r/_/flink/">Docker image</a> on the Docker Hub. This image is maintained by the Flink community and curated by the <a href="https://github.com/docker-library/official-images">Docker</a> team to ensure it meets the quality standards for container images of the Docker community.</p>
-
-</p>
-
-      <p><a href="/news/2017/05/16/official-docker-image.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -334,6 +332,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/05/16/official-docker-image.html">Introducing Docker Images for Apache Flink</a></h2>
+
+      <p>16 May 2017 by Patrick Lucas (Data Artisans) and Ismaël Mejía (Talend) (<a href="https://twitter.com/">@iemejia</a>)
+      </p>
+
+      <p><p>For some time, the Apache Flink community has provided scripts to build a Docker image to run Flink. Now, starting with version 1.2.1, Flink will have a <a href="https://hub.docker.com/r/_/flink/">Docker image</a> on the Docker Hub. This image is maintained by the Flink community and curated by the <a href="https://github.com/docker-library/official-images">Docker</a> team to ensure it meets the quality standards for container images of the Docker community.</p>
+
+</p>
+
+      <p><a href="/news/2017/05/16/official-docker-image.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/04/26/release-1.2.1.html">Apache Flink 1.2.1 Released</a></h2>
 
       <p>26 Apr 2017
@@ -282,21 +297,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/08/24/ff16-keynotes-panels.html">Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion</a></h2>
-
-      <p>24 Aug 2016
-      </p>
-
-      <p><p>An update for the Flink community: the <a href="http://flink-forward.org/kb_day/day-1/">Flink Forward 2016 schedule</a> is now available online. This year's event will include 2 days of talks from stream processing experts at Google, MapR, Alibaba, Netflix, Cloudera, and more. Following the talks is a full day of hands-on Flink training.</p>
-
-</p>
-
-      <p><a href="/news/2016/08/24/ff16-keynotes-panels.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -328,6 +328,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/08/24/ff16-keynotes-panels.html">Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion</a></h2>
+
+      <p>24 Aug 2016
+      </p>
+
+      <p><p>An update for the Flink community: the <a href="http://flink-forward.org/kb_day/day-1/">Flink Forward 2016 schedule</a> is now available online. This year's event will include 2 days of talks from stream processing experts at Google, MapR, Alibaba, Netflix, Cloudera, and more. Following the talks is a full day of hands-on Flink training.</p>
+
+</p>
+
+      <p><a href="/news/2016/08/24/ff16-keynotes-panels.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/08/11/release-1.1.1.html">Flink 1.1.1 Released</a></h2>
 
       <p>11 Aug 2016
@@ -286,21 +301,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/02/11/release-0.10.2.html">Flink 0.10.2 Released</a></h2>
-
-      <p>11 Feb 2016
-      </p>
-
-      <p><p>Today, the Flink community released Flink version <strong>0.10.2</strong>, the second bugfix release of the 0.10 series.</p>
-
-</p>
-
-      <p><a href="/news/2016/02/11/release-0.10.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -332,6 +332,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/02/11/release-0.10.2.html">Flink 0.10.2 Released</a></h2>
+
+      <p>11 Feb 2016
+      </p>
+
+      <p><p>Today, the Flink community released Flink version <strong>0.10.2</strong>, the second bugfix release of the 0.10 series.</p>
+
+</p>
+
+      <p><a href="/news/2016/02/11/release-0.10.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/12/18/a-year-in-review.html">Flink 2015: A year in review, and a lookout to 2016</a></h2>
 
       <p>18 Dec 2015 by Robert Metzger (<a href="https://twitter.com/">@rmetzger_</a>)
@@ -290,21 +305,6 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Announcing Apache Flink 0.9.0</a></h2>
-
-      <p>24 Jun 2015
-      </p>
-
-      <p><p>The Apache Flink community is pleased to announce the availability of the 0.9.0 release. The release is the result of many months of hard work within the Flink community. It contains many new features and improvements which were previewed in the 0.9.0-milestone1 release and have been polished since then. This is the largest Flink release so far.</p>
-
-</p>
-
-      <p><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -336,6 +336,16 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Announcing Apache Flink 0.9.0</a></h2>
+
+      <p>24 Jun 2015
+      </p>
+
+      <p><p>The Apache Flink community is pleased to announce the availability of the 0.9.0 release. The release is the result of many months of hard work within the Flink community. It contains many new features and improvements which were previewed in the 0.9.0-milestone1 release and have been polished since then. This is the largest Flink release so far.</p>
+
+</p>
+
+      <p><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/05/14/Community-update-April.html">April 2015 in the Flink community</a></h2>
 
       <p>14 May 2015 by Kostas Tzoumas (<a href="https://twitter.com/">@kostas_tzoumas</a>)
@@ -296,21 +311,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/01/06/december-in-flink.html">December 2014 in the Flink community</a></h2>
-
-      <p>06 Jan 2015
-      </p>
-
-      <p><p>This is the first blog post of a “newsletter” like series where we give a summary of the monthly activity in the Flink community. As the Flink project grows, this can serve as a “tl;dr” for people that are not following the Flink dev and user mailing lists, or those that are simply overwhelmed by the traffic.</p>
-
-</p>
-
-      <p><a href="/news/2015/01/06/december-in-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -342,6 +342,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -155,6 +155,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/01/06/december-in-flink.html">December 2014 in the Flink community</a></h2>
+
+      <p>06 Jan 2015
+      </p>
+
+      <p><p>This is the first blog post of a “newsletter” like series where we give a summary of the monthly activity in the Flink community. As the Flink project grows, this can serve as a “tl;dr” for people that are not following the Flink dev and user mailing lists, or those that are simply overwhelmed by the traffic.</p>
+
+</p>
+
+      <p><a href="/news/2015/01/06/december-in-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2014/11/18/hadoop-compatibility.html">Hadoop Compatibility in Flink</a></h2>
 
       <p>18 Nov 2014 by Fabian Hüske (<a href="https://twitter.com/">@fhueske</a>)
@@ -263,6 +278,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -438,6 +438,15 @@
 
   <dl>
       
+        <dt> <a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></dt>
+        <dd><p>The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 370 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12344274">complete changelog</a>
+for more details.</p>
+
+</dd>
+      
         <dt> <a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></dt>
         <dd>The monitoring of business-critical applications is a crucial aspect of a production deployment. It ensures that any degradation or downtime is immediately identified and can be resolved as quickly as possible. In this post, we discuss the most important metrics that indicate healthy Flink applications.</dd>
       
@@ -453,11 +462,6 @@
       
         <dt> <a href="/news/2019/02/13/unified-batch-streaming-blink.html">Batch as a Special Case of Streaming and Alibaba's contribution of Blink</a></dt>
         <dd>A few weeks ago, Alibaba contributed its Flink-fork 'Blink' back to Apache Flink. In this blog post we discuss how Blink's features will help the Flink community to make a big step towards its vision to build a truly unified system for stream and batch processing.</dd>
-      
-        <dt> <a href="/news/2018/12/26/release-1.5.6.html">Apache Flink 1.5.6 Released</a></dt>
-        <dd><p>The Apache Flink community released the sixth and last bugfix version of the Apache Flink 1.5 series.</p>
-
-</dd>
     
   </dl>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -437,6 +437,15 @@
 
   <dl>
       
+        <dt> <a href="/news/2019/02/26/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></dt>
+        <dd><p>The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 370 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12344274">complete changelog</a>
+for more details.</p>
+
+</dd>
+      
         <dt> <a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></dt>
         <dd>The monitoring of business-critical applications is a crucial aspect of a production deployment. It ensures that any degradation or downtime is immediately identified and can be resolved as quickly as possible. In this post, we discuss the most important metrics that indicate healthy Flink applications.</dd>
       
@@ -452,11 +461,6 @@
       
         <dt> <a href="/news/2019/02/13/unified-batch-streaming-blink.html">Batch as a Special Case of Streaming and Alibaba's contribution of Blink</a></dt>
         <dd>A few weeks ago, Alibaba contributed its Flink-fork 'Blink' back to Apache Flink. In this blog post we discuss how Blink's features will help the Flink community to make a big step towards its vision to build a truly unified system for stream and batch processing.</dd>
-      
-        <dt> <a href="/news/2018/12/26/release-1.5.6.html">Apache Flink 1.5.6 Released</a></dt>
-        <dd><p>The Apache Flink community released the sixth and last bugfix version of the Apache Flink 1.5 series.</p>
-
-</dd>
     
   </dl>
 


### PR DESCRIPTION
~~This reorganizes the Downloads page a bit. The relevant information for one given release is now in one place: binary release, additional components, alternative binaries (for different Hadoop versions). The layout was simplified a bit to make additional components more visible, most links are now plain links, there is no fold-out section for additional components anymore.~~