### PR TITLE
[hotfix] Fix formatting in Code style formatting

### DIFF
--- a/contributing/code-style-and-quality-formatting.md
+++ b/contributing/code-style-and-quality-formatting.md
@@ -53,20 +53,24 @@ We are aware that spaces are a bit nicer; it just happened to be that we started
 In general long lines should be avoided for the better readability. Try to use short statements which operate on the same level of abstraction. Break the long statements by creating more local variables, defining helper functions etc.
 
 Two major sources of long lines are:
- * Long list of arguments in function declaration or call: <code>void func(type1 arg1, type2 arg2, ...)</code>
- * Long sequence of chained calls: <code>list.stream().map(...).reduce(...).collect(...)...</code>
+
+* Long list of arguments in function declaration or call: `void func(type1 arg1, type2 arg2, ...)`
+* Long sequence of chained calls: `list.stream().map(...).reduce(...).collect(...)...`
 
 Rules about breaking the long lines:
- * Break the argument list or chain of calls if the line exceeds limit or earlier if you believe that the breaking would improve the code readability
- * If you break the line then each argument/call should have a separate line, including the first one
- * Each new line should have one extra indentation (or two for a function declaration) relative to the line of the parent function name or the called entity
+
+* Break the argument list or chain of calls if the line exceeds limit or earlier if you believe that the breaking would improve the code readability
+* If you break the line then each argument/call should have a separate line, including the first one
+* Each new line should have one extra indentation (or two for a function declaration) relative to the line of the parent function name or the called entity
 
 Additionally for function arguments:
- * The opening parenthesis always stays on the line of the parent function name
- * The possible thrown exception list is never broken and stays on the same last line, even if the line length exceeds its limit
- * The line of the function argument should end with a comma staying on the same line except the last argument
+
+* The opening parenthesis always stays on the line of the parent function name
+* The possible thrown exception list is never broken and stays on the same last line, even if the line length exceeds its limit
+* The line of the function argument should end with a comma staying on the same line except the last argument
 
 Example of breaking the list of function arguments:
+
 ```
 public void func(
     int arg1,
@@ -78,14 +82,14 @@ public void func(
 
 The dot of a chained call is always on the line of that chained call proceeding the call at the beginning.
 
-Example of breaking the list of chaind calls:
+Example of breaking the list of chained calls:
+
 ```
 values
     .stream()
     .map(...)
     .collect(...);
 ```
-
 
 ### Braces
 

--- a/contributing/code-style-and-quality-formatting.zh.md
+++ b/contributing/code-style-and-quality-formatting.zh.md
@@ -53,38 +53,43 @@ We are aware that spaces are a bit nicer; it just happened to be that we started
 In general long lines should be avoided for the better readability. Try to use short statements which operate on the same level of abstraction. Break the long statements by creating more local variables, defining helper functions etc.
 
 Two major sources of long lines are:
- * Long list of arguments in function declaration or call: <code>void func(type1 arg1, type2 arg2, ...)</code>
- * Long sequence of chained calls: <code>list.stream().map(...).reduce(...).collect(...)...</code>
+
+* Long list of arguments in function declaration or call: `void func(type1 arg1, type2 arg2, ...)`
+* Long sequence of chained calls: `list.stream().map(...).reduce(...).collect(...)...`
 
 Rules about breaking the long lines:
- * Break the argument list or chain of calls if the line exceeds limit or earlier if you believe that the breaking would improve the code readability
- * If you break the line then each argument/call should have a separate line, including the first one
- * Each new line should have one extra indentation (or two for a function declaration) relative to the line of the parent function name or the called entity
+
+* Break the argument list or chain of calls if the line exceeds limit or earlier if you believe that the breaking would improve the code readability
+* If you break the line then each argument/call should have a separate line, including the first one
+* Each new line should have one extra indentation (or two for a function declaration) relative to the line of the parent function name or the called entity
 
 Additionally for function arguments:
- * The opening parenthesis always stays on the line of the parent function name
- * The possible thrown exception list is never broken and stays on the same last line, even if the line length exceeds its limit
- * The line of the function argument should end with a comma staying on the same line except the last argument
+
+* The opening parenthesis always stays on the line of the parent function name
+* The possible thrown exception list is never broken and stays on the same last line, even if the line length exceeds its limit
+* The line of the function argument should end with a comma staying on the same line except the last argument
 
 Example of breaking the list of function arguments:
+
 ```
 public void func(
     int arg1,
     int arg2,
     ...) throws E1, E2, E3 {
- }
+
+}
 ```
 
 The dot of a chained call is always on the line of that chained call proceeding the call at the beginning.
 
-Example of breaking the list of chaind calls:
+Example of breaking the list of chained calls:
+
 ```
 values
     .stream()
     .map(...)
     .collect(...);
 ```
-
 
 ### Braces
 


### PR DESCRIPTION
This is an attempt to fix formatting in the website for "Apache Flink Code Style and Quality Guide — Formatting" section:

![flink apache org_contributing_code-style-and-quality-formatting html](https://user-images.githubusercontent.com/488251/64029145-4a85ad00-cb44-11e9-8011-743c2c47284d.png)

Screenshot with changes applied:

![localhost_4000_contributing_code-style-and-quality-formatting html](https://user-images.githubusercontent.com/488251/64028955-f4b10500-cb43-11e9-810f-9c7d5c9a19e8.png)
