### PR TITLE
[hotfix] Remove mention of icla requirement on how to contrib guide

### DIFF
--- a/contributing/how-to-contribute.md
+++ b/contributing/how-to-contribute.md
@@ -84,19 +84,6 @@ Apache Flink is developed by an open and friendly community. Everybody is cordia
 
 ## Further reading
 
-### Submit a Contributor License Agreement
-
-Please submit a contributor license agreement to the Apache Software Foundation (ASF) if you are contributing a lot of code to Apache Flink. The following quote from [http://www.apache.org/licenses](http://www.apache.org/licenses/#clas) gives more information about the ICLA and CCLA and why they are necessary.
-
-> The ASF desires that all contributors of ideas, code, or documentation to the Apache projects complete, sign, and submit (via postal mail, fax or email) an [Individual Contributor License Agreement](http://www.apache.org/licenses/icla.txt) (CLA) [ [PDF form](http://www.apache.org/licenses/icla.pdf) ]. The purpose of this agreement is to clearly define the terms under which intellectual property has been contributed to the ASF and thereby allow us to defend the project should there be a legal dispute regarding the software at some future time. A signed CLA is required to be on file before an individual is given commit rights to an ASF project.
->
-> For a corporation that has assigned employees to work on an Apache project, a [Corporate CLA](http://www.apache.org/licenses/cla-corporate.txt) (CCLA) is available for contributing intellectual property via the corporation, that may have been assigned as part of an employment agreement. Note that a Corporate CLA does not remove the need for every developer to sign their own CLA as an individual, to cover any of their contributions which are not owned by the corporation signing the CCLA.
->
->  ...
-
------
-
-### Becoming a Flink Committer and PMC member
 
 #### How to become a committer
 


### PR DESCRIPTION
I would like to remove this part of the flink website, as it regularly leads to first time contributors submitting the document through the asf secretary, which is not the purpose of the section.