### PR TITLE
[FLINK-18309] Recommend avoiding uppercase to emphasise statements in doc style

### DIFF
--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -312,6 +312,18 @@ joke in one culture can be widely misinterpreted in another.</p>
 struggling to complete an action, using words like <em>quick</em> or <em>easy</em> can lead
 to a poor documentation experience.</p>
   </li>
+  <li>
+    <p><strong>Avoid using uppercase words</strong> to highlight or emphasize statements.
+Highlighting key words with e.g. <strong>bold</strong> or <em>italic</em> font usually appears more polite.
+If you want to draw attention to important but not obvious statements,
+try to group them into separate paragraphs starting with a label,
+highlighted with a corresponding HTML tag:</p>
+    <ul>
+      <li><code>&lt;span class="label label-info"&gt;Note&lt;/span&gt;</code></li>
+      <li><code>&lt;span class="label label-warning"&gt;Warning&lt;/span&gt;</code></li>
+      <li><code>&lt;span class="label label-danger"&gt;Danger&lt;/span&gt;</code></li>
+    </ul>
+  </li>
 </ul>
 
 <h3 id="using-flink-specific-terms">Using Flink-specific Terms</h3>

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -310,6 +310,18 @@ joke in one culture can be widely misinterpreted in another.</p>
 struggling to complete an action, using words like <em>quick</em> or <em>easy</em> can lead
 to a poor documentation experience.</p>
   </li>
+  <li>
+    <p><strong>Avoid using uppercase words</strong> to highlight or emphasize statements.
+Highlighting key words with e.g. <strong>bold</strong> or <em>italic</em> font usually appears more polite.
+If you want to draw attention to important but not obvious statements,
+try to group them into separate paragraphs starting with a label,
+highlighted with a corresponding HTML tag:</p>
+    <ul>
+      <li><code>&lt;span class="label label-info"&gt;Note&lt;/span&gt;</code></li>
+      <li><code>&lt;span class="label label-warning"&gt;Warning&lt;/span&gt;</code></li>
+      <li><code>&lt;span class="label label-danger"&gt;Danger&lt;/span&gt;</code></li>
+    </ul>
+  </li>
 </ul>
 
 <h3 id="using-flink-specific-terms">Using Flink-specific Terms</h3>

--- a/contributing/docs-style.md
+++ b/contributing/docs-style.md
@@ -68,6 +68,15 @@ Principles](#general-guiding-principles).
   struggling to complete an action, using words like _quick_ or _easy_ can lead
   to a poor documentation experience.
 
+* **Avoid using uppercase words** to highlight or emphasize statements.
+  Highlighting key words with e.g. **bold** or _italic_ font usually appears more polite.
+  If you want to draw attention to important but not obvious statements,
+  try to group them into separate paragraphs starting with a label,
+  highlighted with a corresponding HTML tag:
+  * `<span class="label label-info">Note</span>`
+  * `<span class="label label-warning">Warning</span>`
+  * `<span class="label label-danger">Danger</span>`
+
 ### Using Flink-specific Terms
 
 Use clear definitions of terms or provide additional instructions on what

--- a/contributing/docs-style.zh.md
+++ b/contributing/docs-style.zh.md
@@ -68,6 +68,15 @@ Principles](#general-guiding-principles).
   struggling to complete an action, using words like _quick_ or _easy_ can lead
   to a poor documentation experience.
 
+* **Avoid using uppercase words** to highlight or emphasize statements.
+  Highlighting key words with e.g. **bold** or _italic_ font usually appears more polite.
+  If you want to draw attention to important but not obvious statements,
+  try to group them into separate paragraphs starting with a label,
+  highlighted with a corresponding HTML tag:
+  * `<span class="label label-info">Note</span>`
+  * `<span class="label label-warning">Warning</span>`
+  * `<span class="label label-danger">Danger</span>`
+
 ### Using Flink-specific Terms
 
 Use clear definitions of terms or provide additional instructions on what


### PR DESCRIPTION
Some contributions tend to use uppercase in user docs to highlight and/or emphasise statements. For example: "you MUST use the latest version". This style may appear somewhat aggressive to users.

Therefore, I suggest to add a recommendation to not use uppercase in user docs. We could highlight these statements as note paragraphs or with less 'shooting' style, e.g. _italics_ to draw user attention.