### PR TITLE
[FLINK-12128][website]Fix a typo in roadmap.md

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -102,7 +102,7 @@ widely-used batch processors, there are some ongoing efforts to make sure this t
     intermediate results for better resource efficiency on systems like Yarn.
     [FLIP-31](https://cwiki.apache.org/confluence/display/FLINK/FLIP-31%3A+Pluggable+Shuffle+Manager).
 
-Various of these enhancements can be taken form the contributed code from the
+Various of these enhancements can be taken from the contributed code from the
 [Blink fork](https://github.com/apache/flink/tree/blink).
 
 To exploit the above optimizations for bounded streams in the DataStream API, we need

--- a/roadmap.zh.md
+++ b/roadmap.zh.md
@@ -102,7 +102,7 @@ widely-used batch processors, there are some ongoing efforts to make sure this t
     intermediate results for better resource efficiency on systems like Yarn.
     [FLIP-31](https://cwiki.apache.org/confluence/display/FLINK/FLIP-31%3A+Pluggable+Shuffle+Manager).
 
-Various of these enhancements can be taken form the contributed code from the
+Various of these enhancements can be taken from the contributed code from the
 [Blink fork](https://github.com/apache/flink/tree/blink).
 
 To exploit the above optimizations for bounded streams in the DataStream API, we need


### PR DESCRIPTION
Fix a typo in roadmap.md. See [FLINK-12128](https://issues.apache.org/jira/browse/FLINK-12128)