### PR TITLE
[FLINK-16436] Update Apache downloads link due to INFRA structural changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,19 +56,19 @@ flink_releases:
           scala_211:
               id: "1100-download_211"
               url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512"
           scala_212:
               id: "1100-download_212"
               url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512"
       source_release:
           name: "Apache Flink 1.10.0"
           id: "1100-download-source"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512"
+          asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
@@ -101,19 +101,19 @@ flink_releases:
           scala_211:
               id: "192-download_211"
               url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512"
+              asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512"
           scala_212:
               id: "192-download_212"
               url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz"
-              asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512"
+              asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512"
       source_release:
           name: "Apache Flink 1.9.2"
           id: "192-download-source"
           url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz"
-          asc_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc"
-          sha512_url: "https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512"
+          asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
@@ -145,8 +145,8 @@ component_releases:
       name: "Apache Flink-shaded 10.0 Source Release"
       id: "s100-download-source"
       url: "https://www.apache.org/dyn/closer.lua/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz"
-      asc_url: "https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc"
-      sha512_url: "https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512"
+      asc_url: "https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc"
+      sha512_url: "https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512"
   -
       name: "Pre-bundled Hadoop 2.4.1"
       id: bundled-hadoop-241-100

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -222,16 +222,16 @@ file system connector), please check out the <a href="https://ci.apache.org/proj
 <h2 id="apache-flink-1100">Apache Flink 1.10.0</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz" class="ga-track" id="1100-download_211">Apache Flink 1.10.0 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz" class="ga-track" id="1100-download_211">Apache Flink 1.10.0 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz" class="ga-track" id="1100-download_212">Apache Flink 1.10.0 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz" class="ga-track" id="1100-download_212">Apache Flink 1.10.0 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz" class="ga-track" id="1100-download-source">Apache Flink 1.10.0 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
+(<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components">Optional components</h4>
@@ -257,16 +257,16 @@ file system connector), please check out the <a href="https://ci.apache.org/proj
 <h2 id="apache-flink-192">Apache Flink 1.9.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz" class="ga-track" id="192-download_211">Apache Flink 1.9.2 for Scala 2.11</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz" class="ga-track" id="192-download_211">Apache Flink 1.9.2 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz" class="ga-track" id="192-download_212">Apache Flink 1.9.2 for Scala 2.12</a> (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz" class="ga-track" id="192-download_212">Apache Flink 1.9.2 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz" class="ga-track" id="192-download-source">Apache Flink 1.9.2 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
+(<a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components-1">Optional components</h4>
@@ -296,7 +296,7 @@ main Flink release:</p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz" class="ga-track" id="s100-download-source">Apache Flink-shaded 10.0 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512">sha512</a>)
+(<a href="https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512">sha512</a>)
 </p>
 
 <p>
@@ -321,7 +321,7 @@ main Flink release:</p>
 
 <h2 id="verifying-hashes-and-signatures">Verifying Hashes and Signatures</h2>
 
-<p>Along with our releases, we also provide sha512 hashes in <code>*.sha512</code> files and cryptographic signatures in <code>*.asc</code> files. The Apache Software Foundation has an extensive <a href="http://www.apache.org/info/verification.html">tutorial to verify hashes and signatures</a> which you can follow by using any of these release-signing <a href="https://www.apache.org/dist/flink/KEYS">KEYS</a>.</p>
+<p>Along with our releases, we also provide sha512 hashes in <code>*.sha512</code> files and cryptographic signatures in <code>*.asc</code> files. The Apache Software Foundation has an extensive <a href="http://www.apache.org/info/verification.html">tutorial to verify hashes and signatures</a> which you can follow by using any of these release-signing <a href="https://downloads.apache.org/flink/KEYS">KEYS</a>.</p>
 
 <h2 id="maven-dependencies">Maven Dependencies</h2>
 

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -220,17 +220,17 @@ Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz" class="ga-track" id="1100-download_211">Apache Flink 1.10.0 for Scala 2.11</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
+ https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz" class="ga-track" id="1100-download_212">Apache Flink 1.10.0 for Scala 2.12</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
+ https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz" class="ga-track" id="1100-download-source">Apache Flink 1.10.0 Source Release</a>
- (<a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
+ (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section">可选组件</h4>
@@ -256,17 +256,17 @@ flink-docs-release-1.10/release-notes/flink-1.10.html">Flink 1.10 的发布说�
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz" class="ga-track" id="192-download_211">Apache Flink 1.9.2 for Scala 2.11</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
+ https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz" class="ga-track" id="192-download_212">Apache Flink 1.9.2 for Scala 2.12</a> (<a href="
- https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
+ https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz" class="ga-track" id="192-download-source">Apache Flink 1.9.2 Source Release</a>
- (<a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
+ (<a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section-2">可选组件</h4>
@@ -294,7 +294,7 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
 
 <p>
 <a href="https://www.apache.org/dyn/closer.lua/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz" class="ga-track" id="s100-download-source">Apache Flink-shaded 10.0 Source Release</a>
-(<a href="https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512">sha512</a>)
+(<a href="https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-shaded-10.0/flink-shaded-10.0-src.tgz.sha512">sha512</a>)
 </p>
 
 <p>
@@ -319,7 +319,7 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
 
 <h2 id="section-5">验证哈希和签名</h2>
 
-<p>随着每次版本发布，我们还提供了包含 sha512 哈希的 <code>*.sha512</code> 文件和包含加密签名的 <code>*.asc</code> 文件。Apache 软件基金会有一个通用的<a href="http://www.apache.org/info/verification.html">教程来验证哈希和签名</a>，你可以使用这些版本签名的 <a href="https://www.apache.org/dist/flink/KEYS">KEYS</a> 来校验它们。</p>
+<p>随着每次版本发布，我们还提供了包含 sha512 哈希的 <code>*.sha512</code> 文件和包含加密签名的 <code>*.asc</code> 文件。Apache 软件基金会有一个通用的<a href="http://www.apache.org/info/verification.html">教程来验证哈希和签名</a>，你可以使用这些版本签名的 <a href="https://downloads.apache.org/flink/KEYS">KEYS</a> 来校验它们。</p>
 
 <h2 id="maven-">Maven 依赖</h2>
 

--- a/downloads.md
+++ b/downloads.md
@@ -131,7 +131,7 @@ main Flink release:
 
 ## Verifying Hashes and Signatures
 
-Along with our releases, we also provide sha512 hashes in `*.sha512` files and cryptographic signatures in `*.asc` files. The Apache Software Foundation has an extensive [tutorial to verify hashes and signatures](http://www.apache.org/info/verification.html) which you can follow by using any of these release-signing [KEYS](https://www.apache.org/dist/flink/KEYS).
+Along with our releases, we also provide sha512 hashes in `*.sha512` files and cryptographic signatures in `*.asc` files. The Apache Software Foundation has an extensive [tutorial to verify hashes and signatures](http://www.apache.org/info/verification.html) which you can follow by using any of these release-signing [KEYS](https://downloads.apache.org/flink/KEYS).
 
 ## Maven Dependencies
 

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -145,7 +145,7 @@ flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flin
 
 ## 验证哈希和签名
 
-随着每次版本发布，我们还提供了包含 sha512 哈希的 `*.sha512` 文件和包含加密签名的 `*.asc` 文件。Apache 软件基金会有一个通用的[教程来验证哈希和签名](http://www.apache.org/info/verification.html)，你可以使用这些版本签名的 [KEYS](https://www.apache.org/dist/flink/KEYS) 来校验它们。
+随着每次版本发布，我们还提供了包含 sha512 哈希的 `*.sha512` 文件和包含加密签名的 `*.asc` 文件。Apache 软件基金会有一个通用的[教程来验证哈希和签名](http://www.apache.org/info/verification.html)，你可以使用这些版本签名的 [KEYS](https://downloads.apache.org/flink/KEYS) 来校验它们。
 
 ## Maven 依赖
 


### PR DESCRIPTION
According to the INFRA notice, we need to replace all `www.apache.org/dist` links with `downloads.apache.org`. More details please refer to [FLINK-16436](https://issues.apache.org/jira/browse/FLINK-16436).

Have manually checked all updated links are valid.