### PR TITLE
Add FFSF preview blog post.

### DIFF
--- a/_posts/2019-03-04-ffsf-preview.md
+++ b/_posts/2019-03-04-ffsf-preview.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: "What to expect from Flink Forward San Francisco 2019"
+date: 2019-03-04T11:00:00.000Z
+authors:
+- fabian:
+  name: "Fabian Hueske"
+  twitter: "fhueske"
+
+excerpt: The third annual Flink Forward conference in San Francisco is just a few weeks away. Let's see what Flink Forward SF 2019 has in store for the Apache Flink and stream processing communities. This post covers some of its highlights!
+categories: news
+---
+
+The third annual Flink Forward San Francisco is just a few weeks away! As always, the Flink Forward will be the right place to meet and mingle with experienced Flink users, contributors, and committers. Attendees will hear and chat about the latest developments around Flink and learn from technical deep-dive sessions and exciting use cases that were put into production with Flink. The event will take place on April 1-2, 2019 at Hotel Nikko in San Francisco. The [program committee](https://sf-2019.flink-forward.org/program-committee) assembled an amazing [lineup of speakers](https://sf-2019.flink-forward.org/speakers) who will cover many different aspects of Apache Flink and stream processing. 
+
+Some highlights of the program are:
+
+* [Realtime Store Visit Predictions at Scale](https://sf-2019.flink-forward.org/conference-program#realtime-store-visit-predictions-at-scale): Luca Giovagnoli from *Yelp* will talk about a "multidisciplinary" Flink application that combines geospatial clustering algorithms, Machine Learning models, and cutting-edge stream-processing technology.
+
+* [Real-time Processing with Flink for Machine Learning at Netflix](https://sf-2019.flink-forward.org/conference-program#real-time-processing-with-flink-for-machine-learning-at-netflix): Elliot Chow will discuss the practical aspects of using Apache Flink to power Machine Learning algorithms for video recommendations, search results ranking, and selection of artwork images at *Netflix*.
+
+* [Building production Flink jobs with Airstream at Airbnb](https://sf-2019.flink-forward.org/conference-program#building-production-flink-jobs-with-airstream-at-airbnb): Pala Muthiah and Hao Wang will reveal how *Airbnb* builds real time data pipelines with Airstream, Airbnb's computation framework that is powered by Flink SQL.
+
+* [When Table meets AI: Build Flink AI Ecosystem on Table API](https://sf-2019.flink-forward.org/conference-program#when-table-meets-ai--build-flink-ai-ecosystem-on-table-api): Weihua Jiang from *Alibaba* will discuss how they are building a solid AI ecosystem for unified batch/streaming Machine Learning data pipelines on top of Flink's Table API.
+
+* [Adventures in Scaling from Zero to 5 Billion Data Points per Day](https://sf-2019.flink-forward.org/conference-program#adventures-in-scaling-from-zero-to-5-billion-data-points-per-day): Dave Torok will take us through *Comcast's* journey in scaling the company's operationalized Machine Learning framework from the very early days in production to processing more than 5 billion data points per day.
+
+If you're new to Apache Flink or want to deepen your knowledge around the framework, Flink Forward features again a full day of training. 
+
+You can choose from 3 training tracks:
+
+* [Introduction to Streaming with Apache Flink](https://sf-2019.flink-forward.org/training-program#introduction-to-streaming-with-apache-flink): A hands-on, in-depth introduction to stream processing and Apache Flink, this course emphasizes those features of Flink that make it easy to build and manage accurate, fault tolerant applications on streams.
+
+* [Analyzing Streaming Data with Flink SQL](https://sf-2019.flink-forward.org/training-program#analyzing-streaming-data-with-flink-sql): In this hands-on training, you will learn what it means to run SQL queries on data streams and how to fully leverage the potential of SQL on Flink. We'll also cover some of the more recent features such as time-versioned joins and the MATCH RECOGNIZE clause.
+
+* [Troubleshooting and Operating Flink at large scale](https://sf-2019.flink-forward.org/training-program#apache-flink-troubleshooting---operations): In this training, we will focus on everything you need to run Apache Flink applications reliably and efficiently in production including topics like capacity planning, monitoring, troubleshooting and tuning Apache Flink.
+
+If you haven't done so yet, check out the [full schedule](http://sf-2019.flink-forward.org/conference-program) and [register](https://sf-2019.flink-forward.org/register) your attendance. <br>
+I'm looking forward to meet you at Flink Forward San Francisco.
+
+*Fabian*


### PR DESCRIPTION
I wrote a short blog post about the highlights of the upcoming Flink Forward San Francisco conference.
Would be great to publish this in the next days.

Thanks, Fabian