### PR TITLE
[FLINK-18454] Add a code contribution section about how to look for what to contribute

### DIFF
--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -220,6 +220,7 @@
 
 <div class="page-toc">
 <ul id="markdown-toc">
+  <li><a href="#looking-for-what-to-contribute" id="markdown-toc-looking-for-what-to-contribute">Looking for what to contribute</a></li>
   <li><a href="#code-contribution-process" id="markdown-toc-code-contribution-process">Code Contribution Process</a>    <ul>
       <li><a href="#create-jira-ticket-and-reach-consensus" id="markdown-toc-create-jira-ticket-and-reach-consensus">1. Create Jira Ticket and Reach Consensus</a></li>
       <li><a href="#implement-your-change" id="markdown-toc-implement-your-change">2. Implement your change</a></li>
@@ -230,6 +231,14 @@
 </ul>
 
 </div>
+
+<h2 id="looking-for-what-to-contribute">Looking for what to contribute</h2>
+
+<p>If you have a good idea for the contribution, you can proceed to <a href="#code-contribution-process">the code contribution process</a>.
+If you are looking for what you could contribute, you can browse open Jira issues in <a href="https://issues.apache.org/jira/projects/FLINK/issues">Flink’s bug tracker</a>,
+which are not assigned, and then follow <a href="#code-contribution-process">the code contribution process</a>. If you are very new
+to the Flink project and want to learn about it and its contribution process, you can check
+<a href="https://issues.apache.org/jira/issues/?filter=12349196">the starter issues</a>, which are annotated with a <em>starter</em> label.</p>
 
 <h2 id="code-contribution-process">Code Contribution Process</h2>
 

--- a/contributing/contribute-code.md
+++ b/contributing/contribute-code.md
@@ -12,6 +12,14 @@ Apache Flink is maintained, improved, and extended by code contributions of volu
 
 {% toc %}
 
+## Looking for what to contribute
+
+If you have a good idea for the contribution, you can proceed to [the code contribution process](#code-contribution-process).
+If you are looking for what you could contribute, you can browse open Jira issues in [Flink's bug tracker](https://issues.apache.org/jira/projects/FLINK/issues),
+which are not assigned, and then follow [the code contribution process](#code-contribution-process). If you are very new
+to the Flink project and want to learn about it and its contribution process, you can check
+[the starter issues](https://issues.apache.org/jira/issues/?filter=12349196), which are annotated with a _starter_ label.
+
 ## Code Contribution Process
 
 <style>


### PR DESCRIPTION
The PR adds a code contribution section about how to look for what to contribute to give general advices about browsing open Jira issues and starter tasks.