### PR TITLE
Add Stateful Functions 2.0.0 to Downloads page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,12 @@ FLINK_GITHUB_URL: https://github.com/apache/flink
 FLINK_CONTRIBUTORS_URL: https://cwiki.apache.org/confluence/display/FLINK/List+of+contributors
 FLINK_GITHUB_REPO_NAME: flink
 
+FLINK_STATEFUN_VERSION_STABLE: 2.0.0
+FLINK_STATEFUN_STABLE_SHORT: "2.0"
+
+FLINK_STATEFUN_GITHUB_URL: https://github.com/apache/flink-statefun
+FLINK_GITHUB_REPO_NAME: flink-statefun
+
 # Example for scala dependent component:
 #  -
 #    name: "Prometheus MetricReporter"
@@ -139,6 +145,17 @@ flink_releases:
           url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar
           asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.asc
           sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.sha1
+
+flink_statefun_releases:
+  -
+      version_short: "2.0"
+      source_release:
+          name: "Apache Flink Stateful Functions 2.0.0"
+          id: "200-statefun-download-source"
+          flink_version: "1.10.0"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-statefun-2.0.0/flink-statefun-2.0.0-src.tgz"
+          asc_url: "https://downloads.apache.org/flink/flink-statefun-2.0.0/flink-statefun-2.0.0-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-statefun-2.0.0/flink-statefun-2.0.0-src.tgz.sha512"
 
 component_releases:
   -
@@ -376,6 +393,12 @@ release_archive:
       -
         version_long: 0.6-incubating
         release_date: 2014-08-26
+
+    flink_statefun:
+      -
+        version_short: 2.0
+        version_long: 2.0.0
+        release_date: 2020-04-02
 
     flink_shaded:
       -

--- a/downloads.md
+++ b/downloads.md
@@ -115,6 +115,23 @@ Please have a look at the [Release Notes for Flink {{ flink_release.version_shor
 
 {% endfor %}
 
+Apache Flink® Stateful Functions {{ site.FLINK_STATEFUN_VERSION_STABLE }} is the latest stable release for the Stateful Functions component.
+
+{% for flink_statefun_release in site.flink_statefun_releases %}
+
+## {{ flink_statefun_release.source_release.name }}
+
+<p>
+<a href="{{ flink_statefun_release.source_release.url }}" class="ga-track" id="{{ flink_statefun_release.source_release.id }}">{{ flink_statefun_release.source_release.name }} Source Release</a>
+(<a href="{{ flink_statefun_release.source_release.asc_url }}">asc</a>, <a href="{{ flink_statefun_release.source_release.sha512_url }}">sha512</a>)
+</p>
+
+This version is compatible with Apache Flink version {{ flink_statefun_release.source_release.flink_version }}.
+
+---
+
+{% endfor %}
+
 ## Additional Components
 
 These are components that the Flink project develops which are not part of the
@@ -134,6 +151,8 @@ main Flink release:
 Along with our releases, we also provide sha512 hashes in `*.sha512` files and cryptographic signatures in `*.asc` files. The Apache Software Foundation has an extensive [tutorial to verify hashes and signatures](http://www.apache.org/info/verification.html) which you can follow by using any of these release-signing [KEYS](https://downloads.apache.org/flink/KEYS).
 
 ## Maven Dependencies
+
+### Apache Flink
 
 You can add the following dependencies to your `pom.xml` to include Apache Flink in your project. These dependencies include a local execution environment and thus support local testing.
 
@@ -156,6 +175,26 @@ You can add the following dependencies to your `pom.xml` to include Apache Flink
   <version>{{ site.FLINK_VERSION_STABLE }}</version>
 </dependency>
 ```
+
+### Apache Flink Stateful Functions
+
+You can add the following dependencies to your `pom.xml` to include Apache Flink Stateful Functions in your project.
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>statefun-sdk</artifactId>
+  <version>{{ site.FLINK_STATEFUN_VERSION_STABLE }}</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>statefun-flink-harness</artifactId>
+  <version>{{ site.FLINK_STATEFUN_VERSION_STABLE }}</version>
+</dependency>
+```
+
+The `statefun-sdk` dependency is the only one you will need to start developing applications.
+The `statefun-flink-harness` dependency includes a local execution environment that allows you to locally test your application in an IDE.
 
 ## Update Policy for old releases
 
@@ -185,6 +224,19 @@ Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
 (<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>, 
 <a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>)
 {% endif %}
+</li>
+{% endfor %}
+</ul>
+
+### Flink-StateFun
+{% assign flink_statefun_releases = site.release_archive.flink_statefun %}
+<ul>
+{% for flink_statefun_release in flink_statefun_releases %}
+<li>
+Flink Stateful Functions {{ flink_statefun_release.version_long }} - {{ flink_statefun_release.release_date }} 
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-{{ flink_statefun_release.version_long }}/flink-statefun-{{ flink_statefun_release.version_long }}-src.tgz">Source</a>, 
+<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}">Docs</a>, 
+<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}/api/java">Javadocs</a>) 
 </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
This PR changes the Downloads page to incorporate Stateful Functions, as well as setup configuration entries for the upcoming 2.0.0 release.

This should not be merged until the release happens.

## Screenshots of the added sections:

### Source tarball download link section, placed under the Apache Flink downloads:

![image](https://user-images.githubusercontent.com/5284370/77985752-dca69b80-7347-11ea-8028-301c1f110eea.png)

### The Maven dependencies section, with Stateful Functions added:

![image](https://user-images.githubusercontent.com/5284370/77985807-fe078780-7347-11ea-841a-a9fc86eaa48f.png)

### List of all history versions, at the very bottom of the downloads page:

![image](https://user-images.githubusercontent.com/5284370/77985893-44f57d00-7348-11ea-92d0-5c7a9c744e75.png)

