### PR TITLE
[FLINK-14213] Replace link to "Local Setup Tutorial" by link to "Getting Started Overview".

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -7,7 +7,7 @@ en:
     powered_by: Powered By
     faq: FAQ
     downloads: Downloads
-    tutorials: Tutorials
+    getting_started: Getting Started
     documentation: Documentation
     getting_help: Getting Help
     flink_blog: Flink Blog
@@ -19,6 +19,7 @@ en:
     contribute_docs: Contribute Documentation
     contribute_website: Contribute to the Website
     roadmap: Roadmap
+    tutorials: Tutorials
 
 zh:
     what_is_flink: Apache Flink 是什么?
@@ -29,7 +30,7 @@ zh:
     powered_by: Flink 用户
     faq: 常见问题
     downloads: 下载
-    tutorials: 教程
+    getting_started: 教程
     documentation: 文档
     getting_help: 获取帮助
     flink_blog: Flink 博客
@@ -41,3 +42,4 @@ zh:
     contribute_docs: 贡献文档
     contribute_website: 贡献网站
     roadmap: 开发计划
+    tutorials: 教程

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -63,9 +63,9 @@
             <!-- Downloads -->
             <li{% if page.url contains '/downloads.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/downloads.html">{{ site.data.i18n[page.language].downloads }}</a></li>
 
-            <!-- Quickstart -->
+            <!-- Getting Started -->
             <li>
-              <a href="{{ site.docs-stable }}/getting-started/tutorials/local_setup.html" target="_blank">{{ site.data.i18n[page.language].tutorials }} <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+              <a href="{{ site.docs-stable }}/{% if page.language != 'en' %}{{ page.language }}/{% endif %}getting-started/index.html" target="_blank">{{ site.data.i18n[page.language].getting_started }} <small><span class="glyphicon glyphicon-new-window"></span></small></a>
             </li>
 
             <!-- Documentation -->


### PR DESCRIPTION
We are improving the starting experience for new Flink users by adding new code walkthroughs and Docker-based playgrounds. However, the new material is not easy to find from the Flink website.

To make the material more visible, I'm replacing the prominent *"Tutorials"* link on the Flink website which points to the [local setup tutorial](https://ci.apache.org/projects/flink/flink-docs-release-1.9/getting-started/tutorials/local_setup.html) by a *"Getting Started"* link that points to the [Getting Started Overview](https://ci.apache.org/projects/flink/flink-docs-release-1.9/getting-started/) page.

