### PR TITLE
[hotfix] Rebrand data Artisans to Ververica

### DIFF
--- a/community.md
+++ b/community.md
@@ -164,7 +164,7 @@ There are plenty of meetups on [meetup.com](http://www.meetup.com/topics/apache-
 
 ## Training
 
-[dataArtisans](http://data-artisans.com) currently maintains free Apache Flink training. Their [training website](http://training.data-artisans.com/) has slides and exercises with solutions. The slides are also available on [SlideShare](http://www.slideshare.net/dataArtisans/presentations).
+[Ververica](http://ververica.com) currently maintains free Apache Flink training. Their [training website](http://training.ververica.com/) has slides and exercises with solutions. The slides are also available on [SlideShare](http://www.slideshare.net/dataArtisans/presentations).
 
 ## Project Wiki
 

--- a/poweredby.md
+++ b/poweredby.md
@@ -17,7 +17,7 @@ If you would you like to be included on this page, please reach out to the [Flin
 <div class="row-fluid">
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/alibaba-logo.png" alt="Alibaba" /><br />
-      Alibaba, the world's largest retailer, uses a fork of Flink called Blink to optimize search rankings in real time. <br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Flink's role at Alibaba</a>
+      Alibaba, the world's largest retailer, uses a fork of Flink called Blink to optimize search rankings in real time. <br><br><a href="https://ververica.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Flink's role at Alibaba</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/aws-logo.png" alt="AWS" /><br />
@@ -45,7 +45,7 @@ If you would you like to be included on this page, please reach out to the [Flin
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/dtrb-logo.png" alt="Drivetribe" /><br />
-      Drivetribe, a digital community founded by the former hosts of “Top Gear”, uses Flink for metrics and content recommendations. <br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about Flink in the Drivetribe stack</a>
+      Drivetribe, a digital community founded by the former hosts of “Top Gear”, uses Flink for metrics and content recommendations. <br><br><a href="https://ververica.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about Flink in the Drivetribe stack</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ebay-logo.png" alt="Ebay" /><br />
@@ -101,7 +101,7 @@ If you would you like to be included on this page, please reach out to the [Flin
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/yelp-logo.png" alt="Yelp" /><br />
-      Yelp utilizes Flink to power its data connectors ecosystem and stream processing infrastructure. <br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Find out more watching a Flink Forward talk</a>
+      Yelp utilizes Flink to power its data connectors ecosystem and stream processing infrastructure. <br><br><a href="https://ververica.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Find out more watching a Flink Forward talk</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/zalando-logo.jpg" alt="Zalando" /><br />

--- a/poweredby.zh.md
+++ b/poweredby.zh.md
@@ -17,7 +17,7 @@ Apache Flink 为全球许多公司和企业的关键业务提供支持。在这�
 <div class="row-fluid">
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/alibaba-logo.png" alt="Alibaba" /><br />
-      全球最大的零售商阿里巴巴（Alibaba）使用 Flink 的分支版本 Blink 来优化实时搜索排名。<br><br><a href="https://data-artisans.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多有关 Flink 在阿里巴巴扮演角色的信息</a>
+      全球最大的零售商阿里巴巴（Alibaba）使用 Flink 的分支版本 Blink 来优化实时搜索排名。<br><br><a href="https://ververica.com/blog/blink-flink-alibaba-search" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读更多有关 Flink 在阿里巴巴扮演角色的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/aws-logo.png" alt="AWS" /><br />
@@ -45,7 +45,7 @@ Apache Flink 为全球许多公司和企业的关键业务提供支持。在这�
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/dtrb-logo.png" alt="Drivetribe" /><br />
-     Drivetribe是由前“Top Gear”主持人创建的数字社区，它使用 Flink 作为指标和内容推荐。<br><br><a href="https://data-artisans.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解 Flink 在 Drivetribe stack 的应用</a>
+     Drivetribe是由前“Top Gear”主持人创建的数字社区，它使用 Flink 作为指标和内容推荐。<br><br><a href="https://ververica.com/drivetribe-cqrs-apache-flink/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解 Flink 在 Drivetribe stack 的应用</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/ebay-logo.png" alt="Ebay" /><br />
@@ -101,7 +101,7 @@ Apache Flink 为全球许多公司和企业的关键业务提供支持。在这�
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/yelp-logo.png" alt="Yelp" /><br />
-      Yelp 利用 Flink 为其数据连接器生态系统和流处理基础架构提供支持。<br><br><a href="https://data-artisans.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 Flink Forward 上的演讲</a>
+      Yelp 利用 Flink 为其数据连接器生态系统和流处理基础架构提供支持。<br><br><a href="https://ververica.com/flink-forward/resources/powering-yelps-data-pipeline-infrastructure-with-apache-flink" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 请参阅 Flink Forward 上的演讲</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/zalando-logo.jpg" alt="Zalando" /><br />

--- a/usecases.md
+++ b/usecases.md
@@ -100,6 +100,6 @@ Many common data transformation or enrichment tasks can be addressed by Flink's 
 
 ### What are typical data pipeline applications?
 
-* <a href="https://data-artisans.com/blog/blink-flink-alibaba-search">Real-time search index building</a> in e-commerce
+* <a href="https://ververica.com/blog/blink-flink-alibaba-search">Real-time search index building</a> in e-commerce
 * <a href="https://jobs.zalando.com/tech/blog/apache-showdown-flink-vs.-spark/">Continuous ETL</a> in e-commerce 
 

--- a/usecases.zh.md
+++ b/usecases.zh.md
@@ -100,5 +100,5 @@ Flink 为持续流式分析和批量分析都提供了良好的支持。具体�
 
 ### 典型的数据管道应用实例
 
-* 电子商务中的<a href="https://data-artisans.com/blog/blink-flink-alibaba-search">实时查询索引构建</a>
+* 电子商务中的<a href="https://ververica.com/blog/blink-flink-alibaba-search">实时查询索引构建</a>
 * 电子商务中的<a href="https://jobs.zalando.com/tech/blog/apache-showdown-flink-vs.-spark/">持续 ETL</a>


### PR DESCRIPTION
Change dA training website to ververica. 

* Slide share is still dataArtisans
* The zh page already points to ververica  