### PR TITLE
[hotfix] update training links to point to stable docs

### DIFF
--- a/content/training.html
+++ b/content/training.html
@@ -289,7 +289,7 @@ on learning how to use the DataStream API to meet the needs of common, real-worl
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="https://ci.apache.org/projects/flink/flink-docs-master/training" target="_blank">Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="https://ci.apache.org/projects/flink/flink-docs-stable/learn-flink" target="_blank">Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -287,7 +287,7 @@ on learning how to use the DataStream API to meet the needs of common, real-worl
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="https://ci.apache.org/projects/flink/flink-docs-master/zh/training" target="_blank">Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="https://ci.apache.org/projects/flink/flink-docs-stable/zh/learn-flink" target="_blank">Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 

--- a/training.md
+++ b/training.md
@@ -100,7 +100,7 @@ This training covers the fundamentals of Flink, including:
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="{{site.DOCS_BASE_URL}}flink-docs-master/training" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="{{site.DOCS_BASE_URL}}flink-docs-stable/learn-flink" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 

--- a/training.zh.md
+++ b/training.zh.md
@@ -100,7 +100,7 @@ This training covers the fundamentals of Flink, including:
 </div>
 
 <div style="margin-bottom: 400px;">
-<a href="{{site.DOCS_BASE_URL}}flink-docs-master/zh/training" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
+<a href="{{site.DOCS_BASE_URL}}flink-docs-stable/zh/learn-flink" target='_blank'>Apache Flink Training Course <small><span class="glyphicon glyphicon-new-window"></span></small> </a> 
 </div>
 
 <!-- 


### PR DESCRIPTION
Now that Flink 1.11 has been released, the training is available in the stable docs. That's where these links should go.