### PR TITLE
Add Apache Flink release 1.9.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: https://flink.apache.org
 
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
-FLINK_VERSION_STABLE: 1.9.1
+FLINK_VERSION_STABLE: 1.9.2
 FLINK_VERSION_STABLE_SHORT: 1.9
 
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
@@ -52,48 +52,48 @@ flink_releases:
   -
       version_short: 1.9
       binary_release:
-          name: "Apache Flink 1.9.1"
+          name: "Apache Flink 1.9.2"
           scala_211:
-              id: "191-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.sha512"
+              id: "192-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "191-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.sha512"
+              id: "192-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz"
+              asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.9.1"
-          id: "191-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.sha512"
+          name: "Apache Flink 1.9.2"
+          id: "192-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz"
+          asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc"
+          sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 191-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.sha1
+          id: 192-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 191-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.sha1
+          id: 192-sql-format-csv
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 191-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.sha1
+          id: 192-sql-format-json
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.sha1
   -
       version_short: 1.8
       binary_release:
@@ -261,7 +261,12 @@ component_releases:
 
 release_archive:
     flink:
-      - version_short: 1.9
+      -
+        version_short: 1.9
+        version_long: 1.9.2
+        release_date: 2020-01-30
+      -
+        version_short: 1.9
         version_long: 1.9.1
         release_date: 2019-10-18
       -

--- a/_posts/2020-01-30-release-1.9.2.md
+++ b/_posts/2020-01-30-release-1.9.2.md
@@ -1,0 +1,289 @@
+---
+layout: post
+title:  "Apache Flink 1.9.2 Released"
+date:   2020-01-30 12:00:00
+categories: news
+authors:
+- hequn:
+  name: "Hequn Cheng"
+  twitter: "HequnC"
+---
+
+The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.
+
+This release includes 117 fixes and minor improvements for Flink 1.9.1. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.9.2.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.9.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.9.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.9.2</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12122'>FLINK-12122</a>] -         Spread out tasks evenly across all available registered TaskManagers
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13360'>FLINK-13360</a>] -         Add documentation for HBase connector for Table API &amp; SQL
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13361'>FLINK-13361</a>] -         Add documentation for JDBC connector for Table API &amp; SQL
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13723'>FLINK-13723</a>] -         Use liquid-c for faster doc generation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13724'>FLINK-13724</a>] -         Remove unnecessary whitespace from the docs&#39; sidenav
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13725'>FLINK-13725</a>] -         Use sassc for faster doc generation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13726'>FLINK-13726</a>] -         Build docs with jekyll 4.0.0.pre.beta1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13791'>FLINK-13791</a>] -         Speed up sidenav by using group_by
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13817'>FLINK-13817</a>] -         Expose whether web submissions are enabled
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13818'>FLINK-13818</a>] -         Check whether web submission are enabled
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14535'>FLINK-14535</a>] -         Cast exception is thrown when count distinct on decimal fields
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14735'>FLINK-14735</a>] -         Improve batch schedule check input consumable performance
+</li>
+</ul>
+        
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-10377'>FLINK-10377</a>] -         Remove precondition in TwoPhaseCommitSinkFunction.notifyCheckpointComplete
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-10435'>FLINK-10435</a>] -         Client sporadically hangs after Ctrl + C
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11120'>FLINK-11120</a>] -         TIMESTAMPADD function handles TIME incorrectly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11835'>FLINK-11835</a>] -         ZooKeeperLeaderElectionITCase.testJobExecutionOnClusterWithLeaderChange failed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12342'>FLINK-12342</a>] -         Yarn Resource Manager Acquires Too Many Containers
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12399'>FLINK-12399</a>] -         FilterableTableSource does not use filters on job run
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13184'>FLINK-13184</a>] -         Starting a TaskExecutor blocks the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13589'>FLINK-13589</a>] -         DelimitedInputFormat index error on multi-byte delimiters with whole file input splits
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13702'>FLINK-13702</a>] -         BaseMapSerializerTest.testDuplicate fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13708'>FLINK-13708</a>] -         Transformations should be cleared because a table environment could execute multiple job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13740'>FLINK-13740</a>] -         TableAggregateITCase.testNonkeyedFlatAggregate failed on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13749'>FLINK-13749</a>] -         Make Flink client respect classloading policy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13758'>FLINK-13758</a>] -         Failed to submit JobGraph when registered hdfs file in DistributedCache 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13799'>FLINK-13799</a>] -         Web Job Submit Page displays stream of error message when web submit is disables in the config
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13827'>FLINK-13827</a>] -         Shell variable should be escaped in start-scala-shell.sh
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13862'>FLINK-13862</a>] -         Update Execution Plan docs
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13945'>FLINK-13945</a>] -         Instructions for building flink-shaded against vendor repository don&#39;t work
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13969'>FLINK-13969</a>] -         Resuming Externalized Checkpoint (rocks, incremental, scale down) end-to-end test fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13995'>FLINK-13995</a>] -         Fix shading of the licence information of netty
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13999'>FLINK-13999</a>] -         Correct the documentation of MATCH_RECOGNIZE
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14066'>FLINK-14066</a>] -         Pyflink building failure in master and 1.9.0 version
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14074'>FLINK-14074</a>] -         MesosResourceManager can&#39;t create new taskmanagers in Session Cluster Mode.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14175'>FLINK-14175</a>] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14200'>FLINK-14200</a>] -         Temporal Table Function Joins do not work on Tables (only TableSources) on the query side
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14235'>FLINK-14235</a>] -         Kafka010ProducerITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14315'>FLINK-14315</a>] -         NPE with JobMaster.disconnectTaskManager
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14337'>FLINK-14337</a>] -         HistoryServer does not handle NPE on corruped archives properly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14347'>FLINK-14347</a>] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14355'>FLINK-14355</a>] -         Example code in state processor API docs doesn&#39;t compile
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14370'>FLINK-14370</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14382'>FLINK-14382</a>] -         Incorrect handling of FLINK_PLUGINS_DIR on Yarn
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14398'>FLINK-14398</a>] -         Further split input unboxing code into separate methods
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14413'>FLINK-14413</a>] -         Shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14434'>FLINK-14434</a>] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14445'>FLINK-14445</a>] -         Python module build failed when making sdist
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14447'>FLINK-14447</a>] -         Network metrics doc table render confusion
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14459'>FLINK-14459</a>] -         Python module build hangs
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14524'>FLINK-14524</a>] -         PostgreSQL JDBC sink generates invalid SQL in upsert mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14547'>FLINK-14547</a>] -         UDF cannot be in the join condition in blink planner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14561'>FLINK-14561</a>] -         Don&#39;t write FLINK_PLUGINS_DIR ENV variable to Flink configuration
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14562'>FLINK-14562</a>] -         RMQSource leaves idle consumer after closing
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14574'>FLINK-14574</a>] -          flink-s3-fs-hadoop doesn&#39;t work with plugins mechanism
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14589'>FLINK-14589</a>] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14641'>FLINK-14641</a>] -         Fix description of metric `fullRestarts`
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14673'>FLINK-14673</a>] -         Shouldn&#39;t expect HMS client to throw NoSuchObjectException for non-existing function
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14683'>FLINK-14683</a>] -         RemoteStreamEnvironment&#39;s construction function has a wrong method
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14701'>FLINK-14701</a>] -         Slot leaks if SharedSlotOversubscribedException happens
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14784'>FLINK-14784</a>] -         CsvTableSink miss delimiter when row start with null member
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14817'>FLINK-14817</a>] -         &quot;Streaming Aggregation&quot; document contains misleading code examples
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14846'>FLINK-14846</a>] -         Correct the default writerbuffer size documentation of RocksDB
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14910'>FLINK-14910</a>] -         DisableAutoGeneratedUIDs fails on keyBy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14930'>FLINK-14930</a>] -         OSS Filesystem Uses Wrong Shading Prefix
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14949'>FLINK-14949</a>] -         Task cancellation can be stuck against out-of-thread error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14951'>FLINK-14951</a>] -         State TTL backend end-to-end test fail when taskManager has multiple slot
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14953'>FLINK-14953</a>] -         Parquet table source should use schema type to build FilterPredicate
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14960'>FLINK-14960</a>] -         Dependency shading of table modules test fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14976'>FLINK-14976</a>] -         Cassandra Connector leaks Semaphore on Throwable; hangs on close
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15001'>FLINK-15001</a>] -         The digest of sub-plan reuse should contain retraction traits for stream physical nodes
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15013'>FLINK-15013</a>] -         Flink (on YARN) sometimes needs too many slots
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15030'>FLINK-15030</a>] -         Potential deadlock for bounded blocking ResultPartition.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15036'>FLINK-15036</a>] -         Container startup error will be handled out side of the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15063'>FLINK-15063</a>] -         Input group and output group of the task metric are reversed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15065'>FLINK-15065</a>] -         RocksDB configurable options doc description error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15076'>FLINK-15076</a>] -         Source thread should be interrupted during the Task cancellation 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15234'>FLINK-15234</a>] -         Hive table created from flink catalog table shouldn&#39;t have null properties in parameters
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15240'>FLINK-15240</a>] -         is_generic key is missing for Flink table stored in HiveCatalog
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15259'>FLINK-15259</a>] -         HiveInspector.toInspectors() should convert Flink constant to Hive constant 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15266'>FLINK-15266</a>] -         NPE in blink planner code gen
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15361'>FLINK-15361</a>] -         ParquetTableSource should pass predicate in projectFields
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15412'>FLINK-15412</a>] -         LocalExecutorITCase#testParameterizedTypes failed in travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15413'>FLINK-15413</a>] -         ScalarOperatorsTest failed in travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15418'>FLINK-15418</a>] -         StreamExecMatchRule not set FlinkRelDistribution
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15421'>FLINK-15421</a>] -         GroupAggsHandler throws java.time.LocalDateTime cannot be cast to java.sql.Timestamp
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15435'>FLINK-15435</a>] -         ExecutionConfigTests.test_equals_and_hash in pyFlink fails when cpu core numbers is 6
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15443'>FLINK-15443</a>] -         Use JDBC connector write FLOAT value occur ClassCastException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15478'>FLINK-15478</a>] -         FROM_BASE64 code gen type wrong
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15489'>FLINK-15489</a>] -         WebUI log refresh not working
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15522'>FLINK-15522</a>] -         Misleading root cause exception when cancelling the job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15523'>FLINK-15523</a>] -         ConfigConstants generally excluded from japicmp
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15543'>FLINK-15543</a>] -         Apache Camel not bundled but listed in flink-dist NOTICE
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15549'>FLINK-15549</a>] -         Integer overflow in SpillingResettableMutableObjectIterator
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15577'>FLINK-15577</a>] -         WindowAggregate RelNodes missing Window specs in digest
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15615'>FLINK-15615</a>] -         Docs: wrong guarantees stated for the file sink
+</li>
+</ul>
+                
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11135'>FLINK-11135</a>] -         Reorder Hadoop config loading in HadoopUtils
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12848'>FLINK-12848</a>] -         Method equals() in RowTypeInfo should consider fieldsNames
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13729'>FLINK-13729</a>] -         Update website generation dependencies
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14008'>FLINK-14008</a>] -         Auto-generate binary licensing
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14104'>FLINK-14104</a>] -         Bump Jackson to 2.10.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14123'>FLINK-14123</a>] -         Lower the default value of taskmanager.memory.fraction
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14206'>FLINK-14206</a>] -         Let fullRestart metric count fine grained restarts as well
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14215'>FLINK-14215</a>] -         Add Docs for TM and JM Environment Variable Setting
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14251'>FLINK-14251</a>] -         Add FutureUtils#forward utility
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14334'>FLINK-14334</a>] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14335'>FLINK-14335</a>] -         ExampleIntegrationTest in testing docs is incorrect
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14408'>FLINK-14408</a>] -         In OldPlanner, UDF open method can not be invoke when SQL is optimized
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14557'>FLINK-14557</a>] -         Clean up the package of py4j
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14639'>FLINK-14639</a>] -         Metrics User Scope docs refer to wrong class
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14646'>FLINK-14646</a>] -         Check non-null for key in KeyGroupStreamPartitioner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14825'>FLINK-14825</a>] -         Rework state processor api documentation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14995'>FLINK-14995</a>] -         Kinesis NOTICE is incorrect
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15113'>FLINK-15113</a>] -         fs.azure.account.key not hidden from global configuration
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15554'>FLINK-15554</a>] -         Bump jetty-util-ajax to 9.3.24
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15657'>FLINK-15657</a>] -         Fix the python table api doc link in Python API tutorial
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15700'>FLINK-15700</a>] -         Improve Python API Tutorial doc
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15726'>FLINK-15726</a>] -         Fixing error message in StreamExecTableSourceScan
+</li>
+</ul>

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -7,6 +7,290 @@
 <atom:link href="https://flink.apache.org/blog/feed.xml" rel="self" type="application/rss+xml" />
 
 <item>
+<title>Apache Flink 1.9.2 Released</title>
+<description>&lt;p&gt;The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.&lt;/p&gt;
+
+&lt;p&gt;This release includes 117 fixes and minor improvements for Flink 1.9.1. The list below includes a detailed list of all fixes and improvements.&lt;/p&gt;
+
+&lt;p&gt;We highly recommend all users to upgrade to Flink 1.9.2.&lt;/p&gt;
+
+&lt;p&gt;Updated Maven dependencies:&lt;/p&gt;
+
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-xml&quot;&gt;&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-java&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.9.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-streaming-java_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.9.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-clients_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.9.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;You can find the binaries on the updated &lt;a href=&quot;/downloads.html&quot;&gt;Downloads page&lt;/a&gt;.&lt;/p&gt;
+
+&lt;p&gt;List of resolved issues:&lt;/p&gt;
+
+&lt;h2&gt;        Sub-task
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12122&quot;&gt;FLINK-12122&lt;/a&gt;] -         Spread out tasks evenly across all available registered TaskManagers
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13360&quot;&gt;FLINK-13360&lt;/a&gt;] -         Add documentation for HBase connector for Table API &amp;amp; SQL
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13361&quot;&gt;FLINK-13361&lt;/a&gt;] -         Add documentation for JDBC connector for Table API &amp;amp; SQL
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13723&quot;&gt;FLINK-13723&lt;/a&gt;] -         Use liquid-c for faster doc generation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13724&quot;&gt;FLINK-13724&lt;/a&gt;] -         Remove unnecessary whitespace from the docs&amp;#39; sidenav
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13725&quot;&gt;FLINK-13725&lt;/a&gt;] -         Use sassc for faster doc generation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13726&quot;&gt;FLINK-13726&lt;/a&gt;] -         Build docs with jekyll 4.0.0.pre.beta1
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13791&quot;&gt;FLINK-13791&lt;/a&gt;] -         Speed up sidenav by using group_by
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13817&quot;&gt;FLINK-13817&lt;/a&gt;] -         Expose whether web submissions are enabled
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13818&quot;&gt;FLINK-13818&lt;/a&gt;] -         Check whether web submission are enabled
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14535&quot;&gt;FLINK-14535&lt;/a&gt;] -         Cast exception is thrown when count distinct on decimal fields
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14735&quot;&gt;FLINK-14735&lt;/a&gt;] -         Improve batch schedule check input consumable performance
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Bug
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10377&quot;&gt;FLINK-10377&lt;/a&gt;] -         Remove precondition in TwoPhaseCommitSinkFunction.notifyCheckpointComplete
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-10435&quot;&gt;FLINK-10435&lt;/a&gt;] -         Client sporadically hangs after Ctrl + C
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-11120&quot;&gt;FLINK-11120&lt;/a&gt;] -         TIMESTAMPADD function handles TIME incorrectly
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-11835&quot;&gt;FLINK-11835&lt;/a&gt;] -         ZooKeeperLeaderElectionITCase.testJobExecutionOnClusterWithLeaderChange failed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12342&quot;&gt;FLINK-12342&lt;/a&gt;] -         Yarn Resource Manager Acquires Too Many Containers
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12399&quot;&gt;FLINK-12399&lt;/a&gt;] -         FilterableTableSource does not use filters on job run
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13184&quot;&gt;FLINK-13184&lt;/a&gt;] -         Starting a TaskExecutor blocks the YarnResourceManager&amp;#39;s main thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13589&quot;&gt;FLINK-13589&lt;/a&gt;] -         DelimitedInputFormat index error on multi-byte delimiters with whole file input splits
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13702&quot;&gt;FLINK-13702&lt;/a&gt;] -         BaseMapSerializerTest.testDuplicate fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13708&quot;&gt;FLINK-13708&lt;/a&gt;] -         Transformations should be cleared because a table environment could execute multiple job
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13740&quot;&gt;FLINK-13740&lt;/a&gt;] -         TableAggregateITCase.testNonkeyedFlatAggregate failed on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13749&quot;&gt;FLINK-13749&lt;/a&gt;] -         Make Flink client respect classloading policy
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13758&quot;&gt;FLINK-13758&lt;/a&gt;] -         Failed to submit JobGraph when registered hdfs file in DistributedCache 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13799&quot;&gt;FLINK-13799&lt;/a&gt;] -         Web Job Submit Page displays stream of error message when web submit is disables in the config
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13827&quot;&gt;FLINK-13827&lt;/a&gt;] -         Shell variable should be escaped in start-scala-shell.sh
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13862&quot;&gt;FLINK-13862&lt;/a&gt;] -         Update Execution Plan docs
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13945&quot;&gt;FLINK-13945&lt;/a&gt;] -         Instructions for building flink-shaded against vendor repository don&amp;#39;t work
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13969&quot;&gt;FLINK-13969&lt;/a&gt;] -         Resuming Externalized Checkpoint (rocks, incremental, scale down) end-to-end test fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13995&quot;&gt;FLINK-13995&lt;/a&gt;] -         Fix shading of the licence information of netty
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13999&quot;&gt;FLINK-13999&lt;/a&gt;] -         Correct the documentation of MATCH_RECOGNIZE
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14066&quot;&gt;FLINK-14066&lt;/a&gt;] -         Pyflink building failure in master and 1.9.0 version
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14074&quot;&gt;FLINK-14074&lt;/a&gt;] -         MesosResourceManager can&amp;#39;t create new taskmanagers in Session Cluster Mode.
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14175&quot;&gt;FLINK-14175&lt;/a&gt;] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14200&quot;&gt;FLINK-14200&lt;/a&gt;] -         Temporal Table Function Joins do not work on Tables (only TableSources) on the query side
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14235&quot;&gt;FLINK-14235&lt;/a&gt;] -         Kafka010ProducerITCase&amp;gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14315&quot;&gt;FLINK-14315&lt;/a&gt;] -         NPE with JobMaster.disconnectTaskManager
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14337&quot;&gt;FLINK-14337&lt;/a&gt;] -         HistoryServer does not handle NPE on corruped archives properly
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14347&quot;&gt;FLINK-14347&lt;/a&gt;] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14355&quot;&gt;FLINK-14355&lt;/a&gt;] -         Example code in state processor API docs doesn&amp;#39;t compile
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14370&quot;&gt;FLINK-14370&lt;/a&gt;] -         KafkaProducerAtLeastOnceITCase&amp;gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14382&quot;&gt;FLINK-14382&lt;/a&gt;] -         Incorrect handling of FLINK_PLUGINS_DIR on Yarn
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14398&quot;&gt;FLINK-14398&lt;/a&gt;] -         Further split input unboxing code into separate methods
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14413&quot;&gt;FLINK-14413&lt;/a&gt;] -         Shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14434&quot;&gt;FLINK-14434&lt;/a&gt;] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14445&quot;&gt;FLINK-14445&lt;/a&gt;] -         Python module build failed when making sdist
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14447&quot;&gt;FLINK-14447&lt;/a&gt;] -         Network metrics doc table render confusion
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14459&quot;&gt;FLINK-14459&lt;/a&gt;] -         Python module build hangs
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14524&quot;&gt;FLINK-14524&lt;/a&gt;] -         PostgreSQL JDBC sink generates invalid SQL in upsert mode
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14547&quot;&gt;FLINK-14547&lt;/a&gt;] -         UDF cannot be in the join condition in blink planner
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14561&quot;&gt;FLINK-14561&lt;/a&gt;] -         Don&amp;#39;t write FLINK_PLUGINS_DIR ENV variable to Flink configuration
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14562&quot;&gt;FLINK-14562&lt;/a&gt;] -         RMQSource leaves idle consumer after closing
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14574&quot;&gt;FLINK-14574&lt;/a&gt;] -          flink-s3-fs-hadoop doesn&amp;#39;t work with plugins mechanism
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14589&quot;&gt;FLINK-14589&lt;/a&gt;] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14641&quot;&gt;FLINK-14641&lt;/a&gt;] -         Fix description of metric `fullRestarts`
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14673&quot;&gt;FLINK-14673&lt;/a&gt;] -         Shouldn&amp;#39;t expect HMS client to throw NoSuchObjectException for non-existing function
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14683&quot;&gt;FLINK-14683&lt;/a&gt;] -         RemoteStreamEnvironment&amp;#39;s construction function has a wrong method
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14701&quot;&gt;FLINK-14701&lt;/a&gt;] -         Slot leaks if SharedSlotOversubscribedException happens
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14784&quot;&gt;FLINK-14784&lt;/a&gt;] -         CsvTableSink miss delimiter when row start with null member
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14817&quot;&gt;FLINK-14817&lt;/a&gt;] -         &amp;quot;Streaming Aggregation&amp;quot; document contains misleading code examples
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14846&quot;&gt;FLINK-14846&lt;/a&gt;] -         Correct the default writerbuffer size documentation of RocksDB
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14910&quot;&gt;FLINK-14910&lt;/a&gt;] -         DisableAutoGeneratedUIDs fails on keyBy
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14930&quot;&gt;FLINK-14930&lt;/a&gt;] -         OSS Filesystem Uses Wrong Shading Prefix
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14949&quot;&gt;FLINK-14949&lt;/a&gt;] -         Task cancellation can be stuck against out-of-thread error
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14951&quot;&gt;FLINK-14951&lt;/a&gt;] -         State TTL backend end-to-end test fail when taskManager has multiple slot
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14953&quot;&gt;FLINK-14953&lt;/a&gt;] -         Parquet table source should use schema type to build FilterPredicate
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14960&quot;&gt;FLINK-14960&lt;/a&gt;] -         Dependency shading of table modules test fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14976&quot;&gt;FLINK-14976&lt;/a&gt;] -         Cassandra Connector leaks Semaphore on Throwable; hangs on close
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15001&quot;&gt;FLINK-15001&lt;/a&gt;] -         The digest of sub-plan reuse should contain retraction traits for stream physical nodes
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15013&quot;&gt;FLINK-15013&lt;/a&gt;] -         Flink (on YARN) sometimes needs too many slots
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15030&quot;&gt;FLINK-15030&lt;/a&gt;] -         Potential deadlock for bounded blocking ResultPartition.
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15036&quot;&gt;FLINK-15036&lt;/a&gt;] -         Container startup error will be handled out side of the YarnResourceManager&amp;#39;s main thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15063&quot;&gt;FLINK-15063&lt;/a&gt;] -         Input group and output group of the task metric are reversed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15065&quot;&gt;FLINK-15065&lt;/a&gt;] -         RocksDB configurable options doc description error
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15076&quot;&gt;FLINK-15076&lt;/a&gt;] -         Source thread should be interrupted during the Task cancellation 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15234&quot;&gt;FLINK-15234&lt;/a&gt;] -         Hive table created from flink catalog table shouldn&amp;#39;t have null properties in parameters
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15240&quot;&gt;FLINK-15240&lt;/a&gt;] -         is_generic key is missing for Flink table stored in HiveCatalog
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15259&quot;&gt;FLINK-15259&lt;/a&gt;] -         HiveInspector.toInspectors() should convert Flink constant to Hive constant 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15266&quot;&gt;FLINK-15266&lt;/a&gt;] -         NPE in blink planner code gen
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15361&quot;&gt;FLINK-15361&lt;/a&gt;] -         ParquetTableSource should pass predicate in projectFields
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15412&quot;&gt;FLINK-15412&lt;/a&gt;] -         LocalExecutorITCase#testParameterizedTypes failed in travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15413&quot;&gt;FLINK-15413&lt;/a&gt;] -         ScalarOperatorsTest failed in travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15418&quot;&gt;FLINK-15418&lt;/a&gt;] -         StreamExecMatchRule not set FlinkRelDistribution
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15421&quot;&gt;FLINK-15421&lt;/a&gt;] -         GroupAggsHandler throws java.time.LocalDateTime cannot be cast to java.sql.Timestamp
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15435&quot;&gt;FLINK-15435&lt;/a&gt;] -         ExecutionConfigTests.test_equals_and_hash in pyFlink fails when cpu core numbers is 6
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15443&quot;&gt;FLINK-15443&lt;/a&gt;] -         Use JDBC connector write FLOAT value occur ClassCastException
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15478&quot;&gt;FLINK-15478&lt;/a&gt;] -         FROM_BASE64 code gen type wrong
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15489&quot;&gt;FLINK-15489&lt;/a&gt;] -         WebUI log refresh not working
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15522&quot;&gt;FLINK-15522&lt;/a&gt;] -         Misleading root cause exception when cancelling the job
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15523&quot;&gt;FLINK-15523&lt;/a&gt;] -         ConfigConstants generally excluded from japicmp
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15543&quot;&gt;FLINK-15543&lt;/a&gt;] -         Apache Camel not bundled but listed in flink-dist NOTICE
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15549&quot;&gt;FLINK-15549&lt;/a&gt;] -         Integer overflow in SpillingResettableMutableObjectIterator
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15577&quot;&gt;FLINK-15577&lt;/a&gt;] -         WindowAggregate RelNodes missing Window specs in digest
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15615&quot;&gt;FLINK-15615&lt;/a&gt;] -         Docs: wrong guarantees stated for the file sink
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Improvement
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-11135&quot;&gt;FLINK-11135&lt;/a&gt;] -         Reorder Hadoop config loading in HadoopUtils
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12848&quot;&gt;FLINK-12848&lt;/a&gt;] -         Method equals() in RowTypeInfo should consider fieldsNames
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13729&quot;&gt;FLINK-13729&lt;/a&gt;] -         Update website generation dependencies
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14008&quot;&gt;FLINK-14008&lt;/a&gt;] -         Auto-generate binary licensing
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14104&quot;&gt;FLINK-14104&lt;/a&gt;] -         Bump Jackson to 2.10.1
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14123&quot;&gt;FLINK-14123&lt;/a&gt;] -         Lower the default value of taskmanager.memory.fraction
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14206&quot;&gt;FLINK-14206&lt;/a&gt;] -         Let fullRestart metric count fine grained restarts as well
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14215&quot;&gt;FLINK-14215&lt;/a&gt;] -         Add Docs for TM and JM Environment Variable Setting
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14251&quot;&gt;FLINK-14251&lt;/a&gt;] -         Add FutureUtils#forward utility
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14334&quot;&gt;FLINK-14334&lt;/a&gt;] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14335&quot;&gt;FLINK-14335&lt;/a&gt;] -         ExampleIntegrationTest in testing docs is incorrect
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14408&quot;&gt;FLINK-14408&lt;/a&gt;] -         In OldPlanner, UDF open method can not be invoke when SQL is optimized
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14557&quot;&gt;FLINK-14557&lt;/a&gt;] -         Clean up the package of py4j
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14639&quot;&gt;FLINK-14639&lt;/a&gt;] -         Metrics User Scope docs refer to wrong class
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14646&quot;&gt;FLINK-14646&lt;/a&gt;] -         Check non-null for key in KeyGroupStreamPartitioner
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14825&quot;&gt;FLINK-14825&lt;/a&gt;] -         Rework state processor api documentation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14995&quot;&gt;FLINK-14995&lt;/a&gt;] -         Kinesis NOTICE is incorrect
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15113&quot;&gt;FLINK-15113&lt;/a&gt;] -         fs.azure.account.key not hidden from global configuration
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15554&quot;&gt;FLINK-15554&lt;/a&gt;] -         Bump jetty-util-ajax to 9.3.24
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15657&quot;&gt;FLINK-15657&lt;/a&gt;] -         Fix the python table api doc link in Python API tutorial
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15700&quot;&gt;FLINK-15700&lt;/a&gt;] -         Improve Python API Tutorial doc
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15726&quot;&gt;FLINK-15726&lt;/a&gt;] -         Fixing error message in StreamExecTableSourceScan
+&lt;/li&gt;
+&lt;/ul&gt;
+</description>
+<pubDate>Thu, 30 Jan 2020 13:00:00 +0100</pubDate>
+<link>https://flink.apache.org/news/2020/01/30/release-1.9.2.html</link>
+<guid isPermaLink="true">/news/2020/01/30/release-1.9.2.html</guid>
+</item>
+
+<item>
 <title>State Unlocked: Interacting with State in Apache Flink</title>
 <description>&lt;h1 id=&quot;introduction&quot;&gt;Introduction&lt;/h1&gt;
 

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></h2>
+
+      <p>30 Jan 2020
+       Hequn Cheng (<a href="https://twitter.com/HequnC">@HequnC</a>)</p>
+
+      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.</p>
+
+</p>
+
+      <p><a href="/news/2020/01/30/release-1.9.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></h2>
 
       <p>29 Jan 2020
@@ -307,22 +322,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/08/22/release-1.9.0.html">Apache Flink 1.9.0 Release Announcement</a></h2>
-
-      <p>22 Aug 2019
-      </p>
-
-      <p><p>The Apache Flink community is proud to announce the release of Apache Flink
-1.9.0.</p>
-
-</p>
-
-      <p><a href="/news/2019/08/22/release-1.9.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -354,6 +353,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/01/21/release-0.8.html">Apache Flink 0.8.0 available</a></h2>
+
+      <p>21 Jan 2015
+      </p>
+
+      <p><p>We are pleased to announce the availability of Flink 0.8.0. This release includes new user-facing features as well as performance and bug fixes, extends the support for filesystems and introduces the Scala API and flexible windowing semantics for Flink Streaming. A total of 33 people have contributed to this release, a big thanks to all of them!</p>
+
+</p>
+
+      <p><a href="/news/2015/01/21/release-0.8.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/01/06/december-in-flink.html">December 2014 in the Flink community</a></h2>
 
       <p>06 Jan 2015
@@ -308,6 +323,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -185,6 +185,22 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/08/22/release-1.9.0.html">Apache Flink 1.9.0 Release Announcement</a></h2>
+
+      <p>22 Aug 2019
+      </p>
+
+      <p><p>The Apache Flink community is proud to announce the release of Apache Flink
+1.9.0.</p>
+
+</p>
+
+      <p><a href="/news/2019/08/22/release-1.9.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/2019/07/23/flink-network-stack-2.html">Flink Network Stack Vol. 2: Monitoring, Metrics, and that Backpressure Thing</a></h2>
 
       <p>23 Jul 2019
@@ -311,19 +327,6 @@ for more details.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/features/2019/03/11/prometheus-monitoring.html">Flink and Prometheus: Cloud-native monitoring of streaming applications</a></h2>
-
-      <p>11 Mar 2019
-       Maximilian Bode, TNG Technology Consulting (<a href="https://twitter.com/mxpbode">@mxpbode</a>)</p>
-
-      <p>This blog post describes how developers can leverage Apache Flink's built-in metrics system together with Prometheus to observe and monitor streaming applications in an effective way.</p>
-
-      <p><a href="/features/2019/03/11/prometheus-monitoring.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -355,6 +358,16 @@ for more details.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -185,6 +185,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/features/2019/03/11/prometheus-monitoring.html">Flink and Prometheus: Cloud-native monitoring of streaming applications</a></h2>
+
+      <p>11 Mar 2019
+       Maximilian Bode, TNG Technology Consulting (<a href="https://twitter.com/mxpbode">@mxpbode</a>)</p>
+
+      <p>This blog post describes how developers can leverage Apache Flink's built-in metrics system together with Prometheus to observe and monitor streaming applications in an effective way.</p>
+
+      <p><a href="/features/2019/03/11/prometheus-monitoring.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/03/06/ffsf-preview.html">What to expect from Flink Forward San Francisco 2019</a></h2>
 
       <p>06 Mar 2019
@@ -315,21 +328,6 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.6.2.html">Apache Flink 1.6.2 Released</a></h2>
-
-      <p>29 Oct 2018
-      </p>
-
-      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.6 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/10/29/release-1.6.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -361,6 +359,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.6.2.html">Apache Flink 1.6.2 Released</a></h2>
+
+      <p>29 Oct 2018
+      </p>
+
+      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.6 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/10/29/release-1.6.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/10/29/release-1.5.5.html">Apache Flink 1.5.5 Released</a></h2>
 
       <p>29 Oct 2018
@@ -319,21 +334,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/03/08/release-1.4.2.html">Apache Flink 1.4.2 Released</a></h2>
-
-      <p>08 Mar 2018
-      </p>
-
-      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.4 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/03/08/release-1.4.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -365,6 +365,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/03/08/release-1.4.2.html">Apache Flink 1.4.2 Released</a></h2>
+
+      <p>08 Mar 2018
+      </p>
+
+      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.4 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/03/08/release-1.4.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">An Overview of End-to-End Exactly-Once Processing in Apache Flink (with Apache Kafka, too!)</a></h2>
 
       <p>01 Mar 2018
@@ -316,21 +331,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/06/01/release-1.3.0.html">Apache Flink 1.3.0 Release Announcement</a></h2>
-
-      <p>01 Jun 2017 by Robert Metzger (<a href="https://twitter.com/">@rmetzger_</a>)
-      </p>
-
-      <p><p>The Apache Flink community is pleased to announce the 1.3.0 release. Over the past 4 months, the Flink community has been working hard to resolve more than 680 issues. See the <a href="/blog/release_1.3.0-changelog.html">complete changelog</a> for more detail.</p>
-
-</p>
-
-      <p><a href="/news/2017/06/01/release-1.3.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -362,6 +362,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/06/01/release-1.3.0.html">Apache Flink 1.3.0 Release Announcement</a></h2>
+
+      <p>01 Jun 2017 by Robert Metzger (<a href="https://twitter.com/">@rmetzger_</a>)
+      </p>
+
+      <p><p>The Apache Flink community is pleased to announce the 1.3.0 release. Over the past 4 months, the Flink community has been working hard to resolve more than 680 issues. See the <a href="/blog/release_1.3.0-changelog.html">complete changelog</a> for more detail.</p>
+
+</p>
+
+      <p><a href="/news/2017/06/01/release-1.3.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/05/16/official-docker-image.html">Introducing Docker Images for Apache Flink</a></h2>
 
       <p>16 May 2017 by Patrick Lucas (Data Artisans) and Ismaël Mejía (Talend) (<a href="https://twitter.com/">@iemejia</a>)
@@ -312,21 +327,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/09/05/release-1.1.2.html">Apache Flink 1.1.2 Released</a></h2>
-
-      <p>05 Sep 2016
-      </p>
-
-      <p><p>The Apache Flink community released another bugfix version of the Apache Flink 1.1. series.</p>
-
-</p>
-
-      <p><a href="/news/2016/09/05/release-1.1.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -358,6 +358,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/09/05/release-1.1.2.html">Apache Flink 1.1.2 Released</a></h2>
+
+      <p>05 Sep 2016
+      </p>
+
+      <p><p>The Apache Flink community released another bugfix version of the Apache Flink 1.1. series.</p>
+
+</p>
+
+      <p><a href="/news/2016/09/05/release-1.1.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/08/24/ff16-keynotes-panels.html">Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion</a></h2>
 
       <p>24 Aug 2016
@@ -316,21 +331,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/03/08/release-1.0.0.html">Announcing Apache Flink 1.0.0</a></h2>
-
-      <p>08 Mar 2016
-      </p>
-
-      <p><p>The Apache Flink community is pleased to announce the availability of the 1.0.0 release. The community put significant effort into improving and extending Apache Flink since the last release, focusing on improving the experience of writing and executing data stream processing pipelines in production.</p>
-
-</p>
-
-      <p><a href="/news/2016/03/08/release-1.0.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -362,6 +362,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -185,6 +185,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/03/08/release-1.0.0.html">Announcing Apache Flink 1.0.0</a></h2>
+
+      <p>08 Mar 2016
+      </p>
+
+      <p><p>The Apache Flink community is pleased to announce the availability of the 1.0.0 release. The community put significant effort into improving and extending Apache Flink since the last release, focusing on improving the experience of writing and executing data stream processing pipelines in production.</p>
+
+</p>
+
+      <p><a href="/news/2016/03/08/release-1.0.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/02/11/release-0.10.2.html">Flink 0.10.2 Released</a></h2>
 
       <p>11 Feb 2016
@@ -317,24 +332,6 @@ Apache Flink started.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/08/24/introducing-flink-gelly.html">Introducing Gelly: Graph Processing with Apache Flink</a></h2>
-
-      <p>24 Aug 2015
-      </p>
-
-      <p><p>This blog post introduces <strong>Gelly</strong>, Apache Flink’s <em>graph-processing API and library</em>. Flink’s native support
-for iterations makes it a suitable platform for large-scale graph analytics.
-By leveraging delta iterations, Gelly is able to map various graph processing models such as
-vertex-centric or gather-sum-apply to Flink dataflows.</p>
-
-</p>
-
-      <p><a href="/news/2015/08/24/introducing-flink-gelly.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -366,6 +363,16 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -185,6 +185,24 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/08/24/introducing-flink-gelly.html">Introducing Gelly: Graph Processing with Apache Flink</a></h2>
+
+      <p>24 Aug 2015
+      </p>
+
+      <p><p>This blog post introduces <strong>Gelly</strong>, Apache Flink’s <em>graph-processing API and library</em>. Flink’s native support
+for iterations makes it a suitable platform for large-scale graph analytics.
+By leveraging delta iterations, Gelly is able to map various graph processing models such as
+vertex-centric or gather-sum-apply to Flink dataflows.</p>
+
+</p>
+
+      <p><a href="/news/2015/08/24/introducing-flink-gelly.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Announcing Apache Flink 0.9.0</a></h2>
 
       <p>24 Jun 2015
@@ -326,21 +344,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/01/21/release-0.8.html">Apache Flink 0.8.0 available</a></h2>
-
-      <p>21 Jan 2015
-      </p>
-
-      <p><p>We are pleased to announce the availability of Flink 0.8.0. This release includes new user-facing features as well as performance and bug fixes, extends the support for filesystems and introduces the Scala API and flexible windowing semantics for Flink Streaming. A total of 33 people have contributed to this release, a big thanks to all of them!</p>
-
-</p>
-
-      <p><a href="/news/2015/01/21/release-0.8.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -372,6 +375,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -196,7 +196,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-191" id="markdown-toc-apache-flink-191">Apache Flink 1.9.1</a></li>
+  <li><a href="#apache-flink-192" id="markdown-toc-apache-flink-192">Apache Flink 1.9.2</a></li>
   <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a></li>
   <li><a href="#apache-flink-172" id="markdown-toc-apache-flink-172">Apache Flink 1.7.2</a></li>
   <li><a href="#additional-components" id="markdown-toc-additional-components">Additional Components</a></li>
@@ -212,39 +212,39 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.9.1 is our latest stable release.</p>
+<p>Apache Flink® 1.9.2 is our latest stable release.</p>
 
 <p>If you plan to use Apache Flink together with Apache Hadoop (run Flink
 on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
 file system connector), please check out the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/ops/deployment/hadoop.html">Hadoop Integration</a> documentation.</p>
 
-<h2 id="apache-flink-191">Apache Flink 1.9.1</h2>
+<h2 id="apache-flink-192">Apache Flink 1.9.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz" class="ga-track" id="191-download_211">Apache Flink 1.9.1 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz" class="ga-track" id="192-download_211">Apache Flink 1.9.2 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz" class="ga-track" id="191-download_212">Apache Flink 1.9.1 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz" class="ga-track" id="192-download_212">Apache Flink 1.9.2 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-src.tgz" class="ga-track" id="191-download-source">Apache Flink 1.9.1 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz" class="ga-track" id="192-download-source">Apache Flink 1.9.2 Source Release</a>
+(<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components">Optional components</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar" class="ga-track" id="191-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar" class="ga-track" id="192-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar" class="ga-track" id="191-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar" class="ga-track" id="192-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar" class="ga-track" id="191-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar" class="ga-track" id="192-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="release-notes">Release Notes</h4>
@@ -398,17 +398,17 @@ main Flink release:</p>
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h2 id="update-policy-for-old-releases">Update Policy for old releases</h2>
@@ -424,6 +424,17 @@ main Flink release:</p>
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.9.2 - 2020-01-30 
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -557,6 +557,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></dt>
         <dd>This post discusses the efforts of the Flink community as they relate to state management in Apache Flink. We showcase some practical examples of how the different features and APIs can be utilized and cover some future ideas for new and improved ways of managing state in Apache Flink.</dd>
       
@@ -570,9 +575,6 @@
       
         <dt> <a href="/news/2019/12/09/flink-kubernetes-kudo.html">Running Apache Flink on Kubernetes with KUDO</a></dt>
         <dd>A common use case for Apache Flink is streaming data analytics together with Apache Kafka, which provides a pub/sub model and durability for data streams. In this post, we demonstrate how to orchestrate Flink and Kafka with KUDO.</dd>
-      
-        <dt> <a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></dt>
-        <dd>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</dd>
     
   </dl>
 

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -1,0 +1,515 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Apache Flink: Apache Flink 1.9.2 Released</title>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/flink.css">
+    <link rel="stylesheet" href="/css/syntax.css">
+
+    <!-- Blog RSS feed -->
+    <link href="/blog/feed.xml" rel="alternate" type="application/rss+xml" title="Apache Flink Blog: RSS feed" />
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <!-- We need to load Jquery in the header for custom google analytics event tracking-->
+    <script src="/js/jquery.min.js"></script>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>  
+    
+
+    <!-- Main content. -->
+    <div class="container">
+    <div class="row">
+
+      
+     <div id="sidebar" class="col-sm-3">
+        
+
+<!-- Top navbar. -->
+    <nav class="navbar navbar-default">
+        <!-- The logo. -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="navbar-logo">
+            <a href="/">
+              <img alt="Apache Flink" src="/img/flink-header-logo.svg" width="147px" height="73px">
+            </a>
+          </div>
+        </div><!-- /.navbar-header -->
+
+        <!-- The navigation links. -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-main">
+
+            <!-- First menu section explains visitors what Flink is -->
+
+            <!-- What is Stream Processing? -->
+            <!--
+            <li><a href="/streamprocessing1.html">What is Stream Processing?</a></li>
+            -->
+
+            <!-- What is Flink? -->
+            <li><a href="/flink-architecture.html">What is Apache Flink?</a></li>
+
+            
+
+            <!-- Use cases -->
+            <li><a href="/usecases.html">Use Cases</a></li>
+
+            <!-- Powered by -->
+            <li><a href="/poweredby.html">Powered By</a></li>
+
+            <!-- FAQ -->
+            <li><a href="/faq.html">FAQ</a></li>
+
+            &nbsp;
+            <!-- Second menu section aims to support Flink users -->
+
+            <!-- Downloads -->
+            <li><a href="/downloads.html">Downloads</a></li>
+
+            <!-- Getting Started -->
+            <li>
+              <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/getting-started/index.html" target="_blank">Getting Started <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            <!-- Documentation -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9" target="_blank">1.9 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+              </ul>
+            </li>
+
+            <!-- getting help -->
+            <li><a href="/gettinghelp.html">Getting Help</a></li>
+
+            <!-- Blog -->
+            <li class="active"><a href="/blog/"><b>Flink Blog</b></a></li>
+
+            <!-- Ecosystem -->
+            <li><a href="/ecosystem.html">Ecosystem</a></li>
+
+            &nbsp;
+
+            <!-- Third menu section aim to support community and contributors -->
+
+            <!-- Community -->
+            <li><a href="/community.html">Community &amp; Project Info</a></li>
+
+            <!-- Roadmap -->
+            <li><a href="/roadmap.html">Roadmap</a></li>
+
+            <!-- Contribute -->
+            <li><a href="/contributing/how-to-contribute.html">How to Contribute</a></li>
+            
+
+            <!-- GitHub -->
+            <li>
+              <a href="https://github.com/apache/flink" target="_blank">Flink on GitHub <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            &nbsp;
+
+            <!-- Language Switcher -->
+            <li>
+              
+                
+                  <!-- link to the Chinese home page when current is blog page -->
+                  <a href="/zh">中文版</a>
+                
+              
+            </li>
+
+          </ul>
+
+          <ul class="nav navbar-nav navbar-bottom">
+          <hr />
+
+            <!-- Twitter -->
+            <li><a href="https://twitter.com/apacheflink" target="_blank">@ApacheFlink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <!-- Visualizer -->
+            <li class=" hidden-md hidden-sm"><a href="/visualizer/" target="_blank">Plan Visualizer <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+          <hr />
+
+            <li><a href="https://apache.org" target="_blank">Apache Software Foundation <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <li>
+              <style>
+                .smalllinks:link {
+                  display: inline-block !important; background: none; padding-top: 0px; padding-bottom: 0px; padding-right: 0px; min-width: 75px;
+                }
+              </style>
+
+              <a class="smalllinks" href="https://www.apache.org/licenses/" target="_blank">License</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/security/" target="_blank">Security</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+            </li>
+
+          </ul>
+        </div><!-- /.navbar-collapse -->
+    </nav>
+
+      </div>
+      <div class="col-sm-9">
+      <div class="row-fluid">
+  <div class="col-sm-12">
+    <div class="row">
+      <h1>Apache Flink 1.9.2 Released</h1>
+
+      <article>
+        <p>30 Jan 2020 Hequn Cheng (<a href="https://twitter.com/HequnC">@HequnC</a>)</p>
+
+<p>The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.</p>
+
+<p>This release includes 117 fixes and minor improvements for Flink 1.9.1. The list below includes a detailed list of all fixes and improvements.</p>
+
+<p>We highly recommend all users to upgrade to Flink 1.9.2.</p>
+
+<p>Updated Maven dependencies:</p>
+
+<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span></code></pre></div>
+
+<p>You can find the binaries on the updated <a href="/downloads.html">Downloads page</a>.</p>
+
+<p>List of resolved issues:</p>
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12122">FLINK-12122</a>] -         Spread out tasks evenly across all available registered TaskManagers
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13360">FLINK-13360</a>] -         Add documentation for HBase connector for Table API &amp; SQL
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13361">FLINK-13361</a>] -         Add documentation for JDBC connector for Table API &amp; SQL
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13723">FLINK-13723</a>] -         Use liquid-c for faster doc generation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13724">FLINK-13724</a>] -         Remove unnecessary whitespace from the docs&#39; sidenav
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13725">FLINK-13725</a>] -         Use sassc for faster doc generation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13726">FLINK-13726</a>] -         Build docs with jekyll 4.0.0.pre.beta1
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13791">FLINK-13791</a>] -         Speed up sidenav by using group_by
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13817">FLINK-13817</a>] -         Expose whether web submissions are enabled
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13818">FLINK-13818</a>] -         Check whether web submission are enabled
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14535">FLINK-14535</a>] -         Cast exception is thrown when count distinct on decimal fields
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14735">FLINK-14735</a>] -         Improve batch schedule check input consumable performance
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-10377">FLINK-10377</a>] -         Remove precondition in TwoPhaseCommitSinkFunction.notifyCheckpointComplete
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-10435">FLINK-10435</a>] -         Client sporadically hangs after Ctrl + C
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-11120">FLINK-11120</a>] -         TIMESTAMPADD function handles TIME incorrectly
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-11835">FLINK-11835</a>] -         ZooKeeperLeaderElectionITCase.testJobExecutionOnClusterWithLeaderChange failed
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12342">FLINK-12342</a>] -         Yarn Resource Manager Acquires Too Many Containers
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12399">FLINK-12399</a>] -         FilterableTableSource does not use filters on job run
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13184">FLINK-13184</a>] -         Starting a TaskExecutor blocks the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13589">FLINK-13589</a>] -         DelimitedInputFormat index error on multi-byte delimiters with whole file input splits
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13702">FLINK-13702</a>] -         BaseMapSerializerTest.testDuplicate fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13708">FLINK-13708</a>] -         Transformations should be cleared because a table environment could execute multiple job
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13740">FLINK-13740</a>] -         TableAggregateITCase.testNonkeyedFlatAggregate failed on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13749">FLINK-13749</a>] -         Make Flink client respect classloading policy
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13758">FLINK-13758</a>] -         Failed to submit JobGraph when registered hdfs file in DistributedCache 
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13799">FLINK-13799</a>] -         Web Job Submit Page displays stream of error message when web submit is disables in the config
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13827">FLINK-13827</a>] -         Shell variable should be escaped in start-scala-shell.sh
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13862">FLINK-13862</a>] -         Update Execution Plan docs
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13945">FLINK-13945</a>] -         Instructions for building flink-shaded against vendor repository don&#39;t work
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13969">FLINK-13969</a>] -         Resuming Externalized Checkpoint (rocks, incremental, scale down) end-to-end test fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13995">FLINK-13995</a>] -         Fix shading of the licence information of netty
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13999">FLINK-13999</a>] -         Correct the documentation of MATCH_RECOGNIZE
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14066">FLINK-14066</a>] -         Pyflink building failure in master and 1.9.0 version
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14074">FLINK-14074</a>] -         MesosResourceManager can&#39;t create new taskmanagers in Session Cluster Mode.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14175">FLINK-14175</a>] -         Upgrade KPL version in flink-connector-kinesis to fix application OOM
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14200">FLINK-14200</a>] -         Temporal Table Function Joins do not work on Tables (only TableSources) on the query side
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14235">FLINK-14235</a>] -         Kafka010ProducerITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14315">FLINK-14315</a>] -         NPE with JobMaster.disconnectTaskManager
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14337">FLINK-14337</a>] -         HistoryServer does not handle NPE on corruped archives properly
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14347">FLINK-14347</a>] -         YARNSessionFIFOITCase.checkForProhibitedLogContents found a log with prohibited string
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14355">FLINK-14355</a>] -         Example code in state processor API docs doesn&#39;t compile
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14370">FLINK-14370</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceRegularSink fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14382">FLINK-14382</a>] -         Incorrect handling of FLINK_PLUGINS_DIR on Yarn
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14398">FLINK-14398</a>] -         Further split input unboxing code into separate methods
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14413">FLINK-14413</a>] -         Shade-plugin ApacheNoticeResourceTransformer uses platform-dependent encoding
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14434">FLINK-14434</a>] -         Dispatcher#createJobManagerRunner should not start JobManagerRunner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14445">FLINK-14445</a>] -         Python module build failed when making sdist
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14447">FLINK-14447</a>] -         Network metrics doc table render confusion
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14459">FLINK-14459</a>] -         Python module build hangs
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14524">FLINK-14524</a>] -         PostgreSQL JDBC sink generates invalid SQL in upsert mode
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14547">FLINK-14547</a>] -         UDF cannot be in the join condition in blink planner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14561">FLINK-14561</a>] -         Don&#39;t write FLINK_PLUGINS_DIR ENV variable to Flink configuration
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14562">FLINK-14562</a>] -         RMQSource leaves idle consumer after closing
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14574">FLINK-14574</a>] -          flink-s3-fs-hadoop doesn&#39;t work with plugins mechanism
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14589">FLINK-14589</a>] -         Redundant slot requests with the same AllocationID leads to inconsistent slot table
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14641">FLINK-14641</a>] -         Fix description of metric `fullRestarts`
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14673">FLINK-14673</a>] -         Shouldn&#39;t expect HMS client to throw NoSuchObjectException for non-existing function
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14683">FLINK-14683</a>] -         RemoteStreamEnvironment&#39;s construction function has a wrong method
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14701">FLINK-14701</a>] -         Slot leaks if SharedSlotOversubscribedException happens
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14784">FLINK-14784</a>] -         CsvTableSink miss delimiter when row start with null member
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14817">FLINK-14817</a>] -         &quot;Streaming Aggregation&quot; document contains misleading code examples
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14846">FLINK-14846</a>] -         Correct the default writerbuffer size documentation of RocksDB
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14910">FLINK-14910</a>] -         DisableAutoGeneratedUIDs fails on keyBy
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14930">FLINK-14930</a>] -         OSS Filesystem Uses Wrong Shading Prefix
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14949">FLINK-14949</a>] -         Task cancellation can be stuck against out-of-thread error
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14951">FLINK-14951</a>] -         State TTL backend end-to-end test fail when taskManager has multiple slot
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14953">FLINK-14953</a>] -         Parquet table source should use schema type to build FilterPredicate
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14960">FLINK-14960</a>] -         Dependency shading of table modules test fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14976">FLINK-14976</a>] -         Cassandra Connector leaks Semaphore on Throwable; hangs on close
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15001">FLINK-15001</a>] -         The digest of sub-plan reuse should contain retraction traits for stream physical nodes
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15013">FLINK-15013</a>] -         Flink (on YARN) sometimes needs too many slots
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15030">FLINK-15030</a>] -         Potential deadlock for bounded blocking ResultPartition.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15036">FLINK-15036</a>] -         Container startup error will be handled out side of the YarnResourceManager&#39;s main thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15063">FLINK-15063</a>] -         Input group and output group of the task metric are reversed
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15065">FLINK-15065</a>] -         RocksDB configurable options doc description error
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15076">FLINK-15076</a>] -         Source thread should be interrupted during the Task cancellation 
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15234">FLINK-15234</a>] -         Hive table created from flink catalog table shouldn&#39;t have null properties in parameters
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15240">FLINK-15240</a>] -         is_generic key is missing for Flink table stored in HiveCatalog
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15259">FLINK-15259</a>] -         HiveInspector.toInspectors() should convert Flink constant to Hive constant 
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15266">FLINK-15266</a>] -         NPE in blink planner code gen
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15361">FLINK-15361</a>] -         ParquetTableSource should pass predicate in projectFields
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15412">FLINK-15412</a>] -         LocalExecutorITCase#testParameterizedTypes failed in travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15413">FLINK-15413</a>] -         ScalarOperatorsTest failed in travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15418">FLINK-15418</a>] -         StreamExecMatchRule not set FlinkRelDistribution
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15421">FLINK-15421</a>] -         GroupAggsHandler throws java.time.LocalDateTime cannot be cast to java.sql.Timestamp
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15435">FLINK-15435</a>] -         ExecutionConfigTests.test_equals_and_hash in pyFlink fails when cpu core numbers is 6
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15443">FLINK-15443</a>] -         Use JDBC connector write FLOAT value occur ClassCastException
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15478">FLINK-15478</a>] -         FROM_BASE64 code gen type wrong
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15489">FLINK-15489</a>] -         WebUI log refresh not working
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15522">FLINK-15522</a>] -         Misleading root cause exception when cancelling the job
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15523">FLINK-15523</a>] -         ConfigConstants generally excluded from japicmp
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15543">FLINK-15543</a>] -         Apache Camel not bundled but listed in flink-dist NOTICE
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15549">FLINK-15549</a>] -         Integer overflow in SpillingResettableMutableObjectIterator
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15577">FLINK-15577</a>] -         WindowAggregate RelNodes missing Window specs in digest
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15615">FLINK-15615</a>] -         Docs: wrong guarantees stated for the file sink
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-11135">FLINK-11135</a>] -         Reorder Hadoop config loading in HadoopUtils
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-12848">FLINK-12848</a>] -         Method equals() in RowTypeInfo should consider fieldsNames
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13729">FLINK-13729</a>] -         Update website generation dependencies
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14008">FLINK-14008</a>] -         Auto-generate binary licensing
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14104">FLINK-14104</a>] -         Bump Jackson to 2.10.1
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14123">FLINK-14123</a>] -         Lower the default value of taskmanager.memory.fraction
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14206">FLINK-14206</a>] -         Let fullRestart metric count fine grained restarts as well
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14215">FLINK-14215</a>] -         Add Docs for TM and JM Environment Variable Setting
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14251">FLINK-14251</a>] -         Add FutureUtils#forward utility
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14334">FLINK-14334</a>] -         ElasticSearch docs refer to non-existent ExceptionUtils.containsThrowable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14335">FLINK-14335</a>] -         ExampleIntegrationTest in testing docs is incorrect
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14408">FLINK-14408</a>] -         In OldPlanner, UDF open method can not be invoke when SQL is optimized
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14557">FLINK-14557</a>] -         Clean up the package of py4j
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14639">FLINK-14639</a>] -         Metrics User Scope docs refer to wrong class
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14646">FLINK-14646</a>] -         Check non-null for key in KeyGroupStreamPartitioner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14825">FLINK-14825</a>] -         Rework state processor api documentation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14995">FLINK-14995</a>] -         Kinesis NOTICE is incorrect
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15113">FLINK-15113</a>] -         fs.azure.account.key not hidden from global configuration
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15554">FLINK-15554</a>] -         Bump jetty-util-ajax to 9.3.24
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15657">FLINK-15657</a>] -         Fix the python table api doc link in Python API tutorial
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15700">FLINK-15700</a>] -         Improve Python API Tutorial doc
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15726">FLINK-15726</a>] -         Fixing error message in StreamExecTableSourceScan
+</li>
+</ul>
+
+      </article>
+    </div>
+
+    <div class="row">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = 'stratosphere-eu'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+      </script>
+    </div>
+  </div>
+</div>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="row">
+      <div class="footer text-center col-sm-12">
+        <p>Copyright © 2014-2019 <a href="http://apache.org">The Apache Software Foundation</a>. All Rights Reserved.</p>
+        <p>Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        <p><a href="/privacy-policy.html">Privacy Policy</a> &middot; <a href="/blog/feed.xml">RSS feed</a></p>
+      </div>
+    </div>
+    </div><!-- /.container -->
+
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
+    <script src="/js/codetabs.js"></script>
+    <script src="/js/stickysidebar.js"></script>
+
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52545728-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+  </body>
+</html>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -194,7 +194,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-191" id="markdown-toc-apache-flink-191">Apache Flink 1.9.1</a></li>
+  <li><a href="#apache-flink-192" id="markdown-toc-apache-flink-192">Apache Flink 1.9.2</a></li>
   <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a></li>
   <li><a href="#apache-flink-172" id="markdown-toc-apache-flink-172">Apache Flink 1.7.2</a></li>
   <li><a href="#section-7" id="markdown-toc-section-7">额外组件</a></li>
@@ -210,40 +210,40 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.9.1 是我们最新的稳定版本。</p>
+<p>Apache Flink® 1.9.2 是我们最新的稳定版本。</p>
 
 <p>如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
 Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/zh/ops/deployment/hadoop.html">Hadoop 集成</a>文档。</p>
 
-<h2 id="apache-flink-191">Apache Flink 1.9.1</h2>
+<h2 id="apache-flink-192">Apache Flink 1.9.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz" class="ga-track" id="191-download_211">Apache Flink 1.9.1 for Scala 2.11</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz" class="ga-track" id="192-download_211">Apache Flink 1.9.2 for Scala 2.11</a> (<a href="
+ https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz" class="ga-track" id="191-download_212">Apache Flink 1.9.1 for Scala 2.12</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz" class="ga-track" id="192-download_212">Apache Flink 1.9.2 for Scala 2.12</a> (<a href="
+ https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.1/flink-1.9.1-src.tgz" class="ga-track" id="191-download-source">Apache Flink 1.9.1 Source Release</a>
- (<a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz" class="ga-track" id="192-download-source">Apache Flink 1.9.2 Source Release</a>
+ (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section">可选组件</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar" class="ga-track" id="191-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar" class="ga-track" id="192-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar" class="ga-track" id="191-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.1/flink-csv-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar" class="ga-track" id="192-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar" class="ga-track" id="191-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar" class="ga-track" id="192-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="section-1">发布说明</h4>
@@ -397,17 +397,17 @@ flink-docs-release-1.7/release-notes/flink-1.7.html">Flink 1.7 的发布说明</
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.9.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.9.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h2 id="section-9">旧版本的更新策略</h2>
@@ -421,6 +421,17 @@ flink-docs-release-1.7/release-notes/flink-1.7.html">Flink 1.7 的发布说明</
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.9.2 - 2020-01-30 
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -548,6 +548,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.9 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></dt>
         <dd>This post discusses the efforts of the Flink community as they relate to state management in Apache Flink. We showcase some practical examples of how the different features and APIs can be utilized and cover some future ideas for new and improved ways of managing state in Apache Flink.</dd>
       
@@ -561,9 +566,6 @@
       
         <dt> <a href="/news/2019/12/09/flink-kubernetes-kudo.html">Running Apache Flink on Kubernetes with KUDO</a></dt>
         <dd>A common use case for Apache Flink is streaming data analytics together with Apache Kafka, which provides a pub/sub model and durability for data streams. In this post, we demonstrate how to orchestrate Flink and Kafka with KUDO.</dd>
-      
-        <dt> <a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></dt>
-        <dd>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</dd>
     
   </dl>
 


### PR DESCRIPTION
Adds release announcement and download link for 1.9.2
Dates on announcements are still TBD and should be updated accordingly once release happens.