### PR TITLE
Add Apache Flink release 1.8.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -129,23 +129,23 @@ flink_releases:
   -
       version_short: 1.8
       binary_release:
-          name: "Apache Flink 1.8.2"
+          name: "Apache Flink 1.8.3"
           scala_211:
-              id: "182-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.sha512"
+              id: "183-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "182-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.sha512"
+              id: "183-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.8.2"
-          id: "182-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.sha512"
+          name: "Apache Flink 1.8.3"
+          id: "183-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.sha512"
       optional_components:
         -
           name: "Pre-bundled Hadoop 2.4.1"
@@ -183,26 +183,26 @@ flink_releases:
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 182-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.sha1
+          id: 183-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 182-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.sha1
+          id: 183-sql-format-csv
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 182-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.sha1
+          id: 183-sql-format-json
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.sha1
   -
       version_short: 1.7
       binary_release:
@@ -308,6 +308,10 @@ release_archive:
         version_short: 1.9
         version_long: 1.9.0
         release_date: 2019-08-22
+      -
+        version_short: 1.8
+        version_long: 1.8.3
+        release_date: 2019-11-27
       -
         version_short: 1.8
         version_long: 1.8.2

--- a/_posts/2019-11-27-release-1.8.3.md
+++ b/_posts/2019-11-27-release-1.8.3.md
@@ -1,0 +1,144 @@
+---
+layout: post
+title:  "Apache Flink 1.8.3 Released"
+date:   2019-11-27 12:00:00
+categories: news
+authors:
+- hequn:
+  name: "Hequn Cheng"
+---
+
+The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.
+
+This release includes 45 fixes and minor improvements for Flink 1.8.2. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.8.3.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.8.3</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.8.3</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.8.3</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13723'>FLINK-13723</a>] -         Use liquid-c for faster doc generation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13724'>FLINK-13724</a>] -         Remove unnecessary whitespace from the docs&#39; sidenav
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13725'>FLINK-13725</a>] -         Use sassc for faster doc generation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13726'>FLINK-13726</a>] -         Build docs with jekyll 4.0.0.pre.beta1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13791'>FLINK-13791</a>] -         Speed up sidenav by using group_by
+</li>
+</ul>
+        
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12342'>FLINK-12342</a>] -         Yarn Resource Manager Acquires Too Many Containers
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13184'>FLINK-13184</a>] -         Starting a TaskExecutor blocks the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13728'>FLINK-13728</a>] -         Fix wrong closing tag order in sidenav
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13746'>FLINK-13746</a>] -         Elasticsearch (v2.3.5) sink end-to-end test fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13749'>FLINK-13749</a>] -         Make Flink client respect classloading policy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13892'>FLINK-13892</a>] -         HistoryServerTest failed on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13936'>FLINK-13936</a>] -         NOTICE-binary is outdated
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13966'>FLINK-13966</a>] -         Jar sorting in collect_license_files.sh is locale dependent
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13995'>FLINK-13995</a>] -         Fix shading of the licence information of netty
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13999'>FLINK-13999</a>] -         Correct the documentation of MATCH_RECOGNIZE
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14009'>FLINK-14009</a>] -         Cron jobs broken due to verifying incorrect NOTICE-binary file
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14010'>FLINK-14010</a>] -         Dispatcher &amp; JobManagers don&#39;t give up leadership when AM is shut down
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14043'>FLINK-14043</a>] -         SavepointMigrationTestBase is super slow
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14107'>FLINK-14107</a>] -         Kinesis consumer record emitter deadlock under event time alignment
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14175'>FLINK-14175</a>] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14235'>FLINK-14235</a>] -         Kafka010ProducerITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14315'>FLINK-14315</a>] -         NPE with JobMaster.disconnectTaskManager
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14337'>FLINK-14337</a>] -         HistoryServerTest.testHistoryServerIntegration failed on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14347'>FLINK-14347</a>] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14370'>FLINK-14370</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14398'>FLINK-14398</a>] -         Further split input unboxing code into separate methods
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14413'>FLINK-14413</a>] -         shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14434'>FLINK-14434</a>] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14562'>FLINK-14562</a>] -         RMQSource leaves idle consumer after closing
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14589'>FLINK-14589</a>] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15036'>FLINK-15036</a>] -         Container startup error will be handled out side of the YarnResourceManager&#39;s main thread
+</li>
+</ul>
+                
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12848'>FLINK-12848</a>] -         Method equals() in RowTypeInfo should consider fieldsNames
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13729'>FLINK-13729</a>] -         Update website generation dependencies
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13965'>FLINK-13965</a>] -         Keep hasDeprecatedKeys and deprecatedKeys methods in ConfigOption and mark it with @Deprecated annotation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13967'>FLINK-13967</a>] -         Generate full binary licensing via collect_license_files.sh
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13968'>FLINK-13968</a>] -         Add travis check for the correctness of the binary licensing
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13991'>FLINK-13991</a>] -         Add git exclusion for 1.9+ features to 1.8
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14008'>FLINK-14008</a>] -         Auto-generate binary licensing
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14104'>FLINK-14104</a>] -         Bump Jackson to 2.10.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14123'>FLINK-14123</a>] -         Lower the default value of taskmanager.memory.fraction
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14215'>FLINK-14215</a>] -         Add Docs for TM and JM Environment Variable Setting
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14334'>FLINK-14334</a>] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14639'>FLINK-14639</a>] -         Fix the document of Metrics  that has an error for `User Scope` 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14646'>FLINK-14646</a>] -         Check non-null for key in KeyGroupStreamPartitioner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14995'>FLINK-14995</a>] -         Kinesis NOTICE is incorrect
+</li>
+</ul>

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -7,6 +7,146 @@
 <atom:link href="https://flink.apache.org/blog/feed.xml" rel="self" type="application/rss+xml" />
 
 <item>
+<title>Apache Flink 1.8.3 Released</title>
+<description>&lt;p&gt;The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.&lt;/p&gt;
+
+&lt;p&gt;This release includes 45 fixes and minor improvements for Flink 1.8.2. The list below includes a detailed list of all fixes and improvements.&lt;/p&gt;
+
+&lt;p&gt;We highly recommend all users to upgrade to Flink 1.8.3.&lt;/p&gt;
+
+&lt;p&gt;Updated Maven dependencies:&lt;/p&gt;
+
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-xml&quot;&gt;&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-java&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.8.3&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-streaming-java_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.8.3&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-clients_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.8.3&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;You can find the binaries on the updated &lt;a href=&quot;/downloads.html&quot;&gt;Downloads page&lt;/a&gt;.&lt;/p&gt;
+
+&lt;p&gt;List of resolved issues:&lt;/p&gt;
+
+&lt;h2&gt;        Sub-task
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13723&quot;&gt;FLINK-13723&lt;/a&gt;] -         Use liquid-c for faster doc generation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13724&quot;&gt;FLINK-13724&lt;/a&gt;] -         Remove unnecessary whitespace from the docs&amp;#39; sidenav
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13725&quot;&gt;FLINK-13725&lt;/a&gt;] -         Use sassc for faster doc generation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13726&quot;&gt;FLINK-13726&lt;/a&gt;] -         Build docs with jekyll 4.0.0.pre.beta1
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13791&quot;&gt;FLINK-13791&lt;/a&gt;] -         Speed up sidenav by using group_by
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Bug
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12342&quot;&gt;FLINK-12342&lt;/a&gt;] -         Yarn Resource Manager Acquires Too Many Containers
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13184&quot;&gt;FLINK-13184&lt;/a&gt;] -         Starting a TaskExecutor blocks the YarnResourceManager&amp;#39;s main thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13728&quot;&gt;FLINK-13728&lt;/a&gt;] -         Fix wrong closing tag order in sidenav
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13746&quot;&gt;FLINK-13746&lt;/a&gt;] -         Elasticsearch (v2.3.5) sink end-to-end test fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13749&quot;&gt;FLINK-13749&lt;/a&gt;] -         Make Flink client respect classloading policy
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13892&quot;&gt;FLINK-13892&lt;/a&gt;] -         HistoryServerTest failed on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13936&quot;&gt;FLINK-13936&lt;/a&gt;] -         NOTICE-binary is outdated
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13966&quot;&gt;FLINK-13966&lt;/a&gt;] -         Jar sorting in collect_license_files.sh is locale dependent
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13995&quot;&gt;FLINK-13995&lt;/a&gt;] -         Fix shading of the licence information of netty
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13999&quot;&gt;FLINK-13999&lt;/a&gt;] -         Correct the documentation of MATCH_RECOGNIZE
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14009&quot;&gt;FLINK-14009&lt;/a&gt;] -         Cron jobs broken due to verifying incorrect NOTICE-binary file
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14010&quot;&gt;FLINK-14010&lt;/a&gt;] -         Dispatcher &amp;amp; JobManagers don&amp;#39;t give up leadership when AM is shut down
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14043&quot;&gt;FLINK-14043&lt;/a&gt;] -         SavepointMigrationTestBase is super slow
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14107&quot;&gt;FLINK-14107&lt;/a&gt;] -         Kinesis consumer record emitter deadlock under event time alignment
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14175&quot;&gt;FLINK-14175&lt;/a&gt;] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14235&quot;&gt;FLINK-14235&lt;/a&gt;] -         Kafka010ProducerITCase&amp;gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14315&quot;&gt;FLINK-14315&lt;/a&gt;] -         NPE with JobMaster.disconnectTaskManager
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14337&quot;&gt;FLINK-14337&lt;/a&gt;] -         HistoryServerTest.testHistoryServerIntegration failed on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14347&quot;&gt;FLINK-14347&lt;/a&gt;] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14370&quot;&gt;FLINK-14370&lt;/a&gt;] -         KafkaProducerAtLeastOnceITCase&amp;gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14398&quot;&gt;FLINK-14398&lt;/a&gt;] -         Further split input unboxing code into separate methods
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14413&quot;&gt;FLINK-14413&lt;/a&gt;] -         shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14434&quot;&gt;FLINK-14434&lt;/a&gt;] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14562&quot;&gt;FLINK-14562&lt;/a&gt;] -         RMQSource leaves idle consumer after closing
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14589&quot;&gt;FLINK-14589&lt;/a&gt;] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15036&quot;&gt;FLINK-15036&lt;/a&gt;] -         Container startup error will be handled out side of the YarnResourceManager&amp;#39;s main thread
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Improvement
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12848&quot;&gt;FLINK-12848&lt;/a&gt;] -         Method equals() in RowTypeInfo should consider fieldsNames
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13729&quot;&gt;FLINK-13729&lt;/a&gt;] -         Update website generation dependencies
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13965&quot;&gt;FLINK-13965&lt;/a&gt;] -         Keep hasDeprecatedKeys and deprecatedKeys methods in ConfigOption and mark it with @Deprecated annotation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13967&quot;&gt;FLINK-13967&lt;/a&gt;] -         Generate full binary licensing via collect_license_files.sh
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13968&quot;&gt;FLINK-13968&lt;/a&gt;] -         Add travis check for the correctness of the binary licensing
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13991&quot;&gt;FLINK-13991&lt;/a&gt;] -         Add git exclusion for 1.9+ features to 1.8
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14008&quot;&gt;FLINK-14008&lt;/a&gt;] -         Auto-generate binary licensing
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14104&quot;&gt;FLINK-14104&lt;/a&gt;] -         Bump Jackson to 2.10.1
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14123&quot;&gt;FLINK-14123&lt;/a&gt;] -         Lower the default value of taskmanager.memory.fraction
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14215&quot;&gt;FLINK-14215&lt;/a&gt;] -         Add Docs for TM and JM Environment Variable Setting
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14334&quot;&gt;FLINK-14334&lt;/a&gt;] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14639&quot;&gt;FLINK-14639&lt;/a&gt;] -         Fix the document of Metrics  that has an error for `User Scope` 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14646&quot;&gt;FLINK-14646&lt;/a&gt;] -         Check non-null for key in KeyGroupStreamPartitioner
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14995&quot;&gt;FLINK-14995&lt;/a&gt;] -         Kinesis NOTICE is incorrect
+&lt;/li&gt;
+&lt;/ul&gt;
+</description>
+<pubDate>Wed, 27 Nov 2019 13:00:00 +0100</pubDate>
+<link>https://flink.apache.org/news/2019/11/27/release-1.8.3.html</link>
+<guid isPermaLink="true">/news/2019/11/27/release-1.8.3.html</guid>
+</item>
+
+<item>
 <title>How to query Pulsar Streams using Apache Flink</title>
 <description>&lt;p&gt;In a previous &lt;a href=&quot;https://flink.apache.org/2019/05/03/pulsar-flink.html&quot;&gt;story&lt;/a&gt; on the  Flink blog, we explained the different ways that &lt;a href=&quot;https://flink.apache.org/&quot;&gt;Apache Flink&lt;/a&gt; and &lt;a href=&quot;https://pulsar.apache.org/&quot;&gt;Apache Pulsar&lt;/a&gt; can integrate to provide elastic data processing at large scale. This blog post discusses the new developments and integrations between the two frameworks and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.&lt;/p&gt;
 

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></h2>
+
+      <p>27 Nov 2019
+       Hequn Cheng </p>
+
+      <p><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.</p>
+
+</p>
+
+      <p><a href="/news/2019/11/27/release-1.8.3.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></h2>
 
       <p>25 Nov 2019
@@ -310,19 +325,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/2019/06/05/flink-network-stack.html">A Deep-Dive into Flink's Network Stack</a></h2>
-
-      <p>05 Jun 2019
-       Nico Kruber </p>
-
-      <p>Flink’s network stack is one of the core components that make up Apache Flink's runtime module sitting at the core of every Flink job. In this post, which is the first in a series of posts about the network stack, we look at the abstractions exposed to the stream operators and detail their physical implementation and various optimisations in Apache Flink.</p>
-
-      <p><a href="/2019/06/05/flink-network-stack.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -354,6 +356,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2014/10/03/upcoming_events.html">Upcoming Events</a></h2>
+
+      <p>03 Oct 2014
+      </p>
+
+      <p><p>We are happy to announce several upcoming Flink events both in Europe and the US. Starting with a <strong>Flink hackathon in Stockholm</strong> (Oct 8-9) and a talk about Flink at the <strong>Stockholm Hadoop User Group</strong> (Oct 8). This is followed by the very first <strong>Flink Meetup in Berlin</strong> (Oct 15). In the US, there will be two Flink Meetup talks: the first one at the <strong>Pasadena Big Data User Group</strong> (Oct 29) and the second one at <strong>Silicon Valley Hands On Programming Events</strong> (Nov 4).</p>
+
+</p>
+
+      <p><a href="/news/2014/10/03/upcoming_events.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2014/09/26/release-0.6.1.html">Apache Flink 0.6.1 available</a></h2>
 
       <p>26 Sep 2014
@@ -248,6 +263,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -185,6 +185,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/2019/06/05/flink-network-stack.html">A Deep-Dive into Flink's Network Stack</a></h2>
+
+      <p>05 Jun 2019
+       Nico Kruber </p>
+
+      <p>Flink’s network stack is one of the core components that make up Apache Flink's runtime module sitting at the core of every Flink job. In this post, which is the first in a series of posts about the network stack, we look at the abstractions exposed to the stream operators and detail their physical implementation and various optimisations in Apache Flink.</p>
+
+      <p><a href="/2019/06/05/flink-network-stack.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/2019/05/19/state-ttl.html">State TTL in Flink 1.8.0: How to Automatically Cleanup Application State in Apache Flink</a></h2>
 
       <p>19 May 2019
@@ -311,21 +324,6 @@ for more details.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/02/15/release-1.7.2.html">Apache Flink 1.7.2 Released</a></h2>
-
-      <p>15 Feb 2019
-      </p>
-
-      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.7 series.</p>
-
-</p>
-
-      <p><a href="/news/2019/02/15/release-1.7.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -357,6 +355,16 @@ for more details.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/02/15/release-1.7.2.html">Apache Flink 1.7.2 Released</a></h2>
+
+      <p>15 Feb 2019
+      </p>
+
+      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.7 series.</p>
+
+</p>
+
+      <p><a href="/news/2019/02/15/release-1.7.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/02/13/unified-batch-streaming-blink.html">Batch as a Special Case of Streaming and Alibaba's contribution of Blink</a></h2>
 
       <p>13 Feb 2019
@@ -319,21 +334,6 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/08/21/release-1.5.3.html">Apache Flink 1.5.3 Released</a></h2>
-
-      <p>21 Aug 2018
-      </p>
-
-      <p><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.5 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/08/21/release-1.5.3.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -365,6 +365,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/08/21/release-1.5.3.html">Apache Flink 1.5.3 Released</a></h2>
+
+      <p>21 Aug 2018
+      </p>
+
+      <p><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.5 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/08/21/release-1.5.3.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/08/09/release-1.6.0.html">Apache Flink 1.6.0 Release Announcement</a></h2>
 
       <p>09 Aug 2018
@@ -315,19 +330,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/12/21/2017-year-in-review.html">Apache Flink in 2017: Year in Review</a></h2>
-
-      <p>21 Dec 2017
-       Chris Ward (<a href="https://twitter.com/chrischinch">@chrischinch</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
-
-      <p>As 2017 comes to a close, let's take a moment to look back on the Flink community's great work during the past year.</p>
-
-      <p><a href="/news/2017/12/21/2017-year-in-review.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -359,6 +361,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -185,6 +185,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/12/21/2017-year-in-review.html">Apache Flink in 2017: Year in Review</a></h2>
+
+      <p>21 Dec 2017
+       Chris Ward (<a href="https://twitter.com/chrischinch">@chrischinch</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
+
+      <p>As 2017 comes to a close, let's take a moment to look back on the Flink community's great work during the past year.</p>
+
+      <p><a href="/news/2017/12/21/2017-year-in-review.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/12/12/release-1.4.0.html">Apache Flink 1.4.0 Release Announcement</a></h2>
 
       <p>12 Dec 2017
@@ -321,19 +334,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/03/29/table-sql-api-update.html">From Streams to Tables and Back Again: An Update on Flink's Table & SQL API</a></h2>
-
-      <p>29 Mar 2017 by Timo Walther (<a href="https://twitter.com/">@twalthr</a>)
-      </p>
-
-      <p><p>Broadening the user base and unifying batch & streaming with relational APIs</p></p>
-
-      <p><a href="/news/2017/03/29/table-sql-api-update.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -365,6 +365,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -185,6 +185,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/03/29/table-sql-api-update.html">From Streams to Tables and Back Again: An Update on Flink's Table & SQL API</a></h2>
+
+      <p>29 Mar 2017 by Timo Walther (<a href="https://twitter.com/">@twalthr</a>)
+      </p>
+
+      <p><p>Broadening the user base and unifying batch & streaming with relational APIs</p></p>
+
+      <p><a href="/news/2017/03/29/table-sql-api-update.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/03/23/release-1.1.5.html">Apache Flink 1.1.5 Released</a></h2>
 
       <p>23 Mar 2017
@@ -315,20 +328,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/05/24/stream-sql.html">Stream Processing for Everyone with SQL and Apache Flink</a></h2>
-
-      <p>24 May 2016 by Fabian Hueske (<a href="https://twitter.com/">@fhueske</a>)
-      </p>
-
-      <p><p>About six months ago, the Apache Flink community started an effort to add a SQL interface for stream data analysis. SQL is <i>the</i> standard language to access and process data. Everybody who occasionally analyzes data is familiar with SQL. Consequently, a SQL interface for stream data processing will make this technology accessible to a much wider audience. Moreover, SQL support for streaming data will also enable new use cases such as interactive and ad-hoc stream analysis and significantly simplify many applications including stream ingestion and simple transformations.</p>
-<p>In this blog post, we report on the current status, architectural design, and future plans of the Apache Flink community to implement support for SQL as a language for analyzing data streams.</p></p>
-
-      <p><a href="/news/2016/05/24/stream-sql.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -360,6 +359,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -185,6 +185,20 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/05/24/stream-sql.html">Stream Processing for Everyone with SQL and Apache Flink</a></h2>
+
+      <p>24 May 2016 by Fabian Hueske (<a href="https://twitter.com/">@fhueske</a>)
+      </p>
+
+      <p><p>About six months ago, the Apache Flink community started an effort to add a SQL interface for stream data analysis. SQL is <i>the</i> standard language to access and process data. Everybody who occasionally analyzes data is familiar with SQL. Consequently, a SQL interface for stream data processing will make this technology accessible to a much wider audience. Moreover, SQL support for streaming data will also enable new use cases such as interactive and ad-hoc stream analysis and significantly simplify many applications including stream ingestion and simple transformations.</p>
+<p>In this blog post, we report on the current status, architectural design, and future plans of the Apache Flink community to implement support for SQL as a language for analyzing data streams.</p></p>
+
+      <p><a href="/news/2016/05/24/stream-sql.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/05/11/release-1.0.3.html">Flink 1.0.3 Released</a></h2>
 
       <p>11 May 2016
@@ -313,20 +327,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/12/04/Introducing-windows.html">Introducing Stream Windows in Apache Flink</a></h2>
-
-      <p>04 Dec 2015 by Fabian Hueske (<a href="https://twitter.com/">@fhueske</a>)
-      </p>
-
-      <p><p>The data analysis space is witnessing an evolution from batch to stream processing for many use cases. Although batch can be handled as a special case of stream processing, analyzing never-ending streaming data often requires a shift in the mindset and comes with its own terminology (for example, “windowing” and “at-least-once”/”exactly-once” processing). This shift and the new terminology can be quite confusing for people being new to the space of stream processing. Apache Flink is a production-ready stream processor with an easy-to-use yet very expressive API to define advanced stream analysis programs. Flink's API features very flexible window definitions on data streams which let it stand out among other open source stream processors.</p>
-<p>In this blog post, we discuss the concept of windows for stream processing, present Flink's built-in windows, and explain its support for custom windowing semantics.</p></p>
-
-      <p><a href="/news/2015/12/04/Introducing-windows.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -358,6 +358,16 @@
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -185,6 +185,20 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/12/04/Introducing-windows.html">Introducing Stream Windows in Apache Flink</a></h2>
+
+      <p>04 Dec 2015 by Fabian Hueske (<a href="https://twitter.com/">@fhueske</a>)
+      </p>
+
+      <p><p>The data analysis space is witnessing an evolution from batch to stream processing for many use cases. Although batch can be handled as a special case of stream processing, analyzing never-ending streaming data often requires a shift in the mindset and comes with its own terminology (for example, “windowing” and “at-least-once”/”exactly-once” processing). This shift and the new terminology can be quite confusing for people being new to the space of stream processing. Apache Flink is a production-ready stream processor with an easy-to-use yet very expressive API to define advanced stream analysis programs. Flink's API features very flexible window definitions on data streams which let it stand out among other open source stream processors.</p>
+<p>In this blog post, we discuss the concept of windows for stream processing, present Flink's built-in windows, and explain its support for custom windowing semantics.</p></p>
+
+      <p><a href="/news/2015/12/04/Introducing-windows.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/11/27/release-0.10.1.html">Flink 0.10.1 released</a></h2>
 
       <p>27 Nov 2015
@@ -322,26 +336,6 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/04/13/release-0.9.0-milestone1.html">Announcing Flink 0.9.0-milestone1 preview release</a></h2>
-
-      <p>13 Apr 2015
-      </p>
-
-      <p><p>The Apache Flink community is pleased to announce the availability of
-the 0.9.0-milestone-1 release. The release is a preview of the
-upcoming 0.9.0 release. It contains many new features which will be
-available in the upcoming 0.9 release. Interested users are encouraged
-to try it out and give feedback. As the version number indicates, this
-release is a preview release that contains known issues.</p>
-
-</p>
-
-      <p><a href="/news/2015/04/13/release-0.9.0-milestone1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -373,6 +367,16 @@ release is a preview release that contains known issues.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -185,6 +185,26 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/04/13/release-0.9.0-milestone1.html">Announcing Flink 0.9.0-milestone1 preview release</a></h2>
+
+      <p>13 Apr 2015
+      </p>
+
+      <p><p>The Apache Flink community is pleased to announce the availability of
+the 0.9.0-milestone-1 release. The release is a preview of the
+upcoming 0.9.0 release. It contains many new features which will be
+available in the upcoming 0.9 release. Interested users are encouraged
+to try it out and give feedback. As the version number indicates, this
+release is a preview release that contains known issues.</p>
+
+</p>
+
+      <p><a href="/news/2015/04/13/release-0.9.0-milestone1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/04/07/march-in-flink.html">March 2015 in the Flink community</a></h2>
 
       <p>07 Apr 2015
@@ -324,21 +344,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2014/10/03/upcoming_events.html">Upcoming Events</a></h2>
-
-      <p>03 Oct 2014
-      </p>
-
-      <p><p>We are happy to announce several upcoming Flink events both in Europe and the US. Starting with a <strong>Flink hackathon in Stockholm</strong> (Oct 8-9) and a talk about Flink at the <strong>Stockholm Hadoop User Group</strong> (Oct 8). This is followed by the very first <strong>Flink Meetup in Berlin</strong> (Oct 15). In the US, there will be two Flink Meetup talks: the first one at the <strong>Pasadena Big Data User Group</strong> (Oct 29) and the second one at <strong>Silicon Valley Hands On Programming Events</strong> (Nov 4).</p>
-
-</p>
-
-      <p><a href="/news/2014/10/03/upcoming_events.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -370,6 +375,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2019</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -197,7 +197,7 @@ $( document ).ready(function() {
 <div class="page-toc">
 <ul id="markdown-toc">
   <li><a href="#apache-flink-191" id="markdown-toc-apache-flink-191">Apache Flink 1.9.1</a></li>
-  <li><a href="#apache-flink-182" id="markdown-toc-apache-flink-182">Apache Flink 1.8.2</a></li>
+  <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a></li>
   <li><a href="#apache-flink-172" id="markdown-toc-apache-flink-172">Apache Flink 1.7.2</a></li>
   <li><a href="#additional-components" id="markdown-toc-additional-components">Additional Components</a></li>
   <li><a href="#verifying-hashes-and-signatures" id="markdown-toc-verifying-hashes-and-signatures">Verifying Hashes and Signatures</a></li>
@@ -273,33 +273,33 @@ HADOOP_CLASSPATH</a>.</p>
 
 <hr />
 
-<h2 id="apache-flink-182">Apache Flink 1.8.2</h2>
+<h2 id="apache-flink-183">Apache Flink 1.8.3</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz" class="ga-track" id="182-download_211">Apache Flink 1.8.2 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz" class="ga-track" id="183-download_211">Apache Flink 1.8.3 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz" class="ga-track" id="182-download_212">Apache Flink 1.8.2 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz" class="ga-track" id="183-download_212">Apache Flink 1.8.3 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-src.tgz" class="ga-track" id="182-download-source">Apache Flink 1.8.2 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-src.tgz" class="ga-track" id="183-download-source">Apache Flink 1.8.3 Source Release</a>
+(<a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components-1">Optional components</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar" class="ga-track" id="182-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar" class="ga-track" id="183-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar" class="ga-track" id="182-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar" class="ga-track" id="183-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar" class="ga-track" id="182-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar" class="ga-track" id="183-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
@@ -460,6 +460,17 @@ Flink 1.9.0 - 2019-08-22
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
+
+</li>
+
+<li>
+
+Flink 1.8.3 - 2019-11-27 
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -551,6 +551,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></dt>
+        <dd><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></dt>
         <dd>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</dd>
       
@@ -566,9 +571,6 @@
         <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.8 series.</p>
 
 </dd>
-      
-        <dt> <a href="/news/2019/09/10/community-update.html">Flink Community Update - September'19</a></dt>
-        <dd>This has been an exciting, fast-paced year for the Apache Flink community. But with over 10k messages across the mailing lists, 3k Jira tickets and 2k pull requests, it is not easy to keep up with the latest state of the project. Plus everything happening around it. With that in mind, we want to bring back regular community updates to the Flink blog.</dd>
     
   </dl>
 

--- a/content/news/2019/11/27/release-1.8.3.html
+++ b/content/news/2019/11/27/release-1.8.3.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Apache Flink: Apache Flink 1.8.3 Released</title>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/flink.css">
+    <link rel="stylesheet" href="/css/syntax.css">
+
+    <!-- Blog RSS feed -->
+    <link href="/blog/feed.xml" rel="alternate" type="application/rss+xml" title="Apache Flink Blog: RSS feed" />
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <!-- We need to load Jquery in the header for custom google analytics event tracking-->
+    <script src="/js/jquery.min.js"></script>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>  
+    
+
+    <!-- Main content. -->
+    <div class="container">
+    <div class="row">
+
+      
+     <div id="sidebar" class="col-sm-3">
+        
+
+<!-- Top navbar. -->
+    <nav class="navbar navbar-default">
+        <!-- The logo. -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="navbar-logo">
+            <a href="/">
+              <img alt="Apache Flink" src="/img/flink-header-logo.svg" width="147px" height="73px">
+            </a>
+          </div>
+        </div><!-- /.navbar-header -->
+
+        <!-- The navigation links. -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-main">
+
+            <!-- First menu section explains visitors what Flink is -->
+
+            <!-- What is Stream Processing? -->
+            <!--
+            <li><a href="/streamprocessing1.html">What is Stream Processing?</a></li>
+            -->
+
+            <!-- What is Flink? -->
+            <li><a href="/flink-architecture.html">What is Apache Flink?</a></li>
+
+            
+
+            <!-- Use cases -->
+            <li><a href="/usecases.html">Use Cases</a></li>
+
+            <!-- Powered by -->
+            <li><a href="/poweredby.html">Powered By</a></li>
+
+            <!-- FAQ -->
+            <li><a href="/faq.html">FAQ</a></li>
+
+            &nbsp;
+            <!-- Second menu section aims to support Flink users -->
+
+            <!-- Downloads -->
+            <li><a href="/downloads.html">Downloads</a></li>
+
+            <!-- Quickstart -->
+            <li>
+              <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/getting-started/tutorials/local_setup.html" target="_blank">Tutorials <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            <!-- Documentation -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9" target="_blank">1.9 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+              </ul>
+            </li>
+
+            <!-- getting help -->
+            <li><a href="/gettinghelp.html">Getting Help</a></li>
+
+            <!-- Blog -->
+            <li class="active"><a href="/blog/"><b>Flink Blog</b></a></li>
+
+            <!-- Ecosystem -->
+            <li><a href="/ecosystem.html">Ecosystem</a></li>
+
+            &nbsp;
+
+            <!-- Third menu section aim to support community and contributors -->
+
+            <!-- Community -->
+            <li><a href="/community.html">Community &amp; Project Info</a></li>
+
+            <!-- Roadmap -->
+            <li><a href="/roadmap.html">Roadmap</a></li>
+
+            <!-- Contribute -->
+            <li><a href="/contributing/how-to-contribute.html">How to Contribute</a></li>
+            
+
+            <!-- GitHub -->
+            <li>
+              <a href="https://github.com/apache/flink" target="_blank">Flink on GitHub <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            &nbsp;
+
+            <!-- Language Switcher -->
+            <li>
+              
+                
+                  <!-- link to the Chinese home page when current is blog page -->
+                  <a href="/zh">中文版</a>
+                
+              
+            </li>
+
+          </ul>
+
+          <ul class="nav navbar-nav navbar-bottom">
+          <hr />
+
+            <!-- Twitter -->
+            <li><a href="https://twitter.com/apacheflink" target="_blank">@ApacheFlink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <!-- Visualizer -->
+            <li class=" hidden-md hidden-sm"><a href="/visualizer/" target="_blank">Plan Visualizer <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+          <hr />
+
+            <li><a href="https://apache.org" target="_blank">Apache Software Foundation <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <li>
+              <style>
+                .smalllinks:link {
+                  display: inline-block !important; background: none; padding-top: 0px; padding-bottom: 0px; padding-right: 0px; min-width: 75px;
+                }
+              </style>
+
+              <a class="smalllinks" href="https://www.apache.org/licenses/" target="_blank">License</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/security/" target="_blank">Security</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+            </li>
+
+          </ul>
+        </div><!-- /.navbar-collapse -->
+    </nav>
+
+      </div>
+      <div class="col-sm-9">
+      <div class="row-fluid">
+  <div class="col-sm-12">
+    <div class="row">
+      <h1>Apache Flink 1.8.3 Released</h1>
+
+      <article>
+        <p>27 Nov 2019 Hequn Cheng </p>
+
+<p>The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.</p>
+
+<p>This release includes 45 fixes and minor improvements for Flink 1.8.2. The list below includes a detailed list of all fixes and improvements.</p>
+
+<p>We highly recommend all users to upgrade to Flink 1.8.3.</p>
+
+<p>Updated Maven dependencies:</p>
+
+<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.8.3<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.8.3<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.8.3<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span></code></pre></div>
+
+<p>You can find the binaries on the updated <a href="/downloads.html">Downloads page</a>.</p>
+
+<p>List of resolved issues:</p>
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13723">FLINK-13723</a>] -         Use liquid-c for faster doc generation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13724">FLINK-13724</a>] -         Remove unnecessary whitespace from the docs&#39; sidenav
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13725">FLINK-13725</a>] -         Use sassc for faster doc generation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13726">FLINK-13726</a>] -         Build docs with jekyll 4.0.0.pre.beta1
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13791">FLINK-13791</a>] -         Speed up sidenav by using group_by
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12342">FLINK-12342</a>] -         Yarn Resource Manager Acquires Too Many Containers
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13184">FLINK-13184</a>] -         Starting a TaskExecutor blocks the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13728">FLINK-13728</a>] -         Fix wrong closing tag order in sidenav
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13746">FLINK-13746</a>] -         Elasticsearch (v2.3.5) sink end-to-end test fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13749">FLINK-13749</a>] -         Make Flink client respect classloading policy
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13892">FLINK-13892</a>] -         HistoryServerTest failed on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13936">FLINK-13936</a>] -         NOTICE-binary is outdated
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13966">FLINK-13966</a>] -         Jar sorting in collect_license_files.sh is locale dependent
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13995">FLINK-13995</a>] -         Fix shading of the licence information of netty
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13999">FLINK-13999</a>] -         Correct the documentation of MATCH_RECOGNIZE
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14009">FLINK-14009</a>] -         Cron jobs broken due to verifying incorrect NOTICE-binary file
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14010">FLINK-14010</a>] -         Dispatcher &amp; JobManagers don&#39;t give up leadership when AM is shut down
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14043">FLINK-14043</a>] -         SavepointMigrationTestBase is super slow
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14107">FLINK-14107</a>] -         Kinesis consumer record emitter deadlock under event time alignment
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14175">FLINK-14175</a>] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14235">FLINK-14235</a>] -         Kafka010ProducerITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14315">FLINK-14315</a>] -         NPE with JobMaster.disconnectTaskManager
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14337">FLINK-14337</a>] -         HistoryServerTest.testHistoryServerIntegration failed on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14347">FLINK-14347</a>] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14370">FLINK-14370</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14398">FLINK-14398</a>] -         Further split input unboxing code into separate methods
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14413">FLINK-14413</a>] -         shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14434">FLINK-14434</a>] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14562">FLINK-14562</a>] -         RMQSource leaves idle consumer after closing
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14589">FLINK-14589</a>] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15036">FLINK-15036</a>] -         Container startup error will be handled out side of the YarnResourceManager&#39;s main thread
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12848">FLINK-12848</a>] -         Method equals() in RowTypeInfo should consider fieldsNames
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13729">FLINK-13729</a>] -         Update website generation dependencies
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13965">FLINK-13965</a>] -         Keep hasDeprecatedKeys and deprecatedKeys methods in ConfigOption and mark it with @Deprecated annotation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13967">FLINK-13967</a>] -         Generate full binary licensing via collect_license_files.sh
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13968">FLINK-13968</a>] -         Add travis check for the correctness of the binary licensing
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13991">FLINK-13991</a>] -         Add git exclusion for 1.9+ features to 1.8
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14008">FLINK-14008</a>] -         Auto-generate binary licensing
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14104">FLINK-14104</a>] -         Bump Jackson to 2.10.1
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14123">FLINK-14123</a>] -         Lower the default value of taskmanager.memory.fraction
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14215">FLINK-14215</a>] -         Add Docs for TM and JM Environment Variable Setting
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14334">FLINK-14334</a>] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14639">FLINK-14639</a>] -         Fix the document of Metrics  that has an error for `User Scope` 
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14646">FLINK-14646</a>] -         Check non-null for key in KeyGroupStreamPartitioner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14995">FLINK-14995</a>] -         Kinesis NOTICE is incorrect
+</li>
+</ul>
+
+      </article>
+    </div>
+
+    <div class="row">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = 'stratosphere-eu'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+      </script>
+    </div>
+  </div>
+</div>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="row">
+      <div class="footer text-center col-sm-12">
+        <p>Copyright © 2014-2019 <a href="http://apache.org">The Apache Software Foundation</a>. All Rights Reserved.</p>
+        <p>Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        <p><a href="/privacy-policy.html">Privacy Policy</a> &middot; <a href="/blog/feed.xml">RSS feed</a></p>
+      </div>
+    </div>
+    </div><!-- /.container -->
+
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
+    <script src="/js/codetabs.js"></script>
+    <script src="/js/stickysidebar.js"></script>
+
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52545728-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+  </body>
+</html>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -199,7 +199,7 @@ $( document ).ready(function() {
     </ul>
   </li>
   <li><a href="#section-1" id="markdown-toc-section-1">发布说明</a></li>
-  <li><a href="#apache-flink-182" id="markdown-toc-apache-flink-182">Apache Flink 1.8.2</a>    <ul>
+  <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a>    <ul>
       <li><a href="#section-2" id="markdown-toc-section-2">可选组件</a></li>
     </ul>
   </li>
@@ -282,35 +282,35 @@ Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的
 <p>如果你计划从以前的版本升级 Flink，请查看 <a href="https://ci.apache.org/projects/flink/
 flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</a>。</p>
 
-<h2 id="apache-flink-182">Apache Flink 1.8.2</h2>
+<h2 id="apache-flink-183">Apache Flink 1.8.3</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz" class="ga-track" id="182-download_211">Apache Flink 1.8.2 for Scala 2.11</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz" class="ga-track" id="183-download_211">Apache Flink 1.8.3 for Scala 2.11</a> (<a href="
+ https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz" class="ga-track" id="182-download_212">Apache Flink 1.8.2 for Scala 2.12</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz" class="ga-track" id="183-download_212">Apache Flink 1.8.3 for Scala 2.12</a> (<a href="
+ https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.2/flink-1.8.2-src.tgz" class="ga-track" id="182-download-source">Apache Flink 1.8.2 Source Release</a>
- (<a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.8.3/flink-1.8.3-src.tgz" class="ga-track" id="183-download-source">Apache Flink 1.8.3 Source Release</a>
+ (<a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.sha512">sha512</a>)
 </p>
 
 <h3 id="section-2">可选组件</h3>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar" class="ga-track" id="182-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.2/flink-avro-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar" class="ga-track" id="183-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar" class="ga-track" id="182-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.2/flink-csv-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar" class="ga-track" id="183-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.8.3/flink-csv-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar" class="ga-track" id="182-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.2/flink-json-1.8.2.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar" class="ga-track" id="183-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.sha1">sha1</a>)
 </p>
 
 <p>
@@ -468,6 +468,17 @@ Flink 1.9.0 - 2019-08-22
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
+
+</li>
+
+<li>
+
+Flink 1.8.3 - 2019-11-27 
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -536,6 +536,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2019/11/27/release-1.8.3.html">Apache Flink 1.8.3 Released</a></dt>
+        <dd><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.8 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></dt>
         <dd>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</dd>
       
@@ -551,9 +556,6 @@
         <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.8 series.</p>
 
 </dd>
-      
-        <dt> <a href="/news/2019/09/10/community-update.html">Flink Community Update - September'19</a></dt>
-        <dd>This has been an exciting, fast-paced year for the Apache Flink community. But with over 10k messages across the mailing lists, 3k Jira tickets and 2k pull requests, it is not easy to keep up with the latest state of the project. Plus everything happening around it. With that in mind, we want to bring back regular community updates to the Flink blog.</dd>
     
   </dl>
 


### PR DESCRIPTION
Adds release announcement and download link for 1.8.3
Dates on announcements are still TBD and should be updated accordingly once release happens.