### PR TITLE
Add Apache Flink release 1.9.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,48 +103,48 @@ flink_releases:
   -
       version_short: 1.9
       binary_release:
-          name: "Apache Flink 1.9.2"
+          name: "Apache Flink 1.9.3"
           scala_211:
-              id: "192-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.11.tgz.sha512"
+              id: "193-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "192-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-bin-scala_2.12.tgz.sha512"
+              id: "193-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.9.2"
-          id: "192-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.2/flink-1.9.2-src.tgz"
-          asc_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.asc"
-          sha512_url: "https://downloads.apache.org/flink/flink-1.9.2/flink-1.9.2-src.tgz.sha512"
+          name: "Apache Flink 1.9.3"
+          id: "193-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.9.3/flink-1.9.3-src.tgz"
+          asc_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.9.3/flink-1.9.3-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 192-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.2/flink-avro-1.9.2.jar.sha1
+          id: 193-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.3/flink-avro-1.9.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.3/flink-avro-1.9.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.9.3/flink-avro-1.9.3.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 192-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.2/flink-csv-1.9.2.jar.sha1
+          id: 193-sql-format-csv
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.3/flink-csv-1.9.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.3/flink-csv-1.9.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.9.3/flink-csv-1.9.3.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 192-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.2/flink-json-1.9.2.jar.sha1
+          id: 193-sql-format-json
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.3/flink-json-1.9.3.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.3/flink-json-1.9.3.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.9.3/flink-json-1.9.3.jar.sha1
 
 flink_statefun_releases:
   -
@@ -196,6 +196,10 @@ release_archive:
         version_short: "1.10"
         version_long: 1.10.0
         release_date: 2020-02-11
+      -
+        version_short: 1.9
+        version_long: 1.9.3
+        release_date: 2020-04-24
       -
         version_short: 1.9
         version_long: 1.9.2

--- a/_posts/2020-04-24-release-1.9.3.md
+++ b/_posts/2020-04-24-release-1.9.3.md
@@ -1,0 +1,136 @@
+---
+layout: post
+title:  "Apache Flink 1.9.3 Released"
+date:   2020-04-24 12:00:00
+categories: news
+authors:
+- Dian Fu:
+  name: "Dian Fu"
+  twitter: "DianFu11"
+---
+
+The Apache Flink community released the third bugfix version of the Apache Flink 1.9 series.
+
+This release includes 38 fixes and minor improvements for Flink 1.9.2. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.9.3.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.9.3</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.9.3</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.9.3</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15143'>FLINK-15143</a>] -         Create document for FLIP-49 TM memory model and configuration guide
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16389'>FLINK-16389</a>] -         Bump Kafka 0.10 to 0.10.2.2
+</li>
+</ul>
+        
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11193'>FLINK-11193</a>] -         Rocksdb timer service factory configuration option is not settable per job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14316'>FLINK-14316</a>] -         Stuck in &quot;Job leader ... lost leadership&quot; error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14560'>FLINK-14560</a>] -         The value of taskmanager.memory.size in flink-conf.yaml is set to zero will cause taskmanager not to work 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15010'>FLINK-15010</a>] -         Temp directories flink-netty-shuffle-* are not cleaned up
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15085'>FLINK-15085</a>] -         HistoryServer dashboard config json out of sync
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15386'>FLINK-15386</a>] -         SingleJobSubmittedJobGraphStore.putJobGraph has a logic error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15575'>FLINK-15575</a>] -         Azure Filesystem Shades Wrong Package &quot;httpcomponents&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15638'>FLINK-15638</a>] -         releasing/create_release_branch.sh does not set version in flink-python/pyflink/version.py
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15812'>FLINK-15812</a>] -         HistoryServer archiving is done in Dispatcher main thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15844'>FLINK-15844</a>] -         Removal of JobWithJars.buildUserCodeClassLoader method without Configuration breaks backwards compatibility
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15863'>FLINK-15863</a>] -         Fix docs stating that savepoints are relocatable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16047'>FLINK-16047</a>] -         Blink planner produces wrong aggregate results with state clean up
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16242'>FLINK-16242</a>] -         BinaryGeneric serialization error cause checkpoint failure
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16308'>FLINK-16308</a>] -         SQL connector download links are broken
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16373'>FLINK-16373</a>] -         EmbeddedLeaderService: IllegalStateException: The RPC connection is already closed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16573'>FLINK-16573</a>] -         Kinesis consumer does not properly shutdown RecordFetcher threads
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16576'>FLINK-16576</a>] -         State inconsistency on restore with memory state backends
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16696'>FLINK-16696</a>] -         Savepoint trigger documentation is insufficient
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16703'>FLINK-16703</a>] -         AkkaRpcActor state machine does not record transition to terminating state.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16836'>FLINK-16836</a>] -         Losing leadership does not clear rpc connection in JobManagerLeaderListener
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16860'>FLINK-16860</a>] -         Failed to push filter into OrcTableSource when upgrading to 1.9.2
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16916'>FLINK-16916</a>] -         The logic of NullableSerializer#copy is wrong
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17062'>FLINK-17062</a>] -         Fix the conversion from Java row type to Python row type
+</li>
+</ul>
+                
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14278'>FLINK-14278</a>] -         Pass in ioExecutor into AbstractDispatcherResourceManagerComponentFactory
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15908'>FLINK-15908</a>] -         Add description of support &#39;pip install&#39; to 1.9.x documents
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15909'>FLINK-15909</a>] -         Add PyPI release process into the subsequent release of 1.9.x 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15938'>FLINK-15938</a>] -         Idle state not cleaned in StreamingJoinOperator and StreamingSemiAntiJoinOperator
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16018'>FLINK-16018</a>] -         Improve error reporting when submitting batch job (instead of AskTimeoutException)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16031'>FLINK-16031</a>] -         Improve the description in the README file of PyFlink 1.9.x
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16167'>FLINK-16167</a>] -         Update documentation about python shell execution
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16280'>FLINK-16280</a>] -         Fix sample code errors in the documentation about elasticsearch connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16697'>FLINK-16697</a>] -         Disable JMX rebinding
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16862'>FLINK-16862</a>] -         Remove example url in quickstarts
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16942'>FLINK-16942</a>] -         ES 5 sink should allow users to select netty transport client
+</li>
+</ul>
+            
+<h2>        Task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11767'>FLINK-11767</a>] -         Introduce new TypeSerializerUpgradeTestBase, new PojoSerializerUpgradeTest
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16454'>FLINK-16454</a>] -         Update the copyright year in NOTICE files
+</li>
+</ul>


### PR DESCRIPTION
Adds release announcement and download link for 1.9.3
Dates on announcements are still TBD and should be updated accordingly once release happens.
Also note that FLINK-16954 doesn't appear in the release note as it's a fix of FLINK-11767 which was introduced in 1.9.3.