### PR TITLE
[FLINK-17490] Add training page

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -23,6 +23,7 @@ en:
     contribute_website: Contribute to the Website
     roadmap: Roadmap
     tutorials: Tutorials
+    training: Training
 
 zh:
     what_is_flink: Apache Flink 是什么?
@@ -49,3 +50,4 @@ zh:
     contribute_website: 贡献网站
     roadmap: 开发计划
     tutorials: 教程
+    training: Training

--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -23,7 +23,7 @@ en:
     contribute_website: Contribute to the Website
     roadmap: Roadmap
     tutorials: Tutorials
-    training: Training
+    training_course: Training Course
 
 zh:
     what_is_flink: Apache Flink 是什么?
@@ -50,4 +50,4 @@ zh:
     contribute_website: 贡献网站
     roadmap: 开发计划
     tutorials: 教程
-    training: Training
+    training_course: Training Course

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -71,6 +71,7 @@
               <ul class="dropdown-menu">
                 <li><a href="{{ site.docs-stable }}/{% if page.language != 'en' %}{{ page.language }}/{% endif %}getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-statefun-stable }}/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ baseurl_i18n }}/training.html">{{ site.data.i18n[page.language].training_course }}</a></li>
               </ul>
             </li>
 
@@ -84,9 +85,6 @@
                 <li><a href="{{ site.docs-statefun-snapshot }}" target="_blank">Flink Stateful Functions Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
-
-            <!-- Training -->
-            <li{% if page.url contains '/training.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/training.html">{{ site.data.i18n[page.language].training }}</a></li>
 
             <!-- getting help -->
             <li{% if page.url contains '/gettinghelp.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/gettinghelp.html">{{ site.data.i18n[page.language].getting_help }}</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -85,6 +85,9 @@
               </ul>
             </li>
 
+            <!-- Training -->
+            <li{% if page.url contains '/training.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/training.html">{{ site.data.i18n[page.language].training }}</a></li>
+
             <!-- getting help -->
             <li{% if page.url contains '/gettinghelp.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/gettinghelp.html">{{ site.data.i18n[page.language].getting_help }}</a></li>
 

--- a/training.md
+++ b/training.md
@@ -1,0 +1,107 @@
+---
+title: "Training"
+---
+
+The Apache Flink community maintains a self-paced training course that contains
+a set of lessons and hands-on exercises. This step-by-step introduction to Flink focuses
+on learning how to use the DataStream API to meet the needs of common, real-world use cases.
+
+This training covers the fundamentals of Flink, including:
+
+<div class="row">
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-blackboard"></span>  <b>Intro to Flink</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                    <li>Batch vs. Streaming</li>
+                    <li>Parallel Dataflows</li>
+                    <li>State, Time, and Snapshots</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-random"></span> <b>Intro to the DataStream API</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                    <li>Data Types and Serialization</li>
+                    <li>Architecture</li>
+                    <li>Sources and Sinks</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-copy"></span> <b>Data Pipelines and ETL</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Transformations</li>
+                <li>Stateful Stream Processing</li>
+                <li>Connected Streams</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-time"></span> <b>Streaming Analytics</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Event Time Processing</li>
+                <li>Watermarks</li>
+                <li>Windows</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-log-in"></span> <b>Event-driven Applications</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Process Functions</li>
+                <li>Timers</li>
+                <li>Side Outputs</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-ok"></span> <b>Fault Tolerance</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Checkpoints and Savepoints</li>
+                <li>Exactly-once vs. At-least-once</li>
+                <li>Exactly-once End-to-end</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div style="margin-bottom: 400px;">
+<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+</div>
+
+<!-- 
+Any page on this site whose contents aren't tall enough will not render correctly when scrolling.
+Hence the margin-bottom on the div above.
+-->

--- a/training.md
+++ b/training.md
@@ -2,6 +2,8 @@
 title: "Training Course"
 ---
 
+<hr/>
+
 The Apache Flink community maintains a self-paced training course that contains
 a set of lessons and hands-on exercises. This step-by-step introduction to Flink focuses
 on learning how to use the DataStream API to meet the needs of common, real-world use cases.

--- a/training.md
+++ b/training.md
@@ -1,5 +1,5 @@
 ---
-title: "Training"
+title: "Training Course"
 ---
 
 The Apache Flink community maintains a self-paced training course that contains
@@ -98,7 +98,7 @@ This training covers the fundamentals of Flink, including:
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 

--- a/training.zh.md
+++ b/training.zh.md
@@ -1,0 +1,107 @@
+---
+title: "Training"
+---
+
+The Apache Flink community maintains a self-paced training course that contains
+a set of lessons and hands-on exercises. This step-by-step introduction to Flink focuses
+on learning how to use the DataStream API to meet the needs of common, real-world use cases.
+
+This training covers the fundamentals of Flink, including:
+
+<div class="row">
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-blackboard"></span>  <b>Intro to Flink</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                    <li>Batch vs. Streaming</li>
+                    <li>Parallel Dataflows</li>
+                    <li>State, Time, and Snapshots</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-random"></span> <b>Intro to the DataStream API</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                    <li>Data Types and Serialization</li>
+                    <li>Architecture</li>
+                    <li>Sources and Sinks</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-copy"></span> <b>Data Pipelines and ETL</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Transformations</li>
+                <li>Stateful Stream Processing</li>
+                <li>Connected Streams</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-time"></span> <b>Streaming Analytics</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Event Time Processing</li>
+                <li>Watermarks</li>
+                <li>Windows</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-log-in"></span> <b>Event-driven Applications</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Process Functions</li>
+                <li>Timers</li>
+                <li>Side Outputs</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <span class="glyphicon glyphicon-ok"></span> <b>Fault Tolerance</b>
+            </div>
+            <div class="panel-body">
+                <ul style="font-size: small;">
+                <li>Checkpoints and Savepoints</li>
+                <li>Exactly-once vs. At-least-once</li>
+                <li>Exactly-once End-to-end</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div style="margin-bottom: 400px;">
+<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+</div>
+
+<!-- 
+Any page on this site whose contents aren't tall enough will not render correctly when scrolling.
+Hence the margin-bottom on the div above.
+-->

--- a/training.zh.md
+++ b/training.zh.md
@@ -2,6 +2,8 @@
 title: "Training Course"
 ---
 
+<hr/>
+
 The Apache Flink community maintains a self-paced training course that contains
 a set of lessons and hands-on exercises. This step-by-step introduction to Flink focuses
 on learning how to use the DataStream API to meet the needs of common, real-world use cases.

--- a/training.zh.md
+++ b/training.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Training"
+title: "Training Course"
 ---
 
 The Apache Flink community maintains a self-paced training course that contains
@@ -98,7 +98,7 @@ This training covers the fundamentals of Flink, including:
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="{{site.DOCS_BASE_URL}}flink-docs-master/zh/training" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 


### PR DESCRIPTION
Now that the documentation has a training section, it would be good to help folks find it by promoting it from the project website.

This adds training.md and training.zh.md, and adds a Training entry to the site navigation.

![image](https://user-images.githubusercontent.com/43608/80949575-8c15d880-8df4-11ea-9d41-91eefd08e4e0.png)

