### PR TITLE
Add Apache Flink release 1.10.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: https://flink.apache.org
 
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
-FLINK_VERSION_STABLE: 1.10.0
+FLINK_VERSION_STABLE: 1.10.1
 FLINK_VERSION_STABLE_SHORT: "1.10"
 
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
@@ -58,48 +58,48 @@ flink_releases:
   -
       version_short: "1.10"
       binary_release:
-          name: "Apache Flink 1.10.0"
+          name: "Apache Flink 1.10.1"
           scala_211:
-              id: "1100-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512"
+              id: "1101-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "1100-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512"
+              id: "1101-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.10.0"
-          id: "1100-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz"
-          asc_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc"
-          sha512_url: "https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512"
+          name: "Apache Flink 1.10.1"
+          id: "1101-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz"
+          asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1100-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.sha1
+          id: 1101-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1100-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.sha1
+          id: 1101-sql-format-csv
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1100-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.sha1
+          id: 1101-sql-format-json
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1
   -
       version_short: 1.9
       binary_release:
@@ -192,6 +192,10 @@ component_releases:
 
 release_archive:
     flink:
+      -
+        version_short: "1.10"
+        version_long: 1.10.1
+        release_date: 2020-05-12
       -
         version_short: "1.10"
         version_long: 1.10.0

--- a/_posts/2020-05-12-release-1.10.1.md
+++ b/_posts/2020-05-12-release-1.10.1.md
@@ -15,6 +15,16 @@ This release includes 158 fixes and minor improvements for Flink 1.10.0. The lis
 
 We highly recommend all users to upgrade to Flink 1.10.1.
 
+<div class="alert alert-info" markdown="1">
+<span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+FLINK-16684 changed the builders of the StreamingFileSink to make them compilable in Scala. This change is source compatible but binary incompatible. If using the StreamingFileSink, please recompile your user code against 1.10.1 before upgrading.
+</div>
+
+<div class="alert alert-info" markdown="1">
+<span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+FLINK-16683 Flink no longer supports starting clusters with .bat scripts. Users should instead use environments like WSL or Cygwin and work with the .sh scripts.
+</div>
+
 Updated Maven dependencies:
 
 ```xml

--- a/_posts/2020-05-12-release-1.10.1.md
+++ b/_posts/2020-05-12-release-1.10.1.md
@@ -1,0 +1,382 @@
+---
+layout: post
+title:  "Apache Flink 1.10.1 Released"
+date:   2020-05-12 12:00:00
+categories: news
+authors:
+- liyu:
+  name: "Yu Li"
+  twitter: "LiyuApache"
+---
+
+The Apache Flink community released the first bugfix version of the Apache Flink 1.10 series.
+
+This release includes 158 fixes and minor improvements for Flink 1.10.0. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.10.1.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.10.1</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.10.1</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.10.1</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14126'>FLINK-14126</a>] -         Elasticsearch Xpack Machine Learning doesn&#39;t support ARM
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15143'>FLINK-15143</a>] -         Create document for FLIP-49 TM memory model and configuration guide
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15561'>FLINK-15561</a>] -         Unify Kerberos credentials checking
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15790'>FLINK-15790</a>] -         Make FlinkKubeClient and its implementations asynchronous
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15817'>FLINK-15817</a>] -         Kubernetes Resource leak while deployment exception happens
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16049'>FLINK-16049</a>] -         Remove outdated &quot;Best Practices&quot; section from Application Development Section
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16131'>FLINK-16131</a>] -         Translate &quot;Amazon S3&quot; page of &quot;File Systems&quot; into Chinese
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16389'>FLINK-16389</a>] -         Bump Kafka 0.10 to 0.10.2.2
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-2336'>FLINK-2336</a>] -         ArrayIndexOufOBoundsException in TypeExtractor when mapping
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-10918'>FLINK-10918</a>] -         incremental Keyed state with RocksDB throws cannot create directory error in windows
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-11193'>FLINK-11193</a>] -         Rocksdb timer service factory configuration option is not settable per job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13483'>FLINK-13483</a>] -         PrestoS3FileSystemITCase.testDirectoryListing fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14038'>FLINK-14038</a>] -         ExecutionGraph deploy failed due to akka timeout
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14311'>FLINK-14311</a>] -         Streaming File Sink end-to-end test failed on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14316'>FLINK-14316</a>] -         Stuck in &quot;Job leader ... lost leadership&quot; error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15417'>FLINK-15417</a>] -         Remove the docker volume or mount when starting Mesos e2e cluster
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15669'>FLINK-15669</a>] -         SQL client can&#39;t cancel flink job
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15772'>FLINK-15772</a>] -         Shaded Hadoop S3A with credentials provider end-to-end test fails on travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15811'>FLINK-15811</a>] -         StreamSourceOperatorWatermarksTest.testNoMaxWatermarkOnAsyncCancel fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15812'>FLINK-15812</a>] -         HistoryServer archiving is done in Dispatcher main thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15838'>FLINK-15838</a>] -         Dangling CountDownLatch.await(timeout)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15852'>FLINK-15852</a>] -         Job is submitted to the wrong session cluster
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15904'>FLINK-15904</a>] -         Make Kafka Consumer work with activated &quot;disableGenericTypes()&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15936'>FLINK-15936</a>] -         TaskExecutorTest#testSlotAcceptance deadlocks
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15953'>FLINK-15953</a>] -         Job Status is hard to read for some Statuses
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16013'>FLINK-16013</a>] -         List and map config options could not be parsed correctly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16014'>FLINK-16014</a>] -         S3 plugin ClassNotFoundException SAXParser
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16025'>FLINK-16025</a>] -         Service could expose blob server port mismatched with JM Container
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16026'>FLINK-16026</a>] -         Travis failed due to python setup
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16047'>FLINK-16047</a>] -         Blink planner produces wrong aggregate results with state clean up
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16067'>FLINK-16067</a>] -         Flink&#39;s CalciteParser swallows error position information
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16068'>FLINK-16068</a>] -         table with keyword-escaped columns and computed_column_expression columns
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16070'>FLINK-16070</a>] -         Blink planner can not extract correct unique key for UpsertStreamTableSink
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16108'>FLINK-16108</a>] -         StreamSQLExample is failed if running in blink planner
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16111'>FLINK-16111</a>] -         Kubernetes deployment does not respect &quot;taskmanager.cpu.cores&quot;.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16113'>FLINK-16113</a>] -         ExpressionReducer shouldn&#39;t escape the reduced string value
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16115'>FLINK-16115</a>] -         Aliyun oss filesystem could not work with plugin mechanism
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16139'>FLINK-16139</a>] -         Co-location constraints are not reset on task recovery in DefaultScheduler
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16161'>FLINK-16161</a>] -         Statistics zero should be unknown in HiveCatalog
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16170'>FLINK-16170</a>] -         SearchTemplateRequest ClassNotFoundException when use flink-sql-connector-elasticsearch7
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16220'>FLINK-16220</a>] -         JsonRowSerializationSchema throws cast exception : NullNode cannot be cast to ArrayNode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16231'>FLINK-16231</a>] -         Hive connector is missing jdk.tools exclusion against Hive 2.x.x
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16234'>FLINK-16234</a>] -         Fix unstable cases in StreamingJobGraphGeneratorTest
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16241'>FLINK-16241</a>] -         Remove the license and notice file in flink-ml-lib module on release-1.10 branch
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16242'>FLINK-16242</a>] -         BinaryGeneric serialization error cause checkpoint failure
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16262'>FLINK-16262</a>] -         Class loader problem with FlinkKafkaProducer.Semantic.EXACTLY_ONCE and usrlib directory
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16269'>FLINK-16269</a>] -         Generic type can not be matched when convert table to stream.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16281'>FLINK-16281</a>] -         parameter &#39;maxRetryTimes&#39; can not work in JDBCUpsertTableSink
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16301'>FLINK-16301</a>] -         Annoying &quot;Cannot find FunctionDefinition&quot; messages with SQL for f_proctime or =
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16308'>FLINK-16308</a>] -         SQL connector download links are broken
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16313'>FLINK-16313</a>] -         flink-state-processor-api: surefire execution unstable on Azure
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16331'>FLINK-16331</a>] -         Remove source licenses for old WebUI
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16345'>FLINK-16345</a>] -         Computed column can not refer time attribute column
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16360'>FLINK-16360</a>] -          connector on hive 2.0.1 don&#39;t  support type conversion from STRING to VARCHAR
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16371'>FLINK-16371</a>] -         HadoopCompressionBulkWriter fails with &#39;java.io.NotSerializableException&#39;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16373'>FLINK-16373</a>] -         EmbeddedLeaderService: IllegalStateException: The RPC connection is already closed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16413'>FLINK-16413</a>] -         Reduce hive source parallelism when limit push down
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16414'>FLINK-16414</a>] -         create udaf/udtf function using sql casuing ValidationException: SQL validation failed. null
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16433'>FLINK-16433</a>] -         TableEnvironmentImpl doesn&#39;t clear buffered operations when it fails to translate the operation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16435'>FLINK-16435</a>] -         Replace since decorator with versionadd to mark the version an API was introduced
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16467'>FLINK-16467</a>] -         MemorySizeTest#testToHumanReadableString() is not portable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16526'>FLINK-16526</a>] -         Fix exception when computed column expression references a keyword column name
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16541'>FLINK-16541</a>] -         Document of table.exec.shuffle-mode is incorrect
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16550'>FLINK-16550</a>] -         HadoopS3* tests fail with NullPointerException exceptions
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16560'>FLINK-16560</a>] -         Forward Configuration in PackagedProgramUtils#getPipelineFromProgram
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16567'>FLINK-16567</a>] -         Get the API error of the StreamQueryConfig on Page &quot;Query Configuration&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16573'>FLINK-16573</a>] -         Kinesis consumer does not properly shutdown RecordFetcher threads
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16576'>FLINK-16576</a>] -         State inconsistency on restore with memory state backends
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16626'>FLINK-16626</a>] -         Prevent REST handler from being closed more than once
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16632'>FLINK-16632</a>] -         SqlDateTimeUtils#toSqlTimestamp(String, String) may yield incorrect result
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16635'>FLINK-16635</a>] -         Incompatible okio dependency in flink-metrics-influxdb module
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16646'>FLINK-16646</a>] -         flink read orc file throw a NullPointerException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16647'>FLINK-16647</a>] -         Miss file extension when inserting to hive table with compression
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16652'>FLINK-16652</a>] -         BytesColumnVector should init buffer in Hive 3.x
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16662'>FLINK-16662</a>] -         Blink Planner failed to generate JobGraph for POJO DataStream converting to Table (Cannot determine simple type name)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16664'>FLINK-16664</a>] -         Unable to set DataStreamSource parallelism to default (-1)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16675'>FLINK-16675</a>] -         TableEnvironmentITCase. testClearOperation fails on travis nightly build
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16684'>FLINK-16684</a>] -         StreamingFileSink builder does not work with Scala
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16696'>FLINK-16696</a>] -         Savepoint trigger documentation is insufficient
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16703'>FLINK-16703</a>] -         AkkaRpcActor state machine does not record transition to terminating state.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16705'>FLINK-16705</a>] -         LocalExecutor tears down MiniCluster before client can retrieve JobResult
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16718'>FLINK-16718</a>] -         KvStateServerHandlerTest leaks Netty ByteBufs
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16727'>FLINK-16727</a>] -         Fix cast exception when having time point literal as parameters
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16732'>FLINK-16732</a>] -         Failed to call Hive UDF with constant return value
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16740'>FLINK-16740</a>] -         OrcSplitReaderUtil::logicalTypeToOrcType fails to create decimal type with precision &lt; 10
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16759'>FLINK-16759</a>] -         HiveModuleTest failed to compile on release-1.10
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16767'>FLINK-16767</a>] -         Failed to read Hive table with RegexSerDe
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16771'>FLINK-16771</a>] -         NPE when filtering by decimal column
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16821'>FLINK-16821</a>] -         Run Kubernetes test failed with invalid named &quot;minikube&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16822'>FLINK-16822</a>] -         The config set by SET command does not work
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16825'>FLINK-16825</a>] -         PrometheusReporterEndToEndITCase should rely on path returned by DownloadCache
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16836'>FLINK-16836</a>] -         Losing leadership does not clear rpc connection in JobManagerLeaderListener
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16860'>FLINK-16860</a>] -         Failed to push filter into OrcTableSource when upgrading to 1.9.2
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16888'>FLINK-16888</a>] -         Re-add jquery license file under &quot;/licenses&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16901'>FLINK-16901</a>] -         Flink Kinesis connector NOTICE should have contents of AWS KPL&#39;s THIRD_PARTY_NOTICES file manually merged in
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16913'>FLINK-16913</a>] -         ReadableConfigToConfigurationAdapter#getEnum throws UnsupportedOperationException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16916'>FLINK-16916</a>] -         The logic of NullableSerializer#copy is wrong
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16944'>FLINK-16944</a>] -         Compile error in. DumpCompiledPlanTest and PreviewPlanDumpTest
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16980'>FLINK-16980</a>] -         Python UDF doesn&#39;t work with protobuf 3.6.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16981'>FLINK-16981</a>] -         flink-runtime tests are crashing the JVM on Java11 because of PowerMock
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17062'>FLINK-17062</a>] -         Fix the conversion from Java row type to Python row type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17066'>FLINK-17066</a>] -         Update pyarrow version bounds less than 0.14.0
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17093'>FLINK-17093</a>] -         Python UDF doesn&#39;t work when the input column is from composite field
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17107'>FLINK-17107</a>] -         CheckpointCoordinatorConfiguration#isExactlyOnce() is inconsistent with StreamConfig#getCheckpointMode()
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17114'>FLINK-17114</a>] -         When the pyflink job runs in local mode and the command &quot;python&quot; points to Python 2.7, the startup of the Python UDF worker will fail.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17124'>FLINK-17124</a>] -         The PyFlink Job runs into infinite loop if the Python UDF imports job code
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17152'>FLINK-17152</a>] -         FunctionDefinitionUtil generate wrong resultType and  acc type of AggregateFunctionDefinition
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17308'>FLINK-17308</a>] -         ExecutionGraphCache cachedExecutionGraphs not cleanup cause OOM Bug
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17313'>FLINK-17313</a>] -         Validation error when insert decimal/varchar with precision into sink using TypeInformation of row
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17334'>FLINK-17334</a>] -          Flink does not support HIVE UDFs with primitive return types
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17338'>FLINK-17338</a>] -         LocalExecutorITCase.testBatchQueryCancel test timeout
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17359'>FLINK-17359</a>] -         Entropy key is not resolved if flink-s3-fs-hadoop is added as a plugin
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17403'>FLINK-17403</a>] -         Fix invalid classpath in BashJavaUtilsITCase
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17471'>FLINK-17471</a>] -         Move LICENSE and NOTICE files to root directory of python distribution
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17483'>FLINK-17483</a>] -         Update flink-sql-connector-elasticsearch7 NOTICE file to correctly reflect bundled dependencies
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17496'>FLINK-17496</a>] -         Performance regression with amazon-kinesis-producer 0.13.1 in Flink 1.10.x
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17499'>FLINK-17499</a>] -         LazyTimerService used to register timers via State Processing API incorrectly mixes event time timers with processing time timers
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17514'>FLINK-17514</a>] -         TaskCancelerWatchdog does not kill TaskManager
+</li>
+</ul>
+
+<h2>        New Feature
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17275'>FLINK-17275</a>] -         Add core training exercises
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-9656'>FLINK-9656</a>] -         Environment java opts for flink run
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15094'>FLINK-15094</a>] -         Warning about using private constructor of java.nio.DirectByteBuffer in Java 11
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15584'>FLINK-15584</a>] -         Give nested data type of ROWs in ValidationException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15616'>FLINK-15616</a>] -         Move boot error messages from python-udf-boot.log to taskmanager&#39;s log file
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15989'>FLINK-15989</a>] -         Rewrap OutOfMemoryError in allocateUnpooledOffHeap with better message
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16018'>FLINK-16018</a>] -         Improve error reporting when submitting batch job (instead of AskTimeoutException)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16125'>FLINK-16125</a>] -         Make zookeeper.connect optional for Kafka connectors
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16167'>FLINK-16167</a>] -         Update documentation about python shell execution
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16191'>FLINK-16191</a>] -         Improve error message on Windows when RocksDB Paths are too long
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16280'>FLINK-16280</a>] -         Fix sample code errors in the documentation about elasticsearch connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16288'>FLINK-16288</a>] -         Setting the TTL for discarding task pods on Kubernetes.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16293'>FLINK-16293</a>] -         Document using plugins in Kubernetes
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16343'>FLINK-16343</a>] -         Improve exception message when reading an unbounded source in batch mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16406'>FLINK-16406</a>] -         Increase default value for JVM Metaspace to minimise its OutOfMemoryError
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16538'>FLINK-16538</a>] -         Restructure Python Table API documentation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16604'>FLINK-16604</a>] -         Column key in JM configuration is too narrow
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16683'>FLINK-16683</a>] -         Remove scripts for starting Flink on Windows
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16697'>FLINK-16697</a>] -         Disable JMX rebinding
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16763'>FLINK-16763</a>] -         Should not use BatchTableEnvironment for Python UDF in the document of flink-1.10
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16772'>FLINK-16772</a>] -         Bump derby to 10.12.1.1+ or exclude it
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16790'>FLINK-16790</a>] -         enables the interpretation of backslash escapes
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16862'>FLINK-16862</a>] -         Remove example url in quickstarts
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16874'>FLINK-16874</a>] -         Respect the dynamic options when calculating memory options in taskmanager.sh
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16942'>FLINK-16942</a>] -         ES 5 sink should allow users to select netty transport client
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17065'>FLINK-17065</a>] -         Add documentation about the Python versions supported for PyFlink
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17125'>FLINK-17125</a>] -         Add a Usage Notes Page to Answer Common Questions Encountered by PyFlink Users
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17254'>FLINK-17254</a>] -         Improve the PyFlink documentation and examples to use SQL DDL for source/sink definition
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17276'>FLINK-17276</a>] -         Add checkstyle to training exercises
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17277'>FLINK-17277</a>] -         Apply IntelliJ recommendations to training exercises
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17278'>FLINK-17278</a>] -         Add Travis to the training exercises
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17279'>FLINK-17279</a>] -         Use gradle build scans for training exercises
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17316'>FLINK-17316</a>] -         Have HourlyTips solutions use TumblingEventTimeWindows.of
+</li>
+</ul>
+
+<h2>        Task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15741'>FLINK-15741</a>] -         Fix TTL docs after enabling RocksDB compaction filter by default (needs Chinese translation)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15933'>FLINK-15933</a>] -         update content of how generic table schema is stored in hive via HiveCatalog
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15991'>FLINK-15991</a>] -         Create Chinese documentation for FLIP-49 TM memory model
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16004'>FLINK-16004</a>] -         Exclude flink-rocksdb-state-memory-control-test jars from the dist
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16454'>FLINK-16454</a>] -         Update the copyright year in NOTICE files
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16530'>FLINK-16530</a>] -         Add documentation about &quot;GROUPING SETS&quot; and &quot;CUBE&quot; support in streaming mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16592'>FLINK-16592</a>] -         The doc of Streaming File Sink has a mistake of grammar
+</li>
+</ul>
+

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></h2>
+
+      <p>12 May 2020
+       Yu Li (<a href="https://twitter.com/LiyuApache">@LiyuApache</a>)</p>
+
+      <p><p>The Apache Flink community released the first bugfix version of the Apache Flink 1.10 series.</p>
+
+</p>
+
+      <p><a href="/news/2020/05/12/release-1.10.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></h2>
 
       <p>07 May 2020
@@ -319,19 +334,6 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/03/24/demo-fraud-detection-2.html">Advanced Flink Application Patterns Vol.2: Dynamic Updates of Application Logic</a></h2>
-
-      <p>24 Mar 2020
-       Alexander Fedulov (<a href="https://twitter.com/alex_fedulov">@alex_fedulov</a>)</p>
-
-      <p>In this series of blog posts you will learn about powerful Flink patterns for building streaming applications.</p>
-
-      <p><a href="/news/2020/03/24/demo-fraud-detection-2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -363,6 +365,16 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/11/27/release-0.10.1.html">Flink 0.10.1 released</a></h2>
+
+      <p>27 Nov 2015
+      </p>
+
+      <p><p>Today, the Flink community released the first bugfix release of the 0.10 series of Flink.</p>
+
+</p>
+
+      <p><a href="/news/2015/11/27/release-0.10.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/11/16/release-0.10.0.html">Announcing Apache Flink 0.10.0</a></h2>
 
       <p>16 Nov 2015
@@ -338,21 +353,6 @@ release is a preview release that contains known issues.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/04/07/march-in-flink.html">March 2015 in the Flink community</a></h2>
-
-      <p>07 Apr 2015
-      </p>
-
-      <p><p>March has been a busy month in the Flink community.</p>
-
-</p>
-
-      <p><a href="/news/2015/04/07/march-in-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -384,6 +384,16 @@ release is a preview release that contains known issues.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/04/07/march-in-flink.html">March 2015 in the Flink community</a></h2>
+
+      <p>07 Apr 2015
+      </p>
+
+      <p><p>March has been a busy month in the Flink community.</p>
+
+</p>
+
+      <p><a href="/news/2015/04/07/march-in-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html">Peeking into Apache Flink's Engine Room</a></h2>
 
       <p>13 Mar 2015 by Fabian Hüske (<a href="https://twitter.com/">@fhueske</a>)
@@ -335,21 +350,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2014/09/26/release-0.6.1.html">Apache Flink 0.6.1 available</a></h2>
-
-      <p>26 Sep 2014
-      </p>
-
-      <p><p>We are happy to announce the availability of Flink 0.6.1.</p>
-
-</p>
-
-      <p><a href="/news/2014/09/26/release-0.6.1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -381,6 +381,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2014/09/26/release-0.6.1.html">Apache Flink 0.6.1 available</a></h2>
+
+      <p>26 Sep 2014
+      </p>
+
+      <p><p>We are happy to announce the availability of Flink 0.6.1.</p>
+
+</p>
+
+      <p><a href="/news/2014/09/26/release-0.6.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2014/08/26/release-0.6.html">Apache Flink 0.6 available</a></h2>
 
       <p>26 Aug 2014
@@ -244,6 +259,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/03/24/demo-fraud-detection-2.html">Advanced Flink Application Patterns Vol.2: Dynamic Updates of Application Logic</a></h2>
+
+      <p>24 Mar 2020
+       Alexander Fedulov (<a href="https://twitter.com/alex_fedulov">@alex_fedulov</a>)</p>
+
+      <p>In this series of blog posts you will learn about powerful Flink patterns for building streaming applications.</p>
+
+      <p><a href="/news/2020/03/24/demo-fraud-detection-2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html">Apache Beam: How Beam Runs on Top of Flink</a></h2>
 
       <p>22 Feb 2020
@@ -318,19 +331,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></h2>
-
-      <p>25 Nov 2019
-       Sijie Guo (<a href="https://twitter.com/sijieg">@sijieg</a>) &amp; Markos Sfikas (<a href="https://twitter.com/MarkSfik">@MarkSfik</a>)</p>
-
-      <p>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</p>
-
-      <p><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -362,6 +362,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">How to query Pulsar Streams using Apache Flink</a></h2>
+
+      <p>25 Nov 2019
+       Sijie Guo (<a href="https://twitter.com/sijieg">@sijieg</a>) &amp; Markos Sfikas (<a href="https://twitter.com/MarkSfik">@MarkSfik</a>)</p>
+
+      <p>This blog post discusses the new developments and integrations between Apache Flink and Apache Pulsar and showcases how you can leverage Pulsar’s built-in schema to query Pulsar streams in real time using Apache Flink.</p>
+
+      <p><a href="/news/2019/11/25/query-pulsar-streams-using-apache-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/10/18/release-1.9.1.html">Apache Flink 1.9.1 Released</a></h2>
 
       <p>18 Oct 2019
@@ -321,19 +334,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/2019/05/19/state-ttl.html">State TTL in Flink 1.8.0: How to Automatically Cleanup Application State in Apache Flink</a></h2>
-
-      <p>19 May 2019
-       Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>) &amp; Andrey Zagrebin </p>
-
-      <p>A common requirement for many stateful streaming applications is to automatically cleanup application state for effective management of your state size, or to control how long the application state can be accessed. State TTL enables application state cleanup and efficient state size management in Apache Flink</p>
-
-      <p><a href="/2019/05/19/state-ttl.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -365,6 +365,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/2019/05/19/state-ttl.html">State TTL in Flink 1.8.0: How to Automatically Cleanup Application State in Apache Flink</a></h2>
+
+      <p>19 May 2019
+       Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>) &amp; Andrey Zagrebin </p>
+
+      <p>A common requirement for many stateful streaming applications is to automatically cleanup application state for effective management of your state size, or to control how long the application state can be accessed. State TTL enables application state cleanup and efficient state size management in Apache Flink</p>
+
+      <p><a href="/2019/05/19/state-ttl.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/2019/05/14/temporal-tables.html">Flux capacitor, huh? Temporal Tables and Joins in Streaming SQL</a></h2>
 
       <p>14 May 2019
@@ -324,19 +337,6 @@ for more details.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/02/13/unified-batch-streaming-blink.html">Batch as a Special Case of Streaming and Alibaba's contribution of Blink</a></h2>
-
-      <p>13 Feb 2019
-       Stephan Ewen (<a href="https://twitter.com/stephanewen">@stephanewen</a>), Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>), &amp; Xiaowei Jiang (<a href="https://twitter.com/XiaoweiJ">@XiaoweiJ</a>)</p>
-
-      <p>A few weeks ago, Alibaba contributed its Flink-fork 'Blink' back to Apache Flink. In this blog post we discuss how Blink's features will help the Flink community to make a big step towards its vision to build a truly unified system for stream and batch processing.</p>
-
-      <p><a href="/news/2019/02/13/unified-batch-streaming-blink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -368,6 +368,16 @@ for more details.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/02/13/unified-batch-streaming-blink.html">Batch as a Special Case of Streaming and Alibaba's contribution of Blink</a></h2>
+
+      <p>13 Feb 2019
+       Stephan Ewen (<a href="https://twitter.com/stephanewen">@stephanewen</a>), Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>), &amp; Xiaowei Jiang (<a href="https://twitter.com/XiaoweiJ">@XiaoweiJ</a>)</p>
+
+      <p>A few weeks ago, Alibaba contributed its Flink-fork 'Blink' back to Apache Flink. In this blog post we discuss how Blink's features will help the Flink community to make a big step towards its vision to build a truly unified system for stream and batch processing.</p>
+
+      <p><a href="/news/2019/02/13/unified-batch-streaming-blink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/12/26/release-1.5.6.html">Apache Flink 1.5.6 Released</a></h2>
 
       <p>26 Dec 2018
@@ -332,21 +345,6 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/08/09/release-1.6.0.html">Apache Flink 1.6.0 Release Announcement</a></h2>
-
-      <p>09 Aug 2018
-       Till Rohrmann (<a href="https://twitter.com/stsffap">@stsffap</a>)</p>
-
-      <p><p>The Apache Flink community is proud to announce the 1.6.0 release. Over the past 2 months, the Flink community has worked hard to resolve more than 360 issues. Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12342760">complete changelog</a> for more details.</p>
-
-</p>
-
-      <p><a href="/news/2018/08/09/release-1.6.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -378,6 +376,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/08/09/release-1.6.0.html">Apache Flink 1.6.0 Release Announcement</a></h2>
+
+      <p>09 Aug 2018
+       Till Rohrmann (<a href="https://twitter.com/stsffap">@stsffap</a>)</p>
+
+      <p><p>The Apache Flink community is proud to announce the 1.6.0 release. Over the past 2 months, the Flink community has worked hard to resolve more than 360 issues. Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12342760">complete changelog</a> for more details.</p>
+
+</p>
+
+      <p><a href="/news/2018/08/09/release-1.6.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/07/31/release-1.5.2.html">Apache Flink 1.5.2 Released</a></h2>
 
       <p>31 Jul 2018
@@ -324,23 +339,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/12/12/release-1.4.0.html">Apache Flink 1.4.0 Release Announcement</a></h2>
-
-      <p>12 Dec 2017
-       Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
-
-      <p><p>The Apache Flink community is pleased to announce the 1.4.0 release. Over the past 5 months, the
-Flink community has been working hard to resolve more than 900 issues. See the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12340533">complete changelog</a>
-for more detail.</p>
-
-</p>
-
-      <p><a href="/news/2017/12/12/release-1.4.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -372,6 +370,16 @@ for more detail.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -196,6 +196,23 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/12/12/release-1.4.0.html">Apache Flink 1.4.0 Release Announcement</a></h2>
+
+      <p>12 Dec 2017
+       Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
+
+      <p><p>The Apache Flink community is pleased to announce the 1.4.0 release. Over the past 5 months, the
+Flink community has been working hard to resolve more than 900 issues. See the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12340533">complete changelog</a>
+for more detail.</p>
+
+</p>
+
+      <p><a href="/news/2017/12/12/release-1.4.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/11/22/release-1.4-and-1.5-timeline.html">Looking Ahead to Apache Flink 1.4.0 and 1.5.0</a></h2>
 
       <p>22 Nov 2017
@@ -328,21 +345,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/03/23/release-1.1.5.html">Apache Flink 1.1.5 Released</a></h2>
-
-      <p>23 Mar 2017
-      </p>
-
-      <p><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.1 series.</p>
-
-</p>
-
-      <p><a href="/news/2017/03/23/release-1.1.5.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -374,6 +376,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/03/23/release-1.1.5.html">Apache Flink 1.1.5 Released</a></h2>
+
+      <p>23 Mar 2017
+      </p>
+
+      <p><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.1 series.</p>
+
+</p>
+
+      <p><a href="/news/2017/03/23/release-1.1.5.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/02/06/release-1.2.0.html">Announcing Apache Flink 1.2.0</a></h2>
 
       <p>06 Feb 2017 by Robert Metzger
@@ -325,21 +340,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/05/11/release-1.0.3.html">Flink 1.0.3 Released</a></h2>
-
-      <p>11 May 2016
-      </p>
-
-      <p><p>Today, the Flink community released Flink version <strong>1.0.3</strong>, the third bugfix release of the 1.0 series.</p>
-
-</p>
-
-      <p><a href="/news/2016/05/11/release-1.0.3.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -371,6 +371,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/05/11/release-1.0.3.html">Flink 1.0.3 Released</a></h2>
+
+      <p>11 May 2016
+      </p>
+
+      <p><p>Today, the Flink community released Flink version <strong>1.0.3</strong>, the third bugfix release of the 1.0 series.</p>
+
+</p>
+
+      <p><a href="/news/2016/05/11/release-1.0.3.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/04/22/release-1.0.2.html">Flink 1.0.2 Released</a></h2>
 
       <p>22 Apr 2016
@@ -323,21 +338,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/11/27/release-0.10.1.html">Flink 0.10.1 released</a></h2>
-
-      <p>27 Nov 2015
-      </p>
-
-      <p><p>Today, the Flink community released the first bugfix release of the 0.10 series of Flink.</p>
-
-</p>
-
-      <p><a href="/news/2015/11/27/release-0.10.1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +369,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -207,7 +207,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-1100" id="markdown-toc-apache-flink-1100">Apache Flink 1.10.0</a></li>
+  <li><a href="#apache-flink-1101" id="markdown-toc-apache-flink-1101">Apache Flink 1.10.1</a></li>
   <li><a href="#apache-flink-193" id="markdown-toc-apache-flink-193">Apache Flink 1.9.3</a></li>
   <li><a href="#apache-flink-stateful-functions-200" id="markdown-toc-apache-flink-stateful-functions-200">Apache Flink Stateful Functions 2.0.0</a></li>
   <li><a href="#additional-components" id="markdown-toc-additional-components">Additional Components</a></li>
@@ -228,39 +228,39 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.10.0 is our latest stable release.</p>
+<p>Apache Flink® 1.10.1 is our latest stable release.</p>
 
 <p>If you plan to use Apache Flink together with Apache Hadoop (run Flink
 on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
 file system connector), please check out the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/ops/deployment/hadoop.html">Hadoop Integration</a> documentation.</p>
 
-<h2 id="apache-flink-1100">Apache Flink 1.10.0</h2>
+<h2 id="apache-flink-1101">Apache Flink 1.10.1</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz" class="ga-track" id="1100-download_211">Apache Flink 1.10.0 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz" class="ga-track" id="1101-download_211">Apache Flink 1.10.1 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz" class="ga-track" id="1100-download_212">Apache Flink 1.10.0 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz" class="ga-track" id="1101-download_212">Apache Flink 1.10.1 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz" class="ga-track" id="1100-download-source">Apache Flink 1.10.0 Source Release</a>
-(<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz" class="ga-track" id="1101-download-source">Apache Flink 1.10.1 Source Release</a>
+(<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components">Optional components</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar" class="ga-track" id="1100-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar" class="ga-track" id="1101-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar" class="ga-track" id="1100-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar" class="ga-track" id="1101-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar" class="ga-track" id="1100-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar" class="ga-track" id="1101-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="release-notes">Release Notes</h4>
@@ -364,17 +364,17 @@ main Flink release:</p>
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h3 id="apache-flink-stateful-functions">Apache Flink Stateful Functions</h3>
@@ -408,6 +408,17 @@ The <code>statefun-flink-harness</code> dependency includes a local execution en
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.10.1 - 2020-05-12 
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -568,6 +568,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></dt>
+        <dd><p>The Apache Flink community released the first bugfix version of the Apache Flink 1.10 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></dt>
         <dd>Can you smell it? It’s release month! This time around, we’re warming up for Flink 1.11 and peeping back to the past month in the Flink community — with the release of Stateful Functions 2.0, a new self-paced Flink training and some efforts to improve the Flink documentation experience.</dd>
       
@@ -581,9 +586,6 @@
       
         <dt> <a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Memory Management Improvements with Apache Flink 1.10</a></dt>
         <dd>This post discusses the recent changes to the memory model of the Task Managers and configuration options for your Flink applications in Flink 1.10.</dd>
-      
-        <dt> <a href="/news/2020/04/15/flink-serialization-tuning-vol-1.html">Flink Serialization Tuning Vol. 1: Choosing your Serializer — if you can</a></dt>
-        <dd>Serialization is a crucial element of your Flink job. This article is the first in a series of posts that will highlight Flink’s serialization stack, and looks at the different ways Flink can serialize your data types.</dd>
     
   </dl>
 

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -1,0 +1,630 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Apache Flink: Apache Flink 1.10.1 Released</title>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/flink.css">
+    <link rel="stylesheet" href="/css/syntax.css">
+
+    <!-- Blog RSS feed -->
+    <link href="/blog/feed.xml" rel="alternate" type="application/rss+xml" title="Apache Flink Blog: RSS feed" />
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <!-- We need to load Jquery in the header for custom google analytics event tracking-->
+    <script src="/js/jquery.min.js"></script>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>  
+    
+
+    <!-- Main content. -->
+    <div class="container">
+    <div class="row">
+
+      
+     <div id="sidebar" class="col-sm-3">
+        
+
+<!-- Top navbar. -->
+    <nav class="navbar navbar-default">
+        <!-- The logo. -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="navbar-logo">
+            <a href="/">
+              <img alt="Apache Flink" src="/img/flink-header-logo.svg" width="147px" height="73px">
+            </a>
+          </div>
+        </div><!-- /.navbar-header -->
+
+        <!-- The navigation links. -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-main">
+
+            <!-- First menu section explains visitors what Flink is -->
+
+            <!-- What is Stream Processing? -->
+            <!--
+            <li><a href="/streamprocessing1.html">What is Stream Processing?</a></li>
+            -->
+
+            <!-- What is Flink? -->
+            <li><a href="/flink-architecture.html">What is Apache Flink?</a></li>
+
+            
+
+            <!-- What is Stateful Functions? -->
+
+            <li><a href="/stateful-functions.html">What is Stateful Functions?</a></li>
+
+            <!-- Use cases -->
+            <li><a href="/usecases.html">Use Cases</a></li>
+
+            <!-- Powered by -->
+            <li><a href="/poweredby.html">Powered By</a></li>
+
+
+            &nbsp;
+            <!-- Second menu section aims to support Flink users -->
+
+            <!-- Downloads -->
+            <li><a href="/downloads.html">Downloads</a></li>
+
+            <!-- Getting Started -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="/training.html">Training Course</a></li>
+              </ul>
+            </li>
+
+            <!-- Documentation -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10" target="_blank">Flink 1.10 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Flink Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0" target="_blank">Flink Stateful Functions 2.0 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-master" target="_blank">Flink Stateful Functions Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+              </ul>
+            </li>
+
+            <!-- getting help -->
+            <li><a href="/gettinghelp.html">Getting Help</a></li>
+
+            <!-- Blog -->
+            <li class="active"><a href="/blog/"><b>Flink Blog</b></a></li>
+
+
+            <!-- Flink-packages -->
+            <li>
+              <a href="https://flink-packages.org" target="_blank">flink-packages.org <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+            &nbsp;
+
+            <!-- Third menu section aim to support community and contributors -->
+
+            <!-- Community -->
+            <li><a href="/community.html">Community &amp; Project Info</a></li>
+
+            <!-- Roadmap -->
+            <li><a href="/roadmap.html">Roadmap</a></li>
+
+            <!-- Contribute -->
+            <li><a href="/contributing/how-to-contribute.html">How to Contribute</a></li>
+            
+
+            <!-- GitHub -->
+            <li>
+              <a href="https://github.com/apache/flink" target="_blank">Flink on GitHub <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            &nbsp;
+
+            <!-- Language Switcher -->
+            <li>
+              
+                
+                  <!-- link to the Chinese home page when current is blog page -->
+                  <a href="/zh">中文版</a>
+                
+              
+            </li>
+
+          </ul>
+
+          <ul class="nav navbar-nav navbar-bottom">
+          <hr />
+
+            <!-- Twitter -->
+            <li><a href="https://twitter.com/apacheflink" target="_blank">@ApacheFlink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <!-- Visualizer -->
+            <li class=" hidden-md hidden-sm"><a href="/visualizer/" target="_blank">Plan Visualizer <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+          <hr />
+
+            <li><a href="https://apache.org" target="_blank">Apache Software Foundation <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <li>
+              <style>
+                .smalllinks:link {
+                  display: inline-block !important; background: none; padding-top: 0px; padding-bottom: 0px; padding-right: 0px; min-width: 75px;
+                }
+              </style>
+
+              <a class="smalllinks" href="https://www.apache.org/licenses/" target="_blank">License</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/security/" target="_blank">Security</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+            </li>
+
+          </ul>
+        </div><!-- /.navbar-collapse -->
+    </nav>
+
+      </div>
+      <div class="col-sm-9">
+      <div class="row-fluid">
+  <div class="col-sm-12">
+    <div class="row">
+      <h1>Apache Flink 1.10.1 Released</h1>
+      <p><i></i></p>
+
+      <article>
+        <p>12 May 2020 Yu Li (<a href="https://twitter.com/LiyuApache">@LiyuApache</a>)</p>
+
+<p>The Apache Flink community released the first bugfix version of the Apache Flink 1.10 series.</p>
+
+<p>This release includes 158 fixes and minor improvements for Flink 1.10.0. The list below includes a detailed list of all fixes and improvements.</p>
+
+<p>We highly recommend all users to upgrade to Flink 1.10.1.</p>
+
+<div class="alert alert-info">
+  <p><span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+FLINK-16684 changed the builders of the StreamingFileSink to make them compilable in Scala. This change is source compatible but binary incompatible. If using the StreamingFileSink, please recompile your user code against 1.10.1 before upgrading.</p>
+</div>
+
+<div class="alert alert-info">
+  <p><span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+FLINK-16683 Flink no longer supports starting clusters with .bat scripts. Users should instead use environments like WSL or Cygwin and work with the .sh scripts.</p>
+</div>
+
+<p>Updated Maven dependencies:</p>
+
+<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span></code></pre></div>
+
+<p>You can find the binaries on the updated <a href="/downloads.html">Downloads page</a>.</p>
+
+<p>List of resolved issues:</p>
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14126">FLINK-14126</a>] -         Elasticsearch Xpack Machine Learning doesn&#39;t support ARM
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15143">FLINK-15143</a>] -         Create document for FLIP-49 TM memory model and configuration guide
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15561">FLINK-15561</a>] -         Unify Kerberos credentials checking
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15790">FLINK-15790</a>] -         Make FlinkKubeClient and its implementations asynchronous
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15817">FLINK-15817</a>] -         Kubernetes Resource leak while deployment exception happens
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16049">FLINK-16049</a>] -         Remove outdated &quot;Best Practices&quot; section from Application Development Section
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16131">FLINK-16131</a>] -         Translate &quot;Amazon S3&quot; page of &quot;File Systems&quot; into Chinese
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16389">FLINK-16389</a>] -         Bump Kafka 0.10 to 0.10.2.2
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-2336">FLINK-2336</a>] -         ArrayIndexOufOBoundsException in TypeExtractor when mapping
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-10918">FLINK-10918</a>] -         incremental Keyed state with RocksDB throws cannot create directory error in windows
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-11193">FLINK-11193</a>] -         Rocksdb timer service factory configuration option is not settable per job
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13483">FLINK-13483</a>] -         PrestoS3FileSystemITCase.testDirectoryListing fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14038">FLINK-14038</a>] -         ExecutionGraph deploy failed due to akka timeout
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14311">FLINK-14311</a>] -         Streaming File Sink end-to-end test failed on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14316">FLINK-14316</a>] -         Stuck in &quot;Job leader ... lost leadership&quot; error
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15417">FLINK-15417</a>] -         Remove the docker volume or mount when starting Mesos e2e cluster
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15669">FLINK-15669</a>] -         SQL client can&#39;t cancel flink job
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15772">FLINK-15772</a>] -         Shaded Hadoop S3A with credentials provider end-to-end test fails on travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15811">FLINK-15811</a>] -         StreamSourceOperatorWatermarksTest.testNoMaxWatermarkOnAsyncCancel fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15812">FLINK-15812</a>] -         HistoryServer archiving is done in Dispatcher main thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15838">FLINK-15838</a>] -         Dangling CountDownLatch.await(timeout)
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15852">FLINK-15852</a>] -         Job is submitted to the wrong session cluster
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15904">FLINK-15904</a>] -         Make Kafka Consumer work with activated &quot;disableGenericTypes()&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15936">FLINK-15936</a>] -         TaskExecutorTest#testSlotAcceptance deadlocks
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15953">FLINK-15953</a>] -         Job Status is hard to read for some Statuses
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16013">FLINK-16013</a>] -         List and map config options could not be parsed correctly
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16014">FLINK-16014</a>] -         S3 plugin ClassNotFoundException SAXParser
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16025">FLINK-16025</a>] -         Service could expose blob server port mismatched with JM Container
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16026">FLINK-16026</a>] -         Travis failed due to python setup
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16047">FLINK-16047</a>] -         Blink planner produces wrong aggregate results with state clean up
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16067">FLINK-16067</a>] -         Flink&#39;s CalciteParser swallows error position information
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16068">FLINK-16068</a>] -         table with keyword-escaped columns and computed_column_expression columns
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16070">FLINK-16070</a>] -         Blink planner can not extract correct unique key for UpsertStreamTableSink
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16108">FLINK-16108</a>] -         StreamSQLExample is failed if running in blink planner
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16111">FLINK-16111</a>] -         Kubernetes deployment does not respect &quot;taskmanager.cpu.cores&quot;.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16113">FLINK-16113</a>] -         ExpressionReducer shouldn&#39;t escape the reduced string value
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16115">FLINK-16115</a>] -         Aliyun oss filesystem could not work with plugin mechanism
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16139">FLINK-16139</a>] -         Co-location constraints are not reset on task recovery in DefaultScheduler
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16161">FLINK-16161</a>] -         Statistics zero should be unknown in HiveCatalog
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16170">FLINK-16170</a>] -         SearchTemplateRequest ClassNotFoundException when use flink-sql-connector-elasticsearch7
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16220">FLINK-16220</a>] -         JsonRowSerializationSchema throws cast exception : NullNode cannot be cast to ArrayNode
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16231">FLINK-16231</a>] -         Hive connector is missing jdk.tools exclusion against Hive 2.x.x
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16234">FLINK-16234</a>] -         Fix unstable cases in StreamingJobGraphGeneratorTest
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16241">FLINK-16241</a>] -         Remove the license and notice file in flink-ml-lib module on release-1.10 branch
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16242">FLINK-16242</a>] -         BinaryGeneric serialization error cause checkpoint failure
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16262">FLINK-16262</a>] -         Class loader problem with FlinkKafkaProducer.Semantic.EXACTLY_ONCE and usrlib directory
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16269">FLINK-16269</a>] -         Generic type can not be matched when convert table to stream.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16281">FLINK-16281</a>] -         parameter &#39;maxRetryTimes&#39; can not work in JDBCUpsertTableSink
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16301">FLINK-16301</a>] -         Annoying &quot;Cannot find FunctionDefinition&quot; messages with SQL for f_proctime or =
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16308">FLINK-16308</a>] -         SQL connector download links are broken
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16313">FLINK-16313</a>] -         flink-state-processor-api: surefire execution unstable on Azure
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16331">FLINK-16331</a>] -         Remove source licenses for old WebUI
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16345">FLINK-16345</a>] -         Computed column can not refer time attribute column
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16360">FLINK-16360</a>] -          connector on hive 2.0.1 don&#39;t  support type conversion from STRING to VARCHAR
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16371">FLINK-16371</a>] -         HadoopCompressionBulkWriter fails with &#39;java.io.NotSerializableException&#39;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16373">FLINK-16373</a>] -         EmbeddedLeaderService: IllegalStateException: The RPC connection is already closed
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16413">FLINK-16413</a>] -         Reduce hive source parallelism when limit push down
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16414">FLINK-16414</a>] -         create udaf/udtf function using sql casuing ValidationException: SQL validation failed. null
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16433">FLINK-16433</a>] -         TableEnvironmentImpl doesn&#39;t clear buffered operations when it fails to translate the operation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16435">FLINK-16435</a>] -         Replace since decorator with versionadd to mark the version an API was introduced
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16467">FLINK-16467</a>] -         MemorySizeTest#testToHumanReadableString() is not portable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16526">FLINK-16526</a>] -         Fix exception when computed column expression references a keyword column name
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16541">FLINK-16541</a>] -         Document of table.exec.shuffle-mode is incorrect
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16550">FLINK-16550</a>] -         HadoopS3* tests fail with NullPointerException exceptions
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16560">FLINK-16560</a>] -         Forward Configuration in PackagedProgramUtils#getPipelineFromProgram
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16567">FLINK-16567</a>] -         Get the API error of the StreamQueryConfig on Page &quot;Query Configuration&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16573">FLINK-16573</a>] -         Kinesis consumer does not properly shutdown RecordFetcher threads
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16576">FLINK-16576</a>] -         State inconsistency on restore with memory state backends
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16626">FLINK-16626</a>] -         Prevent REST handler from being closed more than once
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16632">FLINK-16632</a>] -         SqlDateTimeUtils#toSqlTimestamp(String, String) may yield incorrect result
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16635">FLINK-16635</a>] -         Incompatible okio dependency in flink-metrics-influxdb module
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16646">FLINK-16646</a>] -         flink read orc file throw a NullPointerException
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16647">FLINK-16647</a>] -         Miss file extension when inserting to hive table with compression
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16652">FLINK-16652</a>] -         BytesColumnVector should init buffer in Hive 3.x
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16662">FLINK-16662</a>] -         Blink Planner failed to generate JobGraph for POJO DataStream converting to Table (Cannot determine simple type name)
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16664">FLINK-16664</a>] -         Unable to set DataStreamSource parallelism to default (-1)
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16675">FLINK-16675</a>] -         TableEnvironmentITCase. testClearOperation fails on travis nightly build
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16684">FLINK-16684</a>] -         StreamingFileSink builder does not work with Scala
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16696">FLINK-16696</a>] -         Savepoint trigger documentation is insufficient
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16703">FLINK-16703</a>] -         AkkaRpcActor state machine does not record transition to terminating state.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16705">FLINK-16705</a>] -         LocalExecutor tears down MiniCluster before client can retrieve JobResult
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16718">FLINK-16718</a>] -         KvStateServerHandlerTest leaks Netty ByteBufs
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16727">FLINK-16727</a>] -         Fix cast exception when having time point literal as parameters
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16732">FLINK-16732</a>] -         Failed to call Hive UDF with constant return value
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16740">FLINK-16740</a>] -         OrcSplitReaderUtil::logicalTypeToOrcType fails to create decimal type with precision &lt; 10
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16759">FLINK-16759</a>] -         HiveModuleTest failed to compile on release-1.10
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16767">FLINK-16767</a>] -         Failed to read Hive table with RegexSerDe
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16771">FLINK-16771</a>] -         NPE when filtering by decimal column
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16821">FLINK-16821</a>] -         Run Kubernetes test failed with invalid named &quot;minikube&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16822">FLINK-16822</a>] -         The config set by SET command does not work
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16825">FLINK-16825</a>] -         PrometheusReporterEndToEndITCase should rely on path returned by DownloadCache
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16836">FLINK-16836</a>] -         Losing leadership does not clear rpc connection in JobManagerLeaderListener
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16860">FLINK-16860</a>] -         Failed to push filter into OrcTableSource when upgrading to 1.9.2
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16888">FLINK-16888</a>] -         Re-add jquery license file under &quot;/licenses&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16901">FLINK-16901</a>] -         Flink Kinesis connector NOTICE should have contents of AWS KPL&#39;s THIRD_PARTY_NOTICES file manually merged in
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16913">FLINK-16913</a>] -         ReadableConfigToConfigurationAdapter#getEnum throws UnsupportedOperationException
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16916">FLINK-16916</a>] -         The logic of NullableSerializer#copy is wrong
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16944">FLINK-16944</a>] -         Compile error in. DumpCompiledPlanTest and PreviewPlanDumpTest
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16980">FLINK-16980</a>] -         Python UDF doesn&#39;t work with protobuf 3.6.1
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16981">FLINK-16981</a>] -         flink-runtime tests are crashing the JVM on Java11 because of PowerMock
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17062">FLINK-17062</a>] -         Fix the conversion from Java row type to Python row type
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17066">FLINK-17066</a>] -         Update pyarrow version bounds less than 0.14.0
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17093">FLINK-17093</a>] -         Python UDF doesn&#39;t work when the input column is from composite field
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17107">FLINK-17107</a>] -         CheckpointCoordinatorConfiguration#isExactlyOnce() is inconsistent with StreamConfig#getCheckpointMode()
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17114">FLINK-17114</a>] -         When the pyflink job runs in local mode and the command &quot;python&quot; points to Python 2.7, the startup of the Python UDF worker will fail.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17124">FLINK-17124</a>] -         The PyFlink Job runs into infinite loop if the Python UDF imports job code
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17152">FLINK-17152</a>] -         FunctionDefinitionUtil generate wrong resultType and  acc type of AggregateFunctionDefinition
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17308">FLINK-17308</a>] -         ExecutionGraphCache cachedExecutionGraphs not cleanup cause OOM Bug
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17313">FLINK-17313</a>] -         Validation error when insert decimal/varchar with precision into sink using TypeInformation of row
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17334">FLINK-17334</a>] -          Flink does not support HIVE UDFs with primitive return types
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17338">FLINK-17338</a>] -         LocalExecutorITCase.testBatchQueryCancel test timeout
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17359">FLINK-17359</a>] -         Entropy key is not resolved if flink-s3-fs-hadoop is added as a plugin
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17403">FLINK-17403</a>] -         Fix invalid classpath in BashJavaUtilsITCase
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17471">FLINK-17471</a>] -         Move LICENSE and NOTICE files to root directory of python distribution
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17483">FLINK-17483</a>] -         Update flink-sql-connector-elasticsearch7 NOTICE file to correctly reflect bundled dependencies
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17496">FLINK-17496</a>] -         Performance regression with amazon-kinesis-producer 0.13.1 in Flink 1.10.x
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17499">FLINK-17499</a>] -         LazyTimerService used to register timers via State Processing API incorrectly mixes event time timers with processing time timers
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17514">FLINK-17514</a>] -         TaskCancelerWatchdog does not kill TaskManager
+</li>
+</ul>
+
+<h2>        New Feature
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17275">FLINK-17275</a>] -         Add core training exercises
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-9656">FLINK-9656</a>] -         Environment java opts for flink run
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15094">FLINK-15094</a>] -         Warning about using private constructor of java.nio.DirectByteBuffer in Java 11
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15584">FLINK-15584</a>] -         Give nested data type of ROWs in ValidationException
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15616">FLINK-15616</a>] -         Move boot error messages from python-udf-boot.log to taskmanager&#39;s log file
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15989">FLINK-15989</a>] -         Rewrap OutOfMemoryError in allocateUnpooledOffHeap with better message
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16018">FLINK-16018</a>] -         Improve error reporting when submitting batch job (instead of AskTimeoutException)
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16125">FLINK-16125</a>] -         Make zookeeper.connect optional for Kafka connectors
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16167">FLINK-16167</a>] -         Update documentation about python shell execution
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16191">FLINK-16191</a>] -         Improve error message on Windows when RocksDB Paths are too long
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16280">FLINK-16280</a>] -         Fix sample code errors in the documentation about elasticsearch connector
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16288">FLINK-16288</a>] -         Setting the TTL for discarding task pods on Kubernetes.
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16293">FLINK-16293</a>] -         Document using plugins in Kubernetes
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16343">FLINK-16343</a>] -         Improve exception message when reading an unbounded source in batch mode
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16406">FLINK-16406</a>] -         Increase default value for JVM Metaspace to minimise its OutOfMemoryError
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16538">FLINK-16538</a>] -         Restructure Python Table API documentation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16604">FLINK-16604</a>] -         Column key in JM configuration is too narrow
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16683">FLINK-16683</a>] -         Remove scripts for starting Flink on Windows
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16697">FLINK-16697</a>] -         Disable JMX rebinding
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16763">FLINK-16763</a>] -         Should not use BatchTableEnvironment for Python UDF in the document of flink-1.10
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16772">FLINK-16772</a>] -         Bump derby to 10.12.1.1+ or exclude it
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16790">FLINK-16790</a>] -         enables the interpretation of backslash escapes
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16862">FLINK-16862</a>] -         Remove example url in quickstarts
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16874">FLINK-16874</a>] -         Respect the dynamic options when calculating memory options in taskmanager.sh
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16942">FLINK-16942</a>] -         ES 5 sink should allow users to select netty transport client
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17065">FLINK-17065</a>] -         Add documentation about the Python versions supported for PyFlink
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17125">FLINK-17125</a>] -         Add a Usage Notes Page to Answer Common Questions Encountered by PyFlink Users
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17254">FLINK-17254</a>] -         Improve the PyFlink documentation and examples to use SQL DDL for source/sink definition
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17276">FLINK-17276</a>] -         Add checkstyle to training exercises
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17277">FLINK-17277</a>] -         Apply IntelliJ recommendations to training exercises
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17278">FLINK-17278</a>] -         Add Travis to the training exercises
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17279">FLINK-17279</a>] -         Use gradle build scans for training exercises
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17316">FLINK-17316</a>] -         Have HourlyTips solutions use TumblingEventTimeWindows.of
+</li>
+</ul>
+
+<h2>        Task
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15741">FLINK-15741</a>] -         Fix TTL docs after enabling RocksDB compaction filter by default (needs Chinese translation)
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15933">FLINK-15933</a>] -         update content of how generic table schema is stored in hive via HiveCatalog
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15991">FLINK-15991</a>] -         Create Chinese documentation for FLIP-49 TM memory model
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16004">FLINK-16004</a>] -         Exclude flink-rocksdb-state-memory-control-test jars from the dist
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16454">FLINK-16454</a>] -         Update the copyright year in NOTICE files
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16530">FLINK-16530</a>] -         Add documentation about &quot;GROUPING SETS&quot; and &quot;CUBE&quot; support in streaming mode
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16592">FLINK-16592</a>] -         The doc of Streaming File Sink has a mistake of grammar
+</li>
+</ul>
+
+
+      </article>
+    </div>
+
+    <div class="row">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = 'stratosphere-eu'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+      </script>
+    </div>
+  </div>
+</div>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="row">
+      <div class="footer text-center col-sm-12">
+        <p>Copyright © 2014-2019 <a href="http://apache.org">The Apache Software Foundation</a>. All Rights Reserved.</p>
+        <p>Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        <p><a href="/privacy-policy.html">Privacy Policy</a> &middot; <a href="/blog/feed.xml">RSS feed</a></p>
+      </div>
+    </div>
+    </div><!-- /.container -->
+
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
+    <script src="/js/codetabs.js"></script>
+    <script src="/js/stickysidebar.js"></script>
+
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52545728-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+  </body>
+</html>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -205,7 +205,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-1100" id="markdown-toc-apache-flink-1100">Apache Flink 1.10.0</a></li>
+  <li><a href="#apache-flink-1101" id="markdown-toc-apache-flink-1101">Apache Flink 1.10.1</a></li>
   <li><a href="#apache-flink-193" id="markdown-toc-apache-flink-193">Apache Flink 1.9.3</a></li>
   <li><a href="#section-4" id="markdown-toc-section-4">额外组件</a></li>
   <li><a href="#section-5" id="markdown-toc-section-5">验证哈希和签名</a></li>
@@ -220,40 +220,40 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.10.0 是我们最新的稳定版本。</p>
+<p>Apache Flink® 1.10.1 是我们最新的稳定版本。</p>
 
 <p>如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
 Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/zh/ops/deployment/hadoop.html">Hadoop 集成</a>文档。</p>
 
-<h2 id="apache-flink-1100">Apache Flink 1.10.0</h2>
+<h2 id="apache-flink-1101">Apache Flink 1.10.1</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz" class="ga-track" id="1100-download_211">Apache Flink 1.10.0 for Scala 2.11</a> (<a href="
- https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz" class="ga-track" id="1101-download_211">Apache Flink 1.10.1 for Scala 2.11</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz" class="ga-track" id="1100-download_212">Apache Flink 1.10.0 for Scala 2.12</a> (<a href="
- https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz" class="ga-track" id="1101-download_212">Apache Flink 1.10.1 for Scala 2.12</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.0/flink-1.10.0-src.tgz" class="ga-track" id="1100-download-source">Apache Flink 1.10.0 Source Release</a>
- (<a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.0/flink-1.10.0-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz" class="ga-track" id="1101-download-source">Apache Flink 1.10.1 Source Release</a>
+ (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section">可选组件</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar" class="ga-track" id="1100-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.0/flink-avro-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar" class="ga-track" id="1101-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar" class="ga-track" id="1100-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.0/flink-csv-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar" class="ga-track" id="1101-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar" class="ga-track" id="1100-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.0/flink-json-1.10.0.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar" class="ga-track" id="1101-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="section-1">发布说明</h4>
@@ -341,17 +341,17 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.10.0<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.1<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h2 id="section-6">旧版本的更新策略</h2>
@@ -365,6 +365,17 @@ flink-docs-release-1.9/release-notes/flink-1.9.html">Flink 1.9 的发布说明</
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.10.1 - 2020-05-12 
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -565,6 +565,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/05/12/release-1.10.1.html">Apache Flink 1.10.1 Released</a></dt>
+        <dd><p>The Apache Flink community released the first bugfix version of the Apache Flink 1.10 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/05/07/community-update.html">Flink Community Update - May'20</a></dt>
         <dd>Can you smell it? It’s release month! This time around, we’re warming up for Flink 1.11 and peeping back to the past month in the Flink community — with the release of Stateful Functions 2.0, a new self-paced Flink training and some efforts to improve the Flink documentation experience.</dd>
       
@@ -578,9 +583,6 @@
       
         <dt> <a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Memory Management Improvements with Apache Flink 1.10</a></dt>
         <dd>This post discusses the recent changes to the memory model of the Task Managers and configuration options for your Flink applications in Flink 1.10.</dd>
-      
-        <dt> <a href="/news/2020/04/15/flink-serialization-tuning-vol-1.html">Flink Serialization Tuning Vol. 1: Choosing your Serializer — if you can</a></dt>
-        <dd>Serialization is a crucial element of your Flink job. This article is the first in a series of posts that will highlight Flink’s serialization stack, and looks at the different ways Flink can serialize your data types.</dd>
     
   </dl>
 


### PR DESCRIPTION
Adds release announcement and download link for 1.10.1
Dates on announcements are still TBD and should be updated accordingly once release happens.