### PR TITLE
[FLINK-15823] Sync download page translation for Chinese

### DIFF
--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -194,22 +194,9 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-191" id="markdown-toc-apache-flink-191">Apache Flink 1.9.1</a>    <ul>
-      <li><a href="#section" id="markdown-toc-section">可选组件</a></li>
-    </ul>
-  </li>
-  <li><a href="#section-1" id="markdown-toc-section-1">发布说明</a></li>
-  <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a>    <ul>
-      <li><a href="#section-2" id="markdown-toc-section-2">可选组件</a></li>
-    </ul>
-  </li>
-  <li><a href="#section-3" id="markdown-toc-section-3">发布说明</a></li>
-  <li><a href="#apache-flink-172" id="markdown-toc-apache-flink-172">Apache Flink 1.7.2</a>    <ul>
-      <li><a href="#section-4" id="markdown-toc-section-4">可选组件</a></li>
-      <li><a href="#section-5" id="markdown-toc-section-5">其他替代执行包</a></li>
-    </ul>
-  </li>
-  <li><a href="#section-6" id="markdown-toc-section-6">发布说明</a></li>
+  <li><a href="#apache-flink-191" id="markdown-toc-apache-flink-191">Apache Flink 1.9.1</a></li>
+  <li><a href="#apache-flink-183" id="markdown-toc-apache-flink-183">Apache Flink 1.8.3</a></li>
+  <li><a href="#apache-flink-172" id="markdown-toc-apache-flink-172">Apache Flink 1.7.2</a></li>
   <li><a href="#section-7" id="markdown-toc-section-7">额外组件</a></li>
   <li><a href="#section-8" id="markdown-toc-section-8">验证哈希和签名</a></li>
   <li><a href="#maven-" id="markdown-toc-maven-">Maven 依赖</a></li>
@@ -226,9 +213,7 @@ $( document ).ready(function() {
 <p>Apache Flink® 1.9.1 是我们最新的稳定版本。</p>
 
 <p>如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
-Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的下载包，且另外下載对应版本的 Hadoop 库，并且把下载后的 Hadoop 库放置
-到 Flink 安装目录下的 lib 目录
-包并<a href="https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html">设置 HADOOP_CLASSPATH 环境变量</a>。</p>
+Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/zh/ops/deployment/hadoop.html">Hadoop 集成</a>文档。</p>
 
 <h2 id="apache-flink-191">Apache Flink 1.9.1</h2>
 
@@ -247,7 +232,7 @@ Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的
  (<a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz.sha512">sha512</a>)
 </p>
 
-<h3 id="section">可选组件</h3>
+<h4 id="section">可选组件</h4>
 
 <p>
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar" class="ga-track" id="191-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.1/flink-avro-1.9.1.jar.sha1">sha1</a>)
@@ -261,7 +246,7 @@ Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar" class="ga-track" id="191-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.1/flink-json-1.9.1.jar.sha1">sha1</a>)
 </p>
 
-<h2 id="section-1">发布说明</h2>
+<h4 id="section-1">发布说明</h4>
 
 <p>如果你计划从以前的版本升级 Flink，请查看 <a href="https://ci.apache.org/projects/flink/
 flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</a>。</p>
@@ -283,7 +268,7 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
  (<a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz.sha512">sha512</a>)
 </p>
 
-<h3 id="section-2">可选组件</h3>
+<h4 id="section-2">可选组件</h4>
 
 <p>
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar" class="ga-track" id="183-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.8.3/flink-avro-1.8.3.jar.sha1">sha1</a>)
@@ -297,10 +282,10 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar" class="ga-track" id="183-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.8.3/flink-json-1.8.3.jar.sha1">sha1</a>)
 </p>
 
-<h2 id="section-3">发布说明</h2>
+<h4 id="section-3">发布说明</h4>
 
 <p>如果你计划从以前的版本升级 Flink，请查看 <a href="https://ci.apache.org/projects/flink/
-flink-docs-release-1.8/release-notes/flink-1.8.html">Flink 1.9 的发布说明</a>。</p>
+flink-docs-release-1.8/release-notes/flink-1.8.html">Flink 1.8 的发布说明</a>。</p>
 
 <h2 id="apache-flink-172">Apache Flink 1.7.2</h2>
 
@@ -319,7 +304,7 @@ flink-docs-release-1.8/release-notes/flink-1.8.html">Flink 1.9 的发布说明</
  (<a href="https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz.sha512">sha512</a>)
 </p>
 
-<h3 id="section-4">可选组件</h3>
+<h4 id="section-4">可选组件</h4>
 
 <p>
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar" class="ga-track" id="172-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.7.2/flink-avro-1.7.2.jar.sha1">sha1</a>)
@@ -329,7 +314,7 @@ flink-docs-release-1.8/release-notes/flink-1.8.html">Flink 1.9 的发布说明</
 <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar" class="ga-track" id="172-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.7.2/flink-json-1.7.2.jar.sha1">sha1</a>)
 </p>
 
-<h3 id="section-5">其他替代执行包</h3>
+<h4 id="section-5">其他替代执行包</h4>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz" class="ga-track" id="172-download-hadoop24_211">Apache Flink 1.7.2 with Hadoop® 2.4 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop24-scala_2.11.tgz.asc">asc</a>, <a href="">sha512</a>)
@@ -363,10 +348,10 @@ flink-docs-release-1.8/release-notes/flink-1.8.html">Flink 1.9 的发布说明</
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz" class="ga-track" id="172-download-hadoop28_212">Apache Flink 1.7.2 with Hadoop® 2.8 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-bin-hadoop28-scala_2.12.tgz.asc">asc</a>, <a href="">sha512</a>)
 </p>
 
-<h2 id="section-6">发布说明</h2>
+<h4 id="section-6">发布说明</h4>
 
 <p>如果你计划从以前的版本升级 Flink，请查看 <a href="https://ci.apache.org/projects/flink/
-flink-docs-release-1.7/release-notes/flink-1.7.html">Flink 1.9 的发布说明</a>。</p>
+flink-docs-release-1.7/release-notes/flink-1.7.html">Flink 1.7 的发布说明</a>。</p>
 
 <h2 id="section-7">额外组件</h2>
 

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -59,7 +59,7 @@ Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BA
 {% endif %}
 
 {% if flink_release.optional_components %}
-### 可选组件
+#### 可选组件
 
 {% assign components = flink_release.optional_components | | sort: 'name' %}
 {% for component in components %}
@@ -94,7 +94,7 @@ Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BA
 {% endif %}
 
 {% if flink_release.alternative_binaries %}
-### 其他替代执行包
+#### 其他替代执行包
 
 {% assign alternatives = flink_release.alternative_binaries | | sort: 'name' %}
 {% for alternative in alternatives %}
@@ -123,9 +123,9 @@ Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BA
 
 {% endif %}
 
-## 发布说明
+#### 发布说明
 
-如果你计划从以前的版本升级 Flink，请查看 [Flink {{ site.FLINK_VERSION_STABLE_SHORT }} 的发布说明]({{ site.DOCS_BASE_URL }}
+如果你计划从以前的版本升级 Flink，请查看 [Flink {{ flink_release.version_short }} 的发布说明]({{ site.DOCS_BASE_URL }}
 flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flink_release.version_short }}.html)。
 
 {% endfor %}

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -21,9 +21,7 @@ $( document ).ready(function() {
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} 是我们最新的稳定版本。
 
 如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
-Hadoop 文件系统的 connector ），请选择包含匹配的 Hadoop 版本的下载包，且另外下載对应版本的 Hadoop 库，并且把下载后的 Hadoop 库放置
-到 Flink 安装目录下的 lib 目录
-包并[设置 HADOOP_CLASSPATH 环境变量](https://ci.apache.org/projects/flink/flink-docs-stable/ops/deployment/hadoop.html)。
+Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ site.FLINK_VERSION_STABLE_SHORT }}/zh/ops/deployment/hadoop.html)文档。
 
 {% for flink_release in site.flink_releases %}
 


### PR DESCRIPTION
Adjust the Chinese version of `downloads.md` for the changes made in https://issues.apache.org/jira/browse/FLINK-15800

Furthermore, the version display under `Release Notes`  is wrong for the Chinese download page, so change `site.FLINK_VERSION_STABLE_SHORT` to `flink_release.version_short`.