### PR TITLE
Update Downloads page for Flink 1.8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ url: https://flink.apache.org
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
 FLINK_VERSION_STABLE: 1.7.2
-FLINK_VERSION_HADOOP_2_STABLE: 1.7.2
 FLINK_VERSION_STABLE_SHORT: 1.7
 
 FLINK_VERSION_LATEST: 1.8-SNAPSHOT
@@ -20,30 +19,6 @@ FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
 FLINK_GITHUB_URL: https://github.com/apache/flink
 FLINK_CONTRIBUTORS_URL: https://cwiki.apache.org/confluence/display/FLINK/List+of+contributors
 FLINK_GITHUB_REPO_NAME: flink
-
-optional_components:
-  -
-    name: "Avro"
-    category: "SQL Formats"
-    scala_dependent: false
-    versions:
-      -
-        version: "1.7.2"
-        id: 172-sql-format-avro
-        url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar
-        asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.asc
-        sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.sha1
-  -
-    name: "Json"
-    category: "SQL Formats"
-    scala_dependent: false
-    versions:
-      -
-        version: "1.7.2"
-        id: 172-sql-format-json
-        url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar
-        asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.asc
-        sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.sha1
 
 # Example for scala dependent component:
 #  -
@@ -76,166 +51,190 @@ optional_components:
 #          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
 #          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
 
-source_releases:
+flink_releases:
   -
-      name: "Apache Flink 1.7.2"
-      id: "172-download-source"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-src.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.sha512"
+      version_short: 1.7
+      binary_release:
+          name: "Apache Flink 1.7.2"
+          scala_211:
+              id: "172-download-hadoopfree_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz.sha512"
+          scala_212:
+              id: "172-download-hadoopfree_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz.sha512"
+      source_release:
+          name: "Apache Flink 1.7.2"
+          id: "172-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.sha512"
+      optional_components:
+        -
+          name: "Avro SQL Format"
+          category: "SQL Formats"
+          scala_dependent: false
+          id: 172-sql-format-avro
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.sha1
+        -
+          name: "JSON SQL Format"
+          category: "SQL Formats"
+          scala_dependent: false
+          id: 172-sql-format-json
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.sha1
+      alternative_binaries:
+          -
+              name: "Apache Flink 1.7.2 with Hadoop® 2.8"
+              scala_211:
+                  id: "172-download-hadoop28_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz.sha512"
+              scala_212:
+                  id: "172-download-hadoop28_212"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz.sha512"
+          -
+              name: "Apache Flink 1.7.2 with Hadoop® 2.7"
+              scala_211:
+                  id: "172-download-hadoop27_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz.sha512"
+              scala_212:
+                  id: "172-download-hadoop27_212"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz.sha512"
+          -
+              name: "Apache Flink 1.7.2 with Hadoop® 2.6"
+              scala_211:
+                  id: "172-download-hadoop26_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz.sha512"
+              scala_212:
+                  id: "172-download-hadoop26_212"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz.sha512"
+          -
+              name: "Apache Flink 1.7.2 with Hadoop® 2.4"
+              scala_211:
+                  id: "172-download-hadoop24_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz.sha512"
+              scala_212:
+                  id: "172-download-hadoop24_212"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.12.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.12.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512"
   -
-      name: "Apache Flink 1.6.4"
-      id: "164-download-source"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-src.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz.sha512"
+      version_short: 1.6
+      binary_release:
+          name: "Apache Flink 1.6.4"
+          scala_211:
+              id: "164-download-hadoopfree_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz.sha512"
+      source_release:
+          name: "Apache Flink 1.6.4"
+          id: "164-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz.sha512"
+      alternative_binaries:
+          -
+              name: "Flink 1.6.4 with Hadoop® 2.8"
+              scala_211:
+                  id: "164-download-hadoop28_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.6.4 with Hadoop® 2.7"
+              scala_211:
+                  id: "164-download-hadoop27_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.6.4 with Hadoop® 2.6"
+              scala_211:
+                  id: "164-download-hadoop26_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.6.4 with Hadoop® 2.4"
+              scala_211:
+                  id: "164-download-hadoop24_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz.asc"
   -
-      name: "Apache Flink 1.5.6"
-      id: "156-download-source"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-src.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.sha512"
-  -
-      name: "Apache Flink-shaded 6.0"
-      id: "s60-download-source"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz.sha512"
+      version_short: 1.5
+      binary_release:
+          name: "Apache Flink 1.5.6"
+          scala_211:
+              id: "156-download-hadoopfree_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512"
+      source_release:
+          name: "Apache Flink 1.5.6"
+          id: "156-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.sha512"
+      alternative_binaries:
+          -
+              name: "Flink 1.5.6 with Hadoop® 2.8"
+              scala_211:
+                  id: "156-download-hadoop28_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.5.6 with Hadoop® 2.7"
+              scala_211:
+                  id: "156-download-hadoop27_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.5.6 with Hadoop® 2.6"
+              scala_211:
+                  id: "156-download-hadoop26_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512"
+          -
+              name: "Flink 1.5.6 with Hadoop® 2.4"
+              scala_211:
+                  id: "156-download-hadoop24_211"
+                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz"
+                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc"
+                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512"
 
+component_releases:
+  -
+      source_release:
+          name: "Apache Flink-shaded 6.0"
+          id: "s60-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-shaded-6.0/flink-shaded-6.0-src.tgz.sha512"
 
-stable_releases:
-  -
-      name: "Apache Flink 1.7.2 only"
-      scala_211:
-          id: "172-download-hadoopfree_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.11.tgz.sha512"
-      scala_212:
-          id: "172-download-hadoopfree_212"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-scala_2.12.tgz.sha512"
-  -
-      name: "Apache Flink 1.7.2 with Hadoop® 2.8"
-      scala_211:
-          id: "172-download-hadoop28_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.11.tgz.sha512"
-      scala_212:
-          id: "172-download-hadoop28_212"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz.sha512"
-  -
-      name: "Apache Flink 1.7.2 with Hadoop® 2.7"
-      scala_211:
-          id: "172-download-hadoop27_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.11.tgz.sha512"
-      scala_212:
-          id: "172-download-hadoop27_212"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop27-scala_2.12.tgz.sha512"
-  -
-      name: "Apache Flink 1.7.2 with Hadoop® 2.6"
-      scala_211:
-          id: "172-download-hadoop26_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.11.tgz.sha512"
-      scala_212:
-          id: "172-download-hadoop26_212"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop26-scala_2.12.tgz.sha512"
-  -
-      name: "Apache Flink 1.7.2 with Hadoop® 2.4"
-      scala_211:
-          id: "172-download-hadoop24_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz.sha512"
-      scala_212:
-          id: "172-download-hadoop24_212"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.12.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.12.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.0-bin-hadoop24-scala_2.12.tgz.sha512"
-  -
-      name: "Apache Flink 1.6.4 only"
-      scala_211:
-          id: "164-download-hadoopfree_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.6.4 with Hadoop® 2.8"
-      scala_211:
-          id: "164-download-hadoop28_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop28-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.6.4 with Hadoop® 2.7"
-      scala_211:
-          id: "164-download-hadoop27_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop27-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.6.4 with Hadoop® 2.6"
-      scala_211:
-          id: "164-download-hadoop26_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop26-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.6.4 with Hadoop® 2.4"
-      scala_211:
-          id: "164-download-hadoop24_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz.sha512"
-  -
-      name: "Apache 1.5.6 Flink only"
-      scala_211:
-          id: "156-download-hadoopfree_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.5.6 with Hadoop® 2.8"
-      scala_211:
-          id: "156-download-hadoop28_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.5.6 with Hadoop® 2.7"
-      scala_211:
-          id: "156-download-hadoop27_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.5.6 with Hadoop® 2.6"
-      scala_211:
-          id: "156-download-hadoop26_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512"
-  -
-      name: "Flink 1.5.6 with Hadoop® 2.4"
-      scala_211:
-          id: "156-download-hadoop24_211"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512"
-
-FLINK_DOWNLOAD_URL_HADOOP_2_LATEST: https://s3.amazonaws.com/flink-nightly/flink-1.8-SNAPSHOT-bin-hadoop2.tgz
 
 # Version numbers used in the text for stable and snapshot versions,
 # e.g. "Documentation for {{ site.stable }".

--- a/_config.yml
+++ b/_config.yml
@@ -9,11 +9,11 @@ url: https://flink.apache.org
 
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
-FLINK_VERSION_STABLE: 1.7.2
-FLINK_VERSION_STABLE_SHORT: 1.7
+FLINK_VERSION_STABLE: 1.8.0
+FLINK_VERSION_STABLE_SHORT: 1.8
 
-FLINK_VERSION_LATEST: 1.8-SNAPSHOT
-FLINK_VERSION_LATEST_SHORT: 1.8
+FLINK_VERSION_LATEST: 1.9-SNAPSHOT
+FLINK_VERSION_LATEST_SHORT: 1.9
 
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
 FLINK_GITHUB_URL: https://github.com/apache/flink
@@ -52,6 +52,83 @@ FLINK_GITHUB_REPO_NAME: flink
 #          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
 
 flink_releases:
+  -
+      version_short: 1.8
+      binary_release:
+          name: "Apache Flink 1.8.0"
+          scala_211:
+              id: "180-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.11.tgz.sha512"
+          scala_212:
+              id: "180-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.12.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-bin-scala_2.12.tgz.sha512"
+      source_release:
+          name: "Apache Flink 1.8.0"
+          id: "180-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.0/flink-1.8.0-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz.sha512"
+      optional_components:
+        -
+          name: "Pre-bundled Hadoop 2.4.1"
+          category: "Pre-bundled Hadoop"
+          scala_dependent: false
+          id: 180-bundled-hadoop-241
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.sha1
+        -
+          name: "Pre-bundled Hadoop 2.6.5"
+          category: "Pre-bundled Hadoop"
+          scala_dependent: false
+          id: 180-bundled-hadoop-265
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.sha1
+        -
+          name: "Pre-bundled Hadoop 2.7.5"
+          category: "Pre-bundled Hadoop"
+          scala_dependent: false
+          id: 180-bundled-hadoop-275
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.sha1
+        -
+          name: "Pre-bundled Hadoop 2.8.3"
+          category: "Pre-bundled Hadoop"
+          scala_dependent: false
+          id: 180-bundled-hadoop-283
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.sha1
+        -
+          name: "Avro SQL Format"
+          category: "SQL Formats"
+          scala_dependent: false
+          id: 180-sql-format-avro
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.sha1
+        -
+          name: "CSV SQL Format"
+          category: "SQL Formats"
+          scala_dependent: false
+          id: 180-sql-format-csv
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.sha1
+        -
+          name: "JSON SQL Format"
+          category: "SQL Formats"
+          scala_dependent: false
+          id: 180-sql-format-json
+          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar
+          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.asc
+          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.sha1
   -
       version_short: 1.7
       binary_release:
@@ -181,50 +258,6 @@ flink_releases:
                   id: "164-download-hadoop24_211"
                   url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz"
                   asc_url: "https://www.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-bin-hadoop24-scala_2.11.tgz.asc"
-  -
-      version_short: 1.5
-      binary_release:
-          name: "Apache Flink 1.5.6"
-          scala_211:
-              id: "156-download-hadoopfree_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-scala_2.11.tgz.sha512"
-      source_release:
-          name: "Apache Flink 1.5.6"
-          id: "156-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz.sha512"
-      alternative_binaries:
-          -
-              name: "Flink 1.5.6 with Hadoop® 2.8"
-              scala_211:
-                  id: "156-download-hadoop28_211"
-                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz"
-                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.asc"
-                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop28-scala_2.11.tgz.sha512"
-          -
-              name: "Flink 1.5.6 with Hadoop® 2.7"
-              scala_211:
-                  id: "156-download-hadoop27_211"
-                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz"
-                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.asc"
-                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop27-scala_2.11.tgz.sha512"
-          -
-              name: "Flink 1.5.6 with Hadoop® 2.6"
-              scala_211:
-                  id: "156-download-hadoop26_211"
-                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz"
-                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.asc"
-                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop26-scala_2.11.tgz.sha512"
-          -
-              name: "Flink 1.5.6 with Hadoop® 2.4"
-              scala_211:
-                  id: "156-download-hadoop24_211"
-                  url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz"
-                  asc_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.asc"
-                  sha512_url: "https://www.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-bin-hadoop24-scala_2.11.tgz.sha512"
 
 component_releases:
   -

--- a/downloads.md
+++ b/downloads.md
@@ -18,8 +18,6 @@ $( document ).ready(function() {
 
 {% toc %}
 
-## Latest stable release (v{{ site.FLINK_VERSION_STABLE }})
-
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} is our latest stable release.
 
 An Apache Hadoop installation is [not required](faq.html#how-does-flink-relate-to-the-hadoop-stack) to use Apache Flink.
@@ -27,105 +25,117 @@ For users that use Flink without any Hadoop components, we recommend the release
 
 If you plan to use Apache Flink together with Apache Hadoop (run Flink on YARN, connect to HDFS,
 connect to HBase, or use some Hadoop-based file system connector) then select the download that
-bundles the matching Hadoop version, or use the Hadoop free version and
+bundles the matching Hadoop version, download the optional pre-bundled Hadoop that matches your version and place
+it in the `lib` folder of Flink, or use the Hadoop free version and
 [export your HADOOP_CLASSPATH](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html).
 
-### Binaries
+{% for flink_release in site.flink_releases %}
 
-<table class="table table-striped">
-<thead>
-    <tr>
-    <th></th> <th>Scala 2.11</th> <th>Scala 2.12</th>
-    </tr>
-</thead>
-<tbody>
-    {% for binary_release in site.stable_releases %}
-    <tr>
-    <th>{{ binary_release.name }}</th>
-    {% if binary_release.scala_211 %}
-    <td><a href="{{ binary_release.scala_211.url }}" class="ga-track" id="{{ binary_release.scala_211.id }}">Download</a> (<a href="{{ binary_release.scala_211.asc_url }}">asc</a>, <a href="{{ binary_release.scala_211.sha512_url }}">sha512</a>)</td>
-    {% else %}
-    <td>Not supported.</td>
-    {% endif %}
+## {{ flink_release.binary_release.name }}
 
-    {% if binary_release.scala_212 %}
-    <td><a href="{{ binary_release.scala_212.url }}" class="ga-track" id="{{ binary_release.scala_212.id }}">Download</a> (<a href="{{ binary_release.scala_212.asc_url }}">asc</a>, <a href="{{ binary_release.scala_212.sha512_url }}">sha512</a>)</td>
-    {% else %}
-    <td>Not supported.</td>
-    {% endif %}
-    </tr>
-    {% endfor %}
-</tbody>
-</table>
+{% if flink_release.binary_release.scala_211 %}
 
-### Source
-<p>Review the source code or build Flink on your own, using one of these packages:</p>
+<p>
+<a href="{{ flink_release.binary_release.scala_211.url }}" class="ga-track" id="{{ flink_release.binary_release.scala_211.id }}">{{ flink_release.binary_release.name }} for Scala 2.11</a> (<a href="{{ flink_release.binary_release.scala_211.asc_url }}">asc</a>, <a href="{{ flink_release.binary_release.scala_211.sha512_url }}">sha512</a>)
+</p>
 
-{% for source_release in site.source_releases %}
-<div class="list-group">
-  <!-- Source -->
-  <a href="{{ source_release.url }}" class="list-group-item ga-track" id="{{ source_release.id }}">
-    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
-    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>{{ source_release.name }}</strong> Source Release</h4>
-  </a>
-   (<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
-</div>
-{% endfor %}
+{% endif %}
 
-### Optional components
+{% if flink_release.binary_release.scala_212 %}
 
-{% assign categories = site.optional_components | group_by: 'category' | sort: 'name' %}
-{% for category in categories %}
+<p>
+<a href="{{ flink_release.binary_release.scala_212.url }}" class="ga-track" id="{{ flink_release.binary_release.scala_212.id }}">{{ flink_release.binary_release.name }} for Scala 2.12</a> (<a href="{{ flink_release.binary_release.scala_212.asc_url }}">asc</a>, <a href="{{ flink_release.binary_release.scala_212.sha512_url }}">sha512</a>)
+</p>
 
-<button class="collapsible" data-toggle="collapse" data-target="#{{category.name | slugify}}" aria-hidden="true">{{category.name}}<span class="glyphicon glyphicon-plus" style="float: right; font-size: 20px;"></span></button>
-<div id="{{category.name | slugify}}" class="collapse">
+{% endif %}
 
-{% assign components = category.items | | sort: 'name' %}
+{% if flink_release.source_release %}
+<p>
+<a href="{{ flink_release.source_release.url }}" class="ga-track" id="{{ flink_release.source_release.id }}">{{ flink_release.source_release.name }} Source Release</a>
+(<a href="{{ flink_release.source_release.asc_url }}">asc</a>, <a href="{{ flink_release.source_release.sha512_url }}">sha512</a>)
+</p>
+{% endif %}
+
+{% if flink_release.optional_components %}
+#### Optional components
+
+{% assign components = flink_release.optional_components | | sort: 'name' %}
 {% for component in components %}
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th><strong>{{ component.name }}</strong></th>
-      {% if component.scala_dependent %}
-      <th>Scala 2.11</th>
-      <th>Scala 2.12</th>
-      {% else %}
-      <th></th>
-      {% endif %}
-    </tr>
-  </thead>
-  <tbody>
-    {% for version in component.versions %}
-      <tr>
-        {% if component.scala_dependent %}
-          <td>{{ version.version }}</td>
-          {% if version.scala_211 %}
-            <td><a href="{{ version.scala_211.url }}" class="ga-track" id="{{ version.scala_211.id }}">Download</a> (<a href="{{ version.scala_211.asc_url }}">asc</a>, <a href="{{ version.scala_211.sha512_url }}">sha1</a>)</td>
-          {% else %}
-            <td>Not supported.</td>
-          {% endif %}
-          {% if version.scala_212 %}
-            <td><a href="{{ version.scala_212.url }}" class="ga-track" id="{{ version.scala_212.id }}">Download</a> (<a href="{{ version.scala_212.asc_url }}">asc</a>, <a href="{{ version.scala_212.sha512_url }}">sha1</a>)</td>
-          {% else %}
-            <td>Not supported.</td>
-          {% endif %}
-        {% else %}
-          <td>{{ version.version }}</td>
-          <td><a href="{{ version.url }}" class="ga-track" id="{{ version.id }}">Download</a> (<a href="{{ version.asc_url }}">asc</a>, <a href="{{ version.sha_url }}">sha1</a>)</td>
-        {% endif %}
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
+{% if component.scala_dependent %}
+
+{% if component.scala_211 %}
+<p>
+<a href="{{ component.scala_211.url }}" class="ga-track" id="{{ component.scala_211.id }}">{{ component.name }} for Scala 2.11</a> (<a href="{{ component.scala_211.asc_url }}">asc</a>, <a href="{{ component.scala_211.sha_url }}">sha1</a>)
+</p>
+{% endif %}
+
+{% if component.scala_212 %}
+<p>
+<a href="{{ component.scala_212.url }}" class="ga-track" id="{{ component.scala_212.id }}">{{ component.name }} for Scala 2.12</a> (<a href="{{ component.scala_212.asc_url }}">asc</a>, <a href="{{ component.scala_212.sha_url }}">sha1</a>)
+</p>
+{% endif %}
+
+{% else %}
+<p>
+<a href="{{ component.url }}" class="ga-track" id="{{ component.id }}">{{ component.name }}</a> (<a href="{{ component.asc_url }}">asc</a>, <a href="{{ component.sha_url }}">sha1</a>)
+</p>
+{% endif %}
 
 {% endfor %}
-</div>
+
+{% endif %}
+
+{% if flink_release.alternative_binaries %}
+#### Alternative Binaries
+
+{% assign alternatives = flink_release.alternative_binaries | | sort: 'name' %}
+{% for alternative in alternatives %}
+
+{% if alternative.scala_211 %}
+
+<p>
+<a href="{{ alternative.scala_211.url }}" class="ga-track" id="{{ alternative.scala_211.id }}">{{ alternative.name }} for Scala 2.11</a> (<a href="{{ alternative.scala_211.asc_url }}">asc</a>, <a href="{{ alternative.scala_211.sha_url }}">sha512</a>)
+</p>
+
+{% endif %}
+
+{% if alternative.scala_212 %}
+
+<p>
+<a href="{{ alternative.scala_212.url }}" class="ga-track" id="{{ alternative.scala_212.id }}">{{ alternative.name }} for Scala 2.12</a> (<a href="{{ alternative.scala_212.asc_url }}">asc</a>, <a href="{{ alternative.scala_212.sha_url }}">sha512</a>)
+</p>
+
+{% endif %}
+
 {% endfor %}
 
-## Release Notes
+{% endif %}
 
-Please have a look at the [Release Notes for Flink {{ site.FLINK_VERSION_STABLE_SHORT }}]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ site.FLINK_VERSION_STABLE_SHORT }}/release-notes/flink-{{ site.FLINK_VERSION_STABLE_SHORT }}.html) if you plan to upgrade your Flink setup from a previous version.
+#### Release Notes
+
+Please have a look at the [Release Notes for Flink {{ flink_release.version_short }}]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flink_release.version_short }}.html) if you plan to upgrade your Flink setup from a previous version.
+
+---
+
+{% endfor %}
+
+## Additional Components
+
+These are components that the Flink project develops which are not part of the
+main Flink release:
+
+{% for additional_component in site.component_releases %}
+
+{% if additional_component.source_release %}
+{% assign source_release = additional_component.source_release %}
+<p>
+<a href="{{ source_release.url }}" class="ga-track" id="{{ source_release.id }}">{{ source_release.name }}</a>
+(<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
+</p>
+{% endif %}
+
+{% endfor %}
 
 ## Verifying Hashes and Signatures
 
@@ -221,3 +231,5 @@ All Flink releases are available via [https://archive.apache.org/dist/flink/](ht
 - Flink-shaded 3.0 - 2018-02-28 ([Source](https://archive.apache.org/dist/flink/flink-shaded-3.0/flink-shaded-3.0-src.tgz))
 - Flink-shaded 2.0 - 2017-10-30 ([Source](https://archive.apache.org/dist/flink/flink-shaded-2.0/flink-shaded-2.0-src.tgz))
 - Flink-shaded 1.0 - 2017-07-27 ([Source](https://archive.apache.org/dist/flink/flink-shaded-1.0/flink-shaded-1.0-src.tgz))
+
+

--- a/downloads.md
+++ b/downloads.md
@@ -20,14 +20,13 @@ $( document ).ready(function() {
 
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} is our latest stable release.
 
-An Apache Hadoop installation is [not required](faq.html#how-does-flink-relate-to-the-hadoop-stack) to use Apache Flink.
-For users that use Flink without any Hadoop components, we recommend the release without bundled Hadoop libraries.
-
-If you plan to use Apache Flink together with Apache Hadoop (run Flink on YARN, connect to HDFS,
-connect to HBase, or use some Hadoop-based file system connector) then select the download that
-bundles the matching Hadoop version, download the optional pre-bundled Hadoop that matches your version and place
-it in the `lib` folder of Flink, or use the Hadoop free version and
-[export your HADOOP_CLASSPATH](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html).
+If you plan to use Apache Flink together with Apache Hadoop (run Flink
+on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
+file system connector) then select the download that bundles the
+matching Hadoop version, download the optional pre-bundled Hadoop that
+matches your version and place it in the `lib` folder of Flink, or
+[export your
+HADOOP_CLASSPATH](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html).
 
 {% for flink_release in site.flink_releases %}
 

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -18,110 +18,135 @@ $( document ).ready(function() {
 
 {% toc %}
 
-## 最新稳定版 (v{{ site.FLINK_VERSION_STABLE }})
-
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} 是我们最新的稳定版本。
 
-使用 Apache Flink [不需要](faq.html#how-does-flink-relate-to-the-hadoop-stack)安装 Apache Hadoop。对于使用 Flink 而没有用到任何 Hadoop 组件的用户，我们建议使用不包含 Hadoop 库的包。
+如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
+Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的下载包，且另外下載对应版本的 Hadoop 库，并且把下载后的 Hadoop 库放置
+到 Flink 安装目录下的 lib 目录
+包并[设置 HADOOP_CLASSPATH 环境变量](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html)。
 
-如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于 Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的下载包，或使用不带 Hadoop 版本的包并[设置 HADOOP_CLASSPATH 环境变量](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html)。
+{% for flink_release in site.flink_releases %}
 
-### 二进制包
+## {{ flink_release.binary_release.name }}
 
-<table class="table table-striped">
-<thead>
-    <tr>
-    <th></th> <th>Scala 2.11</th> <th>Scala 2.12</th>
-    </tr>
-</thead>
-<tbody>
-    {% for binary_release in site.stable_releases %}
-    <tr>
-    <th>{{ binary_release.name }}</th>
-    {% if binary_release.scala_211 %}
-    <td><a href="{{ binary_release.scala_211.url }}" class="ga-track" id="{{ binary_release.scala_211.id }}">Download</a> (<a href="{{ binary_release.scala_211.asc_url }}">asc</a>, <a href="{{ binary_release.scala_211.sha512_url }}">sha512</a>)</td>
-    {% else %}
-    <td>Not supported.</td>
-    {% endif %}
+{% if flink_release.binary_release.scala_211 %}
 
-    {% if binary_release.scala_212 %}
-    <td><a href="{{ binary_release.scala_212.url }}" class="ga-track" id="{{ binary_release.scala_212.id }}">Download</a> (<a href="{{ binary_release.scala_212.asc_url }}">asc</a>, <a href="{{ binary_release.scala_212.sha512_url }}">sha512</a>)</td>
-    {% else %}
-    <td>Not supported.</td>
-    {% endif %}
-    </tr>
-    {% endfor %}
-</tbody>
-</table>
+<p>
+<a href="{{ flink_release.binary_release.scala_211.url }}" class="ga-track" id="{{
+ flink_release.binary_release.scala_211.id }}">{{ flink_release.binary_release.name }} for Scala 2.11</a> (<a href="
+ {{ flink_release.binary_release.scala_211.asc_url }}">asc</a>, <a href="{{
+ flink_release.binary_release.scala_211.sha512_url }}">sha512</a>)
+</p>
 
-### 源码包
-<p>使用以下任一软件包查看源代码或自行构建 Flink：</p>
+{% endif %}
 
-{% for source_release in site.source_releases %}
-<div class="list-group">
-  <!-- Source -->
-  <a href="{{ source_release.url }}" class="list-group-item ga-track" id="{{ source_release.id }}">
-    <!-- overrride margin/padding as the boxes otherwise overlap in subtle ways -->
-    <h4 style="margin-top: 0px; padding-top: 0px;"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> <strong>{{ source_release.name }}</strong> Source Release</h4>
-  </a>
-   (<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
-</div>
-{% endfor %}
+{% if flink_release.binary_release.scala_212 %}
 
+<p>
+<a href="{{ flink_release.binary_release.scala_212.url }}" class="ga-track" id="{{
+ flink_release.binary_release.scala_212.id }}">{{ flink_release.binary_release.name }} for Scala 2.12</a> (<a href="
+ {{ flink_release.binary_release.scala_212.asc_url }}">asc</a>, <a href="{{
+ flink_release.binary_release.scala_212.sha512_url }}">sha512</a>)
+</p>
+
+{% endif %}
+
+{% if flink_release.source_release %}
+<p>
+<a href="{{ flink_release.source_release.url }}" class="ga-track" id="{{
+ flink_release.source_release.id }}">{{ flink_release.source_release.name }} Source Release</a>
+ (<a href="{{ flink_release.source_release.asc_url }}">asc</a>, <a href="{{
+ flink_release.source_release.sha512_url }}">sha512</a>)
+</p>
+{% endif %}
+
+{% if flink_release.optional_components %}
 ### 可选组件
 
-{% assign categories = site.optional_components | group_by: 'category' | sort: 'name' %}
-{% for category in categories %}
-
-<button class="collapsible" data-toggle="collapse" data-target="#{{category.name | slugify}}" aria-hidden="true">{{category.name}}<span class="glyphicon glyphicon-plus" style="float: right; font-size: 20px;"></span></button>
-<div id="{{category.name | slugify}}" class="collapse">
-
-{% assign components = category.items | | sort: 'name' %}
+{% assign components = flink_release.optional_components | | sort: 'name' %}
 {% for component in components %}
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th><strong>{{ component.name }}</strong></th>
-      {% if component.scala_dependent %}
-      <th>Scala 2.11</th>
-      <th>Scala 2.12</th>
-      {% else %}
-      <th></th>
-      {% endif %}
-    </tr>
-  </thead>
-  <tbody>
-    {% for version in component.versions %}
-      <tr>
-        {% if component.scala_dependent %}
-          <td>{{ version.version }}</td>
-          {% if version.scala_211 %}
-            <td><a href="{{ version.scala_211.url }}" class="ga-track" id="{{ version.scala_211.id }}">Download</a> (<a href="{{ version.scala_211.asc_url }}">asc</a>, <a href="{{ version.scala_211.sha512_url }}">sha1</a>)</td>
-          {% else %}
-            <td>Not supported.</td>
-          {% endif %}
-          {% if version.scala_212 %}
-            <td><a href="{{ version.scala_212.url }}" class="ga-track" id="{{ version.scala_212.id }}">Download</a> (<a href="{{ version.scala_212.asc_url }}">asc</a>, <a href="{{ version.scala_212.sha512_url }}">sha1</a>)</td>
-          {% else %}
-            <td>Not supported.</td>
-          {% endif %}
-        {% else %}
-          <td>{{ version.version }}</td>
-          <td><a href="{{ version.url }}" class="ga-track" id="{{ version.id }}">Download</a> (<a href="{{ version.asc_url }}">asc</a>, <a href="{{ version.sha_url }}">sha1</a>)</td>
-        {% endif %}
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
+{% if component.scala_dependent %}
+
+{% if component.scala_211 %}
+<p>
+<a href="{{ component.scala_211.url }}" class="ga-track" id="{{
+ component.scala_211.id }}">{{ component.name }} for Scala 2.11</a> (<a href="{{
+ component.scala_211.asc_url }}">asc</a>, <a href="{{ component.scala_211.sha_url }}">sha1</a>)
+</p>
+{% endif %}
+
+{% if component.scala_212 %}
+<p>
+<a href="{{ component.scala_212.url }}" class="ga-track" id="{{
+ component.scala_212.id }}">{{ component.name }} for Scala 2.12</a> (<a href="{{
+ component.scala_212.asc_url }}">asc</a>, <a href="{{ component.scala_212.sha_url }}">sha1</a>)
+</p>
+{% endif %}
+
+{% else %}
+<p>
+<a href="{{ component.url }}" class="ga-track" id="{{
+ component.id }}">{{ component.name }}</a> (<a href="{{ component.asc_url }}">asc</a>, <a href="{{ component.sha_url }}">sha1</a>)
+</p>
+{% endif %}
 
 {% endfor %}
-</div>
+
+{% endif %}
+
+{% if flink_release.alternative_binaries %}
+### 其他替代执行包
+
+{% assign alternatives = flink_release.alternative_binaries | | sort: 'name' %}
+{% for alternative in alternatives %}
+
+{% if alternative.scala_211 %}
+
+<p>
+<a href="{{ alternative.scala_211.url }}" class="ga-track" id="{{
+ alternative.scala_211.id }}">{{ alternative.name }} for Scala 2.11</a> (<a href="{{
+ alternative.scala_211.asc_url }}">asc</a>, <a href="{{ alternative.scala_211.sha_url }}">sha512</a>)
+</p>
+
+{% endif %}
+
+{% if alternative.scala_212 %}
+
+<p>
+<a href="{{ alternative.scala_212.url }}" class="ga-track" id="{{
+ alternative.scala_212.id }}">{{ alternative.name }} for Scala 2.12</a> (<a href="{{
+ alternative.scala_212.asc_url }}">asc</a>, <a href="{{ alternative.scala_212.sha_url }}">sha512</a>)
+</p>
+
+{% endif %}
+
 {% endfor %}
+
+{% endif %}
 
 ## 发布说明
 
-如果你计划从以前的版本升级 Flink，请查看 [Flink {{ site.FLINK_VERSION_STABLE_SHORT }} 的发布说明]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ site.FLINK_VERSION_STABLE_SHORT }}/release-notes/flink-{{ site.FLINK_VERSION_STABLE_SHORT }}.html)。
+如果你计划从以前的版本升级 Flink，请查看 [Flink {{ site.FLINK_VERSION_STABLE_SHORT }} 的发布说明]({{ site.DOCS_BASE_URL }}
+flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flink_release.version_short }}.html)。
+
+{% endfor %}
+
+## 额外组件
+
+其他不包含在 Flink 的主要发布的组件如下所示：
+
+{% for additional_component in site.component_releases %}
+
+{% if additional_component.source_release %}
+{% assign source_release = additional_component.source_release %}
+<p>
+<a href="{{ source_release.url }}" class="ga-track" id="{{ source_release.id }}">{{ source_release.name }}</a>
+(<a href="{{ source_release.asc_url }}">asc</a>, <a href="{{ source_release.sha512_url }}">sha512</a>)
+</p>
+{% endif %}
+
+{% endfor %}
 
 ## 验证哈希和签名
 


### PR DESCRIPTION
This PR does two things:

1. Refactor/reshuffle the Downloads page
2. Add download links for Flink 1.8

The first one is a bit of a bigger change. What I try to achieve with the change is to make everything there is for one release available in one place and easily discoverable. The previous version had a header `Latest stable release (v1.7.2)`, which contains all past binary releases, not just 1.7.2, where you have to hunt for your version in a Table. If you wanted to get the additional SQL components you had to be aware that they existed, scroll past the source release section, expand the optional components section and then hunt for the component that corresponds to your release.

With this change, the optional components are right with the binary release and clearly visible, same for the optional pre-bundled Hadoop.

For comparison, you can look at the current downloads page: https://flink.apache.org/downloads.html and these screenshots of the change:
<img width="2032" alt="screenshot 2019-03-01 at 10 44 02" src="https://user-images.githubusercontent.com/68551/53630878-706fda80-3c11-11e9-846e-1ab34c9a3460.png">
<img width="2032" alt="screenshot 2019-03-01 at 10 44 11" src="https://user-images.githubusercontent.com/68551/53630887-7665bb80-3c11-11e9-932b-22b80be07763.png">
<img width="2032" alt="screenshot 2019-03-01 at 10 44 16" src="https://user-images.githubusercontent.com/68551/53630893-7a91d900-3c11-11e9-943f-e12d1061a93b.png">

