### PR TITLE
[FLINK-12157] Use maven central links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,26 +30,26 @@ FLINK_GITHUB_REPO_NAME: flink
 #        version: "1.7.1"
 #        scala_211:
 #          id: 171-prometheus-211
-#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
-#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
-#          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
+#          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
+#          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
+#          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
 #        scala_212:
 #          id: 171-prometheus-212
-#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
-#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
-#          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
+#          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
+#          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
+#          md1_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
 #      -
 #        version: "1.6.1"
 #        scala_211:
 #          id: 171-prometheus-211
-#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
-#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
-#          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
+#          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar
+#          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.asc
+#          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.11/1.7.1/flink-metrics-prometheus_2.11-1.7.1.jar.sha1
 #        scala_212:
 #          id: 171-prometheus-212
-#          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
-#          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
-#          md1_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
+#          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar
+#          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.asc
+#          md1_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-metrics-prometheus_2.12/1.7.1/flink-metrics-prometheus_2.12-1.7.1.jar.sha1
 
 flink_releases:
   -
@@ -78,57 +78,57 @@ flink_releases:
           category: "Pre-bundled Hadoop"
           scala_dependent: false
           id: 180-bundled-hadoop-241
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.4.1-1.8.0/flink-shaded-hadoop2-uber-2.4.1-1.8.0.jar.sha1
         -
           name: "Pre-bundled Hadoop 2.6.5"
           category: "Pre-bundled Hadoop"
           scala_dependent: false
           id: 180-bundled-hadoop-265
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.6.5-1.8.0/flink-shaded-hadoop2-uber-2.6.5-1.8.0.jar.sha1
         -
           name: "Pre-bundled Hadoop 2.7.5"
           category: "Pre-bundled Hadoop"
           scala_dependent: false
           id: 180-bundled-hadoop-275
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.7.5-1.8.0/flink-shaded-hadoop2-uber-2.7.5-1.8.0.jar.sha1
         -
           name: "Pre-bundled Hadoop 2.8.3"
           category: "Pre-bundled Hadoop"
           scala_dependent: false
           id: 180-bundled-hadoop-283
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/2.8.3-1.8.0/flink-shaded-hadoop2-uber-2.8.3-1.8.0.jar.sha1
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 180-sql-format-avro
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.0/flink-avro-1.8.0.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 180-sql-format-csv
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.0/flink-csv-1.8.0.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 180-sql-format-json
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.0/flink-json-1.8.0.jar.sha1
   -
       version_short: 1.7
       binary_release:
@@ -155,17 +155,17 @@ flink_releases:
           category: "SQL Formats"
           scala_dependent: false
           id: 172-sql-format-avro
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 172-sql-format-json
-          url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar
-          asc_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.asc
-          sha_url: https://repository.apache.org/content/groups/public/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.sha1
       alternative_binaries:
           -
               name: "Apache Flink 1.7.2 with Hadoop® 2.8"


### PR DESCRIPTION
Updates maven artifact links since we're not allowed to point to `repository.apache.org`.
I got this URL from https://central.sonatype.org/pages/consumers.html.

Someone else needs to regenerate the docs since I'm currently not able to do so.