### PR TITLE
Fix link of language switch is broken in blog page

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -67,7 +67,7 @@
             <li{% if page.url contains '/gettinghelp.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/gettinghelp.html">{{ site.data.i18n[page.language].getting_help }}</a></li>
 
             <!-- Blog -->
-            <li{% if page.url contains '/blog/' or page.url contains '/news/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/blog/"><b>{{ site.data.i18n[page.language].flink_blog }}</b></a></li>
+            <li{% if page.url contains '/blog/' or page.url contains '/news/' or page.url contains '/features/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/blog/"><b>{{ site.data.i18n[page.language].flink_blog }}</b></a></li>
 
             &nbsp;
 
@@ -92,7 +92,7 @@
             <!-- Language Switcher -->
             <li>
               {% if page.is_default_language %}
-                {% if page.url contains '/blog/' %}
+                {% if page.url contains '/blog/' or page.url contains '/news/' or page.url contains '/features/' %}
                   <!-- link to the Chinese home page when current is blog page -->
                   <a href="{{ site.baseurl }}/zh">中文版</a>
                 {% else %} 


### PR DESCRIPTION
The link of language switch in blog page should link to homepage of Chinese version, otherwise, the URL is 404 not found.