### PR TITLE
[community] Updating Dawid's status in the community page.

### DIFF
--- a/community.md
+++ b/community.md
@@ -474,7 +474,7 @@ Flink Forward is a conference happening yearly in different locations around the
   <tr>
     <td class="text-center"><img src="https://avatars1.githubusercontent.com/u/6242259?s=50" class="committer-avatar"></td>
     <td class="text-center">Dawid Wysakowicz</td>
-    <td class="text-center">Committer</td>
+    <td class="text-center">PMC, Committer</td>
     <td class="text-center">dwysakowicz</td>
   </tr>
   <tr>


### PR DESCRIPTION
Dawid is still listed as a Committer in the community page.