### PR TITLE
Update expired links in the Powered By page.

### DIFF
--- a/poweredby.md
+++ b/poweredby.md
@@ -70,7 +70,7 @@ If you would you like to be included on this page, please reach out to the [Flin
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/king-logo.png" alt="King" /><br />
-      King, the creators of Candy Crush Saga, uses Flink to provide data science teams a real-time analytics dashboard. <br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read about King's Flink implementation</a>
+      King, the creators of Candy Crush Saga, uses Flink to provide data science teams a real-time analytics dashboard. <br><br><a href="https://www.youtube.com/watch?v=17tUR4TsvpM" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Learn more about King's Flink implementation</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/klaviyo-logo.png" alt="Klaviyo" /><br />
@@ -123,7 +123,7 @@ If you would you like to be included on this page, please reach out to the [Flin
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/telefonica-next-logo.png" alt="Telefonica Next" /><br />
-      Telefónica NEXT's TÜV-certified Data Anonymization Platform is powered by Flink. <br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Telefónica NEXT</a>
+      Telefónica NEXT's TÜV-certified Data Anonymization Platform is powered by Flink. <br><br><a href="https://2016.flink-forward.org/index.html%3Fp=592.html" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> Read more about Telefónica NEXT</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/tencent-logo.png" alt="Tencent" /><br />

--- a/poweredby.zh.md
+++ b/poweredby.zh.md
@@ -70,7 +70,7 @@ Apache Flink 为全球许多公司和企业的关键业务提供支持。在这�
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/king-logo.png" alt="King" /><br />
-      King，Candy Crush Saga的创建者，使用 Flink 为数据科学团队提供实时分析仪表板。<br><br><a href="https://techblog.king.com/rbea-scalable-real-time-analytics-king/" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读 King 的 Flink 实现</a>
+      King，Candy Crush Saga的创建者，使用 Flink 为数据科学团队提供实时分析仪表板。<br><br><a href="https://www.youtube.com/watch?v=17tUR4TsvpM" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 阅读 King 的 Flink 实现</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/klaviyo-logo.png" alt="Klaviyo" /><br />
@@ -124,7 +124,7 @@ Apache Flink 为全球许多公司和企业的关键业务提供支持。在这�
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/telefonica-next-logo.png" alt="Telefonica Next" /><br />
-      Telefónica NEXT 的 TÜV 认证数据匿名平台由 Flink 提供支持。<br><br><a href="https://next.telefonica.de/en/solutions/big-data-privacy-services" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关于 Telefónica NEXT 的信息</a>
+      Telefónica NEXT 的 TÜV 认证数据匿名平台由 Flink 提供支持。<br><br><a href="https://2016.flink-forward.org/index.html%3Fp=592.html" target='_blank'><small><span class="glyphicon glyphicon-new-window"></span></small> 了解更多关于 Telefónica NEXT 的信息</a>
   </div>
   <div class="powered-by-tile col-md-3 col-sm-4 col-xs-6">
     <img src="{{ site.baseurl }}/img/poweredby/tencent-logo.png" alt="Tencent" /><br />


### PR DESCRIPTION
The use cases for King and Telefónica DE point to links that aren't valid anymore.