### PR TITLE
Add Apache Flink release 1.8.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -183,7 +183,7 @@ flink_releases:
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 181-sql-format-avro
+          id: 182-sql-format-avro
           url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar
           asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.asc
           sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.sha1
@@ -191,7 +191,7 @@ flink_releases:
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 181-sql-format-csv
+          id: 182-sql-format-csv
           url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar
           asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.asc
           sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.sha1
@@ -199,7 +199,7 @@ flink_releases:
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 181-sql-format-json
+          id: 182-sql-format-json
           url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar
           asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.asc
           sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.sha1
@@ -302,13 +302,13 @@ component_releases:
 release_archive:
     flink:
       -
-        version_short: 1.8
-        version_long: 1.8.2
-        release_date: 2019-09-10
-      -
         version_short: 1.9
         version_long: 1.9.0
         release_date: 2019-08-22
+      -
+        version_short: 1.8
+        version_long: 1.8.2
+        release_date: 2019-09-10
       -
         version_short: 1.8
         version_long: 1.8.1

--- a/_config.yml
+++ b/_config.yml
@@ -129,23 +129,23 @@ flink_releases:
   -
       version_short: 1.8
       binary_release:
-          name: "Apache Flink 1.8.1"
+          name: "Apache Flink 1.8.2"
           scala_211:
-              id: "181-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.11.tgz.sha512"
+              id: "182-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "181-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.12.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-bin-scala_2.12.tgz.sha512"
+              id: "182-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.8.1"
-          id: "181-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.1/flink-1.8.1-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz.sha512"
+          name: "Apache Flink 1.8.2"
+          id: "182-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.sha512"
       optional_components:
         -
           name: "Pre-bundled Hadoop 2.4.1"
@@ -184,25 +184,25 @@ flink_releases:
           category: "SQL Formats"
           scala_dependent: false
           id: 181-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.1/flink-avro-1.8.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.1/flink-avro-1.8.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.1/flink-avro-1.8.1.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 181-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.1/flink-csv-1.8.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.1/flink-csv-1.8.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.1/flink-csv-1.8.1.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
           id: 181-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.1/flink-json-1.8.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.1/flink-json-1.8.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.1/flink-json-1.8.1.jar.sha1
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.sha1
   -
       version_short: 1.7
       binary_release:
@@ -301,6 +301,10 @@ component_releases:
 
 release_archive:
     flink:
+      -
+        version_short: 1.8
+        version_long: 1.8.2
+        release_date: 2019-09-10
       -
         version_short: 1.9
         version_long: 1.9.0

--- a/_posts/2019-09-03-release-1.8.2.md
+++ b/_posts/2019-09-03-release-1.8.2.md
@@ -38,11 +38,13 @@ Updated Maven dependencies:
 You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
 
 List of resolved issues:
-        
+
 <h2>        Bug
 </h2>
 <ul>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-13941'>FLINK-13941</a>] -         Prevent data-loss by not cleaning up small part files from S3.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-9526'>FLINK-9526</a>] -         BucketingSink end-to-end test failed on Travis
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-10368'>FLINK-10368</a>] -         &#39;Kerberized YARN on Docker test&#39; unstable
 </li>
@@ -64,6 +66,8 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-13484'>FLINK-13484</a>] -         ConnectedComponents end-to-end test instable with NoResourceAvailableException
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13499'>FLINK-13499</a>] -         Remove dependency on MapR artifact repository
+</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-13508'>FLINK-13508</a>] -         CommonTestUtils#waitUntilCondition() may attempt to sleep with negative time
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-13586'>FLINK-13586</a>] -         Method ClosureCleaner.clean broke backward compatibility between 1.8.0 and 1.8.1
@@ -79,7 +83,7 @@ List of resolved issues:
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-13897'>FLINK-13897</a>] -         OSS FS NOTICE file is placed in wrong directory
 </li>
 </ul>
-                
+
 <h2>        Improvement
 </h2>
 <ul>
@@ -87,6 +91,6 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-12741'>FLINK-12741</a>] -         Update docs about Kafka producer fault tolerance guarantees
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12749'>FLINK-12749</a>] -         Add Flink Operations Playground documentation
+</li>
 </ul>
-                                                                                                                                                    
-                                                                                                                                        

--- a/_posts/2019-09-03-release-1.8.2.md
+++ b/_posts/2019-09-03-release-1.8.2.md
@@ -11,7 +11,7 @@ authors:
 
 The Apache Flink community released the second bugfix version of the Apache Flink 1.8 series.
 
-This release includes 20 fixes and minor improvements for Flink 1.8.1. The list below includes a detailed list of all fixes and improvements.
+This release includes 23 fixes and minor improvements for Flink 1.8.1. The list below includes a detailed list of all fixes and improvements.
 
 We highly recommend all users to upgrade to Flink 1.8.2.
 

--- a/_posts/2019-09-03-release-1.8.2.md
+++ b/_posts/2019-09-03-release-1.8.2.md
@@ -1,0 +1,92 @@
+---
+layout: post
+title:  "Apache Flink 1.8.2 Released"
+date:   2019-09-03 12:00:00
+categories: news
+authors:
+- jark:
+  name: "Jark Wu"
+  twitter: "JarkWu"
+---
+
+The Apache Flink community released the second bugfix version of the Apache Flink 1.8 series.
+
+This release includes 20 fixes and minor improvements for Flink 1.8.1. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.8.2.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.8.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.8.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.8.2</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+        
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13941'>FLINK-13941</a>] -         Prevent data-loss by not cleaning up small part files from S3.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-10368'>FLINK-10368</a>] -         &#39;Kerberized YARN on Docker test&#39; unstable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12319'>FLINK-12319</a>] -         StackOverFlowError in cep.nfa.sharedbuffer.SharedBuffer
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12736'>FLINK-12736</a>] -         ResourceManager may release TM with allocated slots
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12889'>FLINK-12889</a>] -         Job keeps in FAILING state
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13059'>FLINK-13059</a>] -         Cassandra Connector leaks Semaphore on Exception; hangs on close
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13159'>FLINK-13159</a>] -         java.lang.ClassNotFoundException when restore job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13367'>FLINK-13367</a>] -         Make ClosureCleaner detect writeReplace serialization override
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13369'>FLINK-13369</a>] -         Recursive closure cleaner ends up with stackOverflow in case of circular dependency
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13394'>FLINK-13394</a>] -         Use fallback unsafe secure MapR in nightly.sh
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13484'>FLINK-13484</a>] -         ConnectedComponents end-to-end test instable with NoResourceAvailableException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13508'>FLINK-13508</a>] -         CommonTestUtils#waitUntilCondition() may attempt to sleep with negative time
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13586'>FLINK-13586</a>] -         Method ClosureCleaner.clean broke backward compatibility between 1.8.0 and 1.8.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13761'>FLINK-13761</a>] -         `SplitStream` should be deprecated because `SplitJavaStream` is deprecated
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13789'>FLINK-13789</a>] -         Transactional Id Generation fails due to user code impacting formatting string
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13806'>FLINK-13806</a>] -         Metric Fetcher floods the JM log with errors when TM is lost
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13807'>FLINK-13807</a>] -         Flink-avro unit tests fails if the character encoding in the environment is not default to UTF-8
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13897'>FLINK-13897</a>] -         OSS FS NOTICE file is placed in wrong directory
+</li>
+</ul>
+                
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12578'>FLINK-12578</a>] -         Use secure URLs for Maven repositories
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12741'>FLINK-12741</a>] -         Update docs about Kafka producer fault tolerance guarantees
+</li>
+</ul>
+                                                                                                                                                    
+                                                                                                                                        


### PR DESCRIPTION
Adds release announcement and download link for 1.8.2.
Dates on announcements are still TBD and should be updated accordingly once release happens.

