### PR TITLE
 [FLINK-13342] Update master documentation link to say "master"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,6 @@ DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 FLINK_VERSION_STABLE: 1.8.1
 FLINK_VERSION_STABLE_SHORT: 1.8
 
-FLINK_VERSION_LATEST: 1.9-SNAPSHOT
-FLINK_VERSION_LATEST_SHORT: 1.9
-
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
 FLINK_GITHUB_URL: https://github.com/apache/flink
 FLINK_CONTRIBUTORS_URL: https://cwiki.apache.org/confluence/display/FLINK/List+of+contributors

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -73,7 +73,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ site.data.i18n[page.language].documentation }}<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="{{ site.docs-stable }}" target="_blank">{{site.FLINK_VERSION_STABLE_SHORT}} (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="{{ site.docs-snapshot }}" target="_blank">{{site.FLINK_VERSION_LATEST_SHORT}} (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ site.docs-snapshot }}" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/community.html
+++ b/content/community.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/code-style-and-quality.html
+++ b/content/contributing/code-style-and-quality.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/faq.html
+++ b/content/faq.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/material.html
+++ b/content/material.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/project.html
+++ b/content/project.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 
@@ -180,7 +180,7 @@ under the License.
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#analytics-applications-an-the-roles-of-datastream-dataset-and-table-api" id="markdown-toc-analytics-applications-an-the-roles-of-datastream-dataset-and-table-api">Analytics, Applications, an the roles of DataStream, DataSet, and Table API</a></li>
+  <li><a href="#analytics-applications-and-the-roles-of-datastream-dataset-and-table-api" id="markdown-toc-analytics-applications-and-the-roles-of-datastream-dataset-and-table-api">Analytics, Applications, and the roles of DataStream, DataSet, and Table API</a></li>
   <li><a href="#batch-and-streaming-unification" id="markdown-toc-batch-and-streaming-unification">Batch and Streaming Unification</a></li>
   <li><a href="#fast-batch-bounded-streams" id="markdown-toc-fast-batch-bounded-streams">Fast Batch (Bounded Streams)</a></li>
   <li><a href="#stream-processing-use-cases" id="markdown-toc-stream-processing-use-cases">Stream Processing Use Cases</a></li>
@@ -202,7 +202,7 @@ there is consensus that they will happen and what they will roughly look like fo
 
 <p><strong>Last Update:</strong> 2019-05-08</p>
 
-<h1 id="analytics-applications-an-the-roles-of-datastream-dataset-and-table-api">Analytics, Applications, an the roles of DataStream, DataSet, and Table API</h1>
+<h1 id="analytics-applications-and-the-roles-of-datastream-dataset-and-table-api">Analytics, Applications, and the roles of DataStream, DataSet, and Table API</h1>
 
 <p>Flink views stream processing as a <a href="/flink-architecture.html">unifying paradigm for data processing</a>
 (batch and real-time) and event-driven applications. The APIs are evolving to reflect that view:</p>

--- a/content/slides.html
+++ b/content/slides.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/code-style-and-quality.html
+++ b/content/zh/contributing/code-style-and-quality.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/faq.html
+++ b/content/zh/faq.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -108,7 +108,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -96,7 +96,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">文档<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8" target="_blank">1.8 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">1.9 (Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 


### PR DESCRIPTION
At least one user was confused by the fact that during releases the "master" documentation does point to the wrong snapshot, see description in the issue.