### PR TITLE
Add Apache Flink release 1.10.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,48 +87,48 @@ flink_releases:
   -
       version_short: "1.10"
       binary_release:
-          name: "Apache Flink 1.10.1"
+          name: "Apache Flink 1.10.2"
           scala_211:
-              id: "1101-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512"
+              id: "1102-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "1101-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512"
+              id: "1102-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.10.1"
-          id: "1101-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz"
-          asc_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc"
-          sha512_url: "https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512"
+          name: "Apache Flink 1.10.2"
+          id: "1102-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-src.tgz"
+          asc_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1101-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1
+          id: 1102-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.sha1
         -
           name: "CSV SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1101-sql-format-csv
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1
+          id: 1102-sql-format-csv
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.sha1
         -
           name: "JSON SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1101-sql-format-json
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1
+          id: 1102-sql-format-json
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.sha1
 
 flink_statefun_releases:
   -
@@ -193,6 +193,10 @@ release_archive:
         version_short: "1.11"
         version_long: 1.11.0
         release_date: 2020-07-06
+      -
+        version_short: "1.10"
+        version_long: 1.10.2
+        release_date: 2020-08-25
       -
         version_short: "1.10"
         version_long: 1.10.1

--- a/_posts/2020-08-25-release-1.10.2.md
+++ b/_posts/2020-08-25-release-1.10.2.md
@@ -1,0 +1,217 @@
+---
+layout: post
+title:  "Apache Flink 1.10.2 Released"
+date:   2020-08-25 00:00:00
+categories: news
+authors:
+- zhuzhu:
+  name: "Zhu Zhu"
+  twitter: "zhuzhv"
+---
+
+The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.
+
+This release includes 73 fixes and minor improvements for Flink 1.10.1. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.10.2.
+
+<div class="alert alert-info" markdown="1">
+<span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+After FLINK-18242, the deprecated `OptionsFactory` and `ConfigurableOptionsFactory` classes are removed (not applicable for release-1.10), please use `RocksDBOptionsFactory` and `ConfigurableRocksDBOptionsFactory` instead. Please also recompile your application codes if any class extending `DefaultConfigurableOptionsFactory`
+</div>
+
+<div class="alert alert-info" markdown="1">
+<span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+After FLINK-17800 by default we will set `setTotalOrderSeek` to true for RocksDB's `ReadOptions`, to prevent user from miss using `optimizeForPointLookup`. Meantime we support customizing `ReadOptions` through `RocksDBOptionsFactory`. Please set `setTotalOrderSeek` back to false if any performance regression observed (normally won't happen according to our testing).
+</div>
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.10.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.10.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.10.2</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+    
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15836'>FLINK-15836</a>] -         Throw fatal error in KubernetesResourceManager when the pods watcher is closed with exception
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16160'>FLINK-16160</a>] -         Schema#proctime and Schema#rowtime don&#39;t work in TableEnvironment#connect code path
+</li>
+</ul>
+            
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-13689'>FLINK-13689</a>] -         Rest High Level Client for Elasticsearch6.x connector leaks threads if no connection could be established
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14369'>FLINK-14369</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14836'>FLINK-14836</a>] -         Unable to set yarn container number for scala shell in yarn mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14894'>FLINK-14894</a>] -         HybridOffHeapUnsafeMemorySegmentTest#testByteBufferWrap failed on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15758'>FLINK-15758</a>] -         Investigate potential out-of-memory problems due to managed unsafe memory allocation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15849'>FLINK-15849</a>] -         Update SQL-CLIENT document from type to data-type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16309'>FLINK-16309</a>] -         ElasticSearch 7 connector is missing in SQL connector list
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16346'>FLINK-16346</a>] -         BlobsCleanupITCase.testBlobServerCleanupCancelledJob fails on Travis
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16432'>FLINK-16432</a>] -         Building Hive connector gives problems
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16451'>FLINK-16451</a>] -         Fix IndexOutOfBoundsException for DISTINCT AGG with constants
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16510'>FLINK-16510</a>] -         Task manager safeguard shutdown may not be reliable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17092'>FLINK-17092</a>] -         Pyflink test BlinkStreamDependencyTests is instable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17322'>FLINK-17322</a>] -         Enable latency tracker would corrupt the broadcast state
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17420'>FLINK-17420</a>] -         Cannot alias Tuple and Row fields when converting DataStream to Table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17466'>FLINK-17466</a>] -         toRetractStream doesn&#39;t work correctly with Pojo conversion class
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17555'>FLINK-17555</a>] -         docstring of pyflink.table.descriptors.FileSystem:1:duplicate object description of pyflink.table.descriptors.FileSystem
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17558'>FLINK-17558</a>] -         Partitions are released in TaskExecutor Main Thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17562'>FLINK-17562</a>] -         POST /jars/:jarid/plan is not working
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17578'>FLINK-17578</a>] -         Union of 2 SideOutputs behaviour incorrect
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17639'>FLINK-17639</a>] -         Document which FileSystems are supported by the StreamingFileSink
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17643'>FLINK-17643</a>] -         LaunchCoordinatorTest fails
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17700'>FLINK-17700</a>] -         The callback client of JavaGatewayServer should run in a daemon thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17744'>FLINK-17744</a>] -         StreamContextEnvironment#execute cannot be call JobListener#onJobExecuted
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17763'>FLINK-17763</a>] -         No log files when starting scala-shell
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17788'>FLINK-17788</a>] -         scala shell in yarn mode is broken
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17800'>FLINK-17800</a>] -         RocksDB optimizeForPointLookup results in missing time windows
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17801'>FLINK-17801</a>] -         TaskExecutorTest.testHeartbeatTimeoutWithResourceManager timeout
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17809'>FLINK-17809</a>] -         BashJavaUtil script logic does not work for paths with spaces
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17822'>FLINK-17822</a>] -         Nightly Flink CLI end-to-end test failed with &quot;JavaGcCleanerWrapper$PendingCleanersRunner cannot access class jdk.internal.misc.SharedSecrets&quot; in Java 11 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17870'>FLINK-17870</a>] -         dependent jars are missing to be shipped to cluster in scala shell
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17891'>FLINK-17891</a>] -          FlinkYarnSessionCli sets wrong execution.target type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17959'>FLINK-17959</a>] -         Exception: &quot;CANCELLED: call already cancelled&quot; is thrown when run python udf
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18008'>FLINK-18008</a>] -         HistoryServer does not log environment information on startup
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18012'>FLINK-18012</a>] -         Deactivate slot timeout if TaskSlotTable.tryMarkSlotActive is called
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18035'>FLINK-18035</a>] -         Executors#newCachedThreadPool could not work as expected
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18045'>FLINK-18045</a>] -         Fix Kerberos credentials checking to unblock Flink on secured MapR
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18048'>FLINK-18048</a>] -         &quot;--host&quot; option could not take effect for standalone application cluster
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18097'>FLINK-18097</a>] -         History server doesn&#39;t clean all job json files
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18168'>FLINK-18168</a>] -         Error results when use UDAF with Object Array return type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18223'>FLINK-18223</a>] -         AvroSerializer does not correctly instantiate GenericRecord
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18241'>FLINK-18241</a>] -         Custom OptionsFactory in user code not working when configured via flink-conf.yaml
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18242'>FLINK-18242</a>] -         Custom OptionsFactory settings seem to have no effect on RocksDB
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18297'>FLINK-18297</a>] -         SQL client: setting execution.type to invalid value shuts down the session
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18329'>FLINK-18329</a>] -         Dist NOTICE issues
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18352'>FLINK-18352</a>] -         org.apache.flink.core.execution.DefaultExecutorServiceLoader not thread safe
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18517'>FLINK-18517</a>] -         kubernetes session test failed with &quot;java.net.SocketException: Broken pipe&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18539'>FLINK-18539</a>] -         StreamExecutionEnvironment#addSource(SourceFunction, TypeInformation) doesn&#39;t use the user defined type information
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18595'>FLINK-18595</a>] -         Deadlock during job shutdown
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18646'>FLINK-18646</a>] -         Managed memory released check can block RPC thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18663'>FLINK-18663</a>] -         RestServerEndpoint may prevent server shutdown
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18677'>FLINK-18677</a>] -         ZooKeeperLeaderRetrievalService does not invalidate leader in case of SUSPENDED connection
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18702'>FLINK-18702</a>] -         Flink elasticsearch connector leaks threads and classloaders thereof
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18815'>FLINK-18815</a>] -         AbstractCloseableRegistryTest.testClose unstable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18821'>FLINK-18821</a>] -         Netty client retry mechanism may cause PartitionRequestClientFactory#createPartitionRequestClient to wait infinitely
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18859'>FLINK-18859</a>] -         ExecutionGraphNotEnoughResourceTest.testRestartWithSlotSharingAndNotEnoughResources failed with &quot;Condition was not met in given timeout.&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18902'>FLINK-18902</a>] -         Cannot serve results of asynchronous REST operations in per-job mode
+</li>
+</ul>
+            
+<h2>        New Feature
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17844'>FLINK-17844</a>] -         Activate japicmp-maven-plugin checks for @PublicEvolving between bug fix releases (x.y.u -&gt; x.y.v)
+</li>
+</ul>
+    
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16217'>FLINK-16217</a>] -         SQL Client crashed when any uncatched exception is thrown
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16225'>FLINK-16225</a>] -         Metaspace Out Of Memory should be handled as Fatal Error in TaskManager
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16619'>FLINK-16619</a>] -         Misleading SlotManagerImpl logging for slot reports of unknown task manager
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16717'>FLINK-16717</a>] -         Use headless service for rpc and blob port when flink on K8S
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17248'>FLINK-17248</a>] -         Make the thread nums of io executor of ClusterEntrypoint and MiniCluster configurable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17503'>FLINK-17503</a>] -         Make memory configuration logging more user-friendly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17819'>FLINK-17819</a>] -         Yarn error unhelpful when forgetting HADOOP_CLASSPATH
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17920'>FLINK-17920</a>] -         Add the Python example of Interval Join in Table API doc
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17945'>FLINK-17945</a>] -         Improve error reporting of Python CI tests
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17970'>FLINK-17970</a>] -         Increase default value of IO pool executor to 4 * #cores
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18010'>FLINK-18010</a>] -         Add more logging to HistoryServer
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18501'>FLINK-18501</a>] -         Mapping of Pluggable Filesystems to scheme is not properly logged
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18644'>FLINK-18644</a>] -         Remove obsolete doc for hive connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18772'>FLINK-18772</a>] -         Hide submit job web ui elements when running in per-job/application mode
+</li>
+</ul>
+                                                                                                                                                            

--- a/content/Makefile
+++ b/content/Makefile
@@ -1,0 +1,25 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+.PHONY: docker-run 
+docker-run: 
+	docker run --rm --volume="$PWD:/srv/flink-web" --expose=4000 -p 4000:4000 -it ruby:2.5 bash -c 'cd /srv/flink-web && ./build.sh -p'
+
+.PHONY: docker-rebuild
+docker-rebuild:
+	docker run --rm --volume="$PWD:/srv/flink-web" --expose=4000 -p 4000:4000 -it ruby:2.5 bash -c 'cd /srv/flink-web && ./build.sh'

--- a/content/README.md
+++ b/content/README.md
@@ -7,5 +7,11 @@ You find instructions for this repository here: https://flink.apache.org/contrib
 You can build the website using Docker such as below (without augmenting your host environment):
 
 ```
-docker run --rm --volume="$PWD:/srv/flink-web" --expose=4000 -p 4000:4000 -it ruby:2.5 bash -c 'cd /srv/flink-web && ./build.sh -p'
+make docker-run
+```
+
+And then rebuild the site before merging into the branch asf-site.
+
+```
+make docker-rebuild
 ```

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -7,6 +7,218 @@
 <atom:link href="https://flink.apache.org/blog/feed.xml" rel="self" type="application/rss+xml" />
 
 <item>
+<title>Apache Flink 1.10.2 Released</title>
+<description>&lt;p&gt;The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.&lt;/p&gt;
+
+&lt;p&gt;This release includes 73 fixes and minor improvements for Flink 1.10.1. The list below includes a detailed list of all fixes and improvements.&lt;/p&gt;
+
+&lt;p&gt;We highly recommend all users to upgrade to Flink 1.10.2.&lt;/p&gt;
+
+&lt;div class=&quot;alert alert-info&quot;&gt;
+  &lt;p&gt;&lt;span class=&quot;label label-info&quot; style=&quot;display: inline-block&quot;&gt;&lt;span class=&quot;glyphicon glyphicon-info-sign&quot; aria-hidden=&quot;true&quot;&gt;&lt;/span&gt; Note&lt;/span&gt;
+After FLINK-18242, the deprecated &lt;code&gt;OptionsFactory&lt;/code&gt; and &lt;code&gt;ConfigurableOptionsFactory&lt;/code&gt; classes are removed (not applicable for release-1.10), please use &lt;code&gt;RocksDBOptionsFactory&lt;/code&gt; and &lt;code&gt;ConfigurableRocksDBOptionsFactory&lt;/code&gt; instead. Please also recompile your application codes if any class extending &lt;code&gt;DefaultConfigurableOptionsFactory&lt;/code&gt;&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;alert alert-info&quot;&gt;
+  &lt;p&gt;&lt;span class=&quot;label label-info&quot; style=&quot;display: inline-block&quot;&gt;&lt;span class=&quot;glyphicon glyphicon-info-sign&quot; aria-hidden=&quot;true&quot;&gt;&lt;/span&gt; Note&lt;/span&gt;
+After FLINK-17800 by default we will set &lt;code&gt;setTotalOrderSeek&lt;/code&gt; to true for RocksDB’s &lt;code&gt;ReadOptions&lt;/code&gt;, to prevent user from miss using &lt;code&gt;optimizeForPointLookup&lt;/code&gt;. Meantime we support customizing &lt;code&gt;ReadOptions&lt;/code&gt; through &lt;code&gt;RocksDBOptionsFactory&lt;/code&gt;. Please set &lt;code&gt;setTotalOrderSeek&lt;/code&gt; back to false if any performance regression observed (normally won’t happen according to our testing).&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;p&gt;Updated Maven dependencies:&lt;/p&gt;
+
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-xml&quot;&gt;&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-java&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.10.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-streaming-java_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.10.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-clients_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.10.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;You can find the binaries on the updated &lt;a href=&quot;/downloads.html&quot;&gt;Downloads page&lt;/a&gt;.&lt;/p&gt;
+
+&lt;p&gt;List of resolved issues:&lt;/p&gt;
+
+&lt;h2&gt;        Sub-task
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15836&quot;&gt;FLINK-15836&lt;/a&gt;] -         Throw fatal error in KubernetesResourceManager when the pods watcher is closed with exception
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16160&quot;&gt;FLINK-16160&lt;/a&gt;] -         Schema#proctime and Schema#rowtime don&amp;#39;t work in TableEnvironment#connect code path
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Bug
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-13689&quot;&gt;FLINK-13689&lt;/a&gt;] -         Rest High Level Client for Elasticsearch6.x connector leaks threads if no connection could be established
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14369&quot;&gt;FLINK-14369&lt;/a&gt;] -         KafkaProducerAtLeastOnceITCase&amp;gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14836&quot;&gt;FLINK-14836&lt;/a&gt;] -         Unable to set yarn container number for scala shell in yarn mode
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-14894&quot;&gt;FLINK-14894&lt;/a&gt;] -         HybridOffHeapUnsafeMemorySegmentTest#testByteBufferWrap failed on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15758&quot;&gt;FLINK-15758&lt;/a&gt;] -         Investigate potential out-of-memory problems due to managed unsafe memory allocation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-15849&quot;&gt;FLINK-15849&lt;/a&gt;] -         Update SQL-CLIENT document from type to data-type
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16309&quot;&gt;FLINK-16309&lt;/a&gt;] -         ElasticSearch 7 connector is missing in SQL connector list
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16346&quot;&gt;FLINK-16346&lt;/a&gt;] -         BlobsCleanupITCase.testBlobServerCleanupCancelledJob fails on Travis
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16432&quot;&gt;FLINK-16432&lt;/a&gt;] -         Building Hive connector gives problems
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16451&quot;&gt;FLINK-16451&lt;/a&gt;] -         Fix IndexOutOfBoundsException for DISTINCT AGG with constants
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16510&quot;&gt;FLINK-16510&lt;/a&gt;] -         Task manager safeguard shutdown may not be reliable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17092&quot;&gt;FLINK-17092&lt;/a&gt;] -         Pyflink test BlinkStreamDependencyTests is instable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17322&quot;&gt;FLINK-17322&lt;/a&gt;] -         Enable latency tracker would corrupt the broadcast state
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17420&quot;&gt;FLINK-17420&lt;/a&gt;] -         Cannot alias Tuple and Row fields when converting DataStream to Table
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17466&quot;&gt;FLINK-17466&lt;/a&gt;] -         toRetractStream doesn&amp;#39;t work correctly with Pojo conversion class
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17555&quot;&gt;FLINK-17555&lt;/a&gt;] -         docstring of pyflink.table.descriptors.FileSystem:1:duplicate object description of pyflink.table.descriptors.FileSystem
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17558&quot;&gt;FLINK-17558&lt;/a&gt;] -         Partitions are released in TaskExecutor Main Thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17562&quot;&gt;FLINK-17562&lt;/a&gt;] -         POST /jars/:jarid/plan is not working
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17578&quot;&gt;FLINK-17578&lt;/a&gt;] -         Union of 2 SideOutputs behaviour incorrect
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17639&quot;&gt;FLINK-17639&lt;/a&gt;] -         Document which FileSystems are supported by the StreamingFileSink
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17643&quot;&gt;FLINK-17643&lt;/a&gt;] -         LaunchCoordinatorTest fails
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17700&quot;&gt;FLINK-17700&lt;/a&gt;] -         The callback client of JavaGatewayServer should run in a daemon thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17744&quot;&gt;FLINK-17744&lt;/a&gt;] -         StreamContextEnvironment#execute cannot be call JobListener#onJobExecuted
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17763&quot;&gt;FLINK-17763&lt;/a&gt;] -         No log files when starting scala-shell
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17788&quot;&gt;FLINK-17788&lt;/a&gt;] -         scala shell in yarn mode is broken
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17800&quot;&gt;FLINK-17800&lt;/a&gt;] -         RocksDB optimizeForPointLookup results in missing time windows
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17801&quot;&gt;FLINK-17801&lt;/a&gt;] -         TaskExecutorTest.testHeartbeatTimeoutWithResourceManager timeout
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17809&quot;&gt;FLINK-17809&lt;/a&gt;] -         BashJavaUtil script logic does not work for paths with spaces
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17822&quot;&gt;FLINK-17822&lt;/a&gt;] -         Nightly Flink CLI end-to-end test failed with &amp;quot;JavaGcCleanerWrapper$PendingCleanersRunner cannot access class jdk.internal.misc.SharedSecrets&amp;quot; in Java 11 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17870&quot;&gt;FLINK-17870&lt;/a&gt;] -         dependent jars are missing to be shipped to cluster in scala shell
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17891&quot;&gt;FLINK-17891&lt;/a&gt;] -          FlinkYarnSessionCli sets wrong execution.target type
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17959&quot;&gt;FLINK-17959&lt;/a&gt;] -         Exception: &amp;quot;CANCELLED: call already cancelled&amp;quot; is thrown when run python udf
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18008&quot;&gt;FLINK-18008&lt;/a&gt;] -         HistoryServer does not log environment information on startup
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18012&quot;&gt;FLINK-18012&lt;/a&gt;] -         Deactivate slot timeout if TaskSlotTable.tryMarkSlotActive is called
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18035&quot;&gt;FLINK-18035&lt;/a&gt;] -         Executors#newCachedThreadPool could not work as expected
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18045&quot;&gt;FLINK-18045&lt;/a&gt;] -         Fix Kerberos credentials checking to unblock Flink on secured MapR
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18048&quot;&gt;FLINK-18048&lt;/a&gt;] -         &amp;quot;--host&amp;quot; option could not take effect for standalone application cluster
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18097&quot;&gt;FLINK-18097&lt;/a&gt;] -         History server doesn&amp;#39;t clean all job json files
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18168&quot;&gt;FLINK-18168&lt;/a&gt;] -         Error results when use UDAF with Object Array return type
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18223&quot;&gt;FLINK-18223&lt;/a&gt;] -         AvroSerializer does not correctly instantiate GenericRecord
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18241&quot;&gt;FLINK-18241&lt;/a&gt;] -         Custom OptionsFactory in user code not working when configured via flink-conf.yaml
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18242&quot;&gt;FLINK-18242&lt;/a&gt;] -         Custom OptionsFactory settings seem to have no effect on RocksDB
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18297&quot;&gt;FLINK-18297&lt;/a&gt;] -         SQL client: setting execution.type to invalid value shuts down the session
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18329&quot;&gt;FLINK-18329&lt;/a&gt;] -         Dist NOTICE issues
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18352&quot;&gt;FLINK-18352&lt;/a&gt;] -         org.apache.flink.core.execution.DefaultExecutorServiceLoader not thread safe
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18517&quot;&gt;FLINK-18517&lt;/a&gt;] -         kubernetes session test failed with &amp;quot;java.net.SocketException: Broken pipe&amp;quot;
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18539&quot;&gt;FLINK-18539&lt;/a&gt;] -         StreamExecutionEnvironment#addSource(SourceFunction, TypeInformation) doesn&amp;#39;t use the user defined type information
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18595&quot;&gt;FLINK-18595&lt;/a&gt;] -         Deadlock during job shutdown
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18646&quot;&gt;FLINK-18646&lt;/a&gt;] -         Managed memory released check can block RPC thread
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18663&quot;&gt;FLINK-18663&lt;/a&gt;] -         RestServerEndpoint may prevent server shutdown
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18677&quot;&gt;FLINK-18677&lt;/a&gt;] -         ZooKeeperLeaderRetrievalService does not invalidate leader in case of SUSPENDED connection
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18702&quot;&gt;FLINK-18702&lt;/a&gt;] -         Flink elasticsearch connector leaks threads and classloaders thereof
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18815&quot;&gt;FLINK-18815&lt;/a&gt;] -         AbstractCloseableRegistryTest.testClose unstable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18821&quot;&gt;FLINK-18821&lt;/a&gt;] -         Netty client retry mechanism may cause PartitionRequestClientFactory#createPartitionRequestClient to wait infinitely
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18859&quot;&gt;FLINK-18859&lt;/a&gt;] -         ExecutionGraphNotEnoughResourceTest.testRestartWithSlotSharingAndNotEnoughResources failed with &amp;quot;Condition was not met in given timeout.&amp;quot;
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18902&quot;&gt;FLINK-18902&lt;/a&gt;] -         Cannot serve results of asynchronous REST operations in per-job mode
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        New Feature
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17844&quot;&gt;FLINK-17844&lt;/a&gt;] -         Activate japicmp-maven-plugin checks for @PublicEvolving between bug fix releases (x.y.u -&amp;gt; x.y.v)
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Improvement
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16217&quot;&gt;FLINK-16217&lt;/a&gt;] -         SQL Client crashed when any uncatched exception is thrown
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16225&quot;&gt;FLINK-16225&lt;/a&gt;] -         Metaspace Out Of Memory should be handled as Fatal Error in TaskManager
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16619&quot;&gt;FLINK-16619&lt;/a&gt;] -         Misleading SlotManagerImpl logging for slot reports of unknown task manager
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16717&quot;&gt;FLINK-16717&lt;/a&gt;] -         Use headless service for rpc and blob port when flink on K8S
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17248&quot;&gt;FLINK-17248&lt;/a&gt;] -         Make the thread nums of io executor of ClusterEntrypoint and MiniCluster configurable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17503&quot;&gt;FLINK-17503&lt;/a&gt;] -         Make memory configuration logging more user-friendly
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17819&quot;&gt;FLINK-17819&lt;/a&gt;] -         Yarn error unhelpful when forgetting HADOOP_CLASSPATH
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17920&quot;&gt;FLINK-17920&lt;/a&gt;] -         Add the Python example of Interval Join in Table API doc
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17945&quot;&gt;FLINK-17945&lt;/a&gt;] -         Improve error reporting of Python CI tests
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-17970&quot;&gt;FLINK-17970&lt;/a&gt;] -         Increase default value of IO pool executor to 4 * #cores
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18010&quot;&gt;FLINK-18010&lt;/a&gt;] -         Add more logging to HistoryServer
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18501&quot;&gt;FLINK-18501&lt;/a&gt;] -         Mapping of Pluggable Filesystems to scheme is not properly logged
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18644&quot;&gt;FLINK-18644&lt;/a&gt;] -         Remove obsolete doc for hive connector
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-18772&quot;&gt;FLINK-18772&lt;/a&gt;] -         Hide submit job web ui elements when running in per-job/application mode
+&lt;/li&gt;
+&lt;/ul&gt;
+
+</description>
+<pubDate>Tue, 25 Aug 2020 02:00:00 +0200</pubDate>
+<link>https://flink.apache.org/news/2020/08/25/release-1.10.2.html</link>
+<guid isPermaLink="true">/news/2020/08/25/release-1.10.2.html</guid>
+</item>
+
+<item>
 <title>The State of Flink on Docker</title>
 <description>&lt;p&gt;With over 50 million downloads from Docker Hub, the Flink docker images are a very popular deployment option.&lt;/p&gt;
 
@@ -17266,77 +17478,6 @@ This feature will allow to prune unpromising event sequences early.&lt;/p&gt;
 <pubDate>Wed, 06 Apr 2016 12:00:00 +0200</pubDate>
 <link>https://flink.apache.org/news/2016/04/06/cep-monitoring.html</link>
 <guid isPermaLink="true">/news/2016/04/06/cep-monitoring.html</guid>
-</item>
-
-<item>
-<title>Flink 1.0.1 Released</title>
-<description>&lt;p&gt;Today, the Flink community released Flink version &lt;strong&gt;1.0.1&lt;/strong&gt;, the first bugfix release of the 1.0 series.&lt;/p&gt;
-
-&lt;p&gt;We &lt;strong&gt;recommend all users updating to this release&lt;/strong&gt; by bumping the version of your Flink dependencies to &lt;code&gt;1.0.1&lt;/code&gt; and updating the binaries on the server. You can find the binaries on the updated &lt;a href=&quot;/downloads.html&quot;&gt;Downloads page&lt;/a&gt;.&lt;/p&gt;
-
-&lt;h2 id=&quot;fixed-issues&quot;&gt;Fixed Issues&lt;/h2&gt;
-
-&lt;h3&gt;Bug&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3179&quot;&gt;FLINK-3179&lt;/a&gt;] -         Combiner is not injected if Reduce or GroupReduce input is explicitly partitioned
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3472&quot;&gt;FLINK-3472&lt;/a&gt;] -         JDBCInputFormat.nextRecord(..) has misleading message on NPE
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3491&quot;&gt;FLINK-3491&lt;/a&gt;] -         HDFSCopyUtilitiesTest fails on Windows
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3495&quot;&gt;FLINK-3495&lt;/a&gt;] -         RocksDB Tests can&amp;#39;t run on Windows
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3533&quot;&gt;FLINK-3533&lt;/a&gt;] -         Update the Gelly docs wrt examples and cluster execution
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3563&quot;&gt;FLINK-3563&lt;/a&gt;] -         .returns() doesn&amp;#39;t compile when using .map() with a custom MapFunction
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3566&quot;&gt;FLINK-3566&lt;/a&gt;] -         Input type validation often fails on custom TypeInfo implementations
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3578&quot;&gt;FLINK-3578&lt;/a&gt;] -         Scala DataStream API does not support Rich Window Functions
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3595&quot;&gt;FLINK-3595&lt;/a&gt;] -         Kafka09 consumer thread does not interrupt when stuck in record emission
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3602&quot;&gt;FLINK-3602&lt;/a&gt;] -         Recursive Types are not supported / crash TypeExtractor
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3621&quot;&gt;FLINK-3621&lt;/a&gt;] -         Misleading documentation of memory configuration parameters
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3629&quot;&gt;FLINK-3629&lt;/a&gt;] -         In wikiedits Quick Start example, &amp;quot;The first call, .window()&amp;quot; should be &amp;quot;The first call, .timeWindow()&amp;quot;
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3651&quot;&gt;FLINK-3651&lt;/a&gt;] -         Fix faulty RollingSink Restore
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3653&quot;&gt;FLINK-3653&lt;/a&gt;] -         recovery.zookeeper.storageDir is not documented on the configuration page
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3663&quot;&gt;FLINK-3663&lt;/a&gt;] -         FlinkKafkaConsumerBase.logPartitionInfo is missing a log marker
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3681&quot;&gt;FLINK-3681&lt;/a&gt;] -         CEP library does not support Java 8 lambdas as select function
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3682&quot;&gt;FLINK-3682&lt;/a&gt;] -         CEP operator does not set the processing timestamp correctly
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3684&quot;&gt;FLINK-3684&lt;/a&gt;] -         CEP operator does not forward watermarks properly
-&lt;/li&gt;
-&lt;/ul&gt;
-
-&lt;h3&gt;Improvement&lt;/h3&gt;
-&lt;ul&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3570&quot;&gt;FLINK-3570&lt;/a&gt;] -         Replace random NIC selection heuristic by InetAddress.getLocalHost
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3575&quot;&gt;FLINK-3575&lt;/a&gt;] -         Update Working With State Section in Doc
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-3591&quot;&gt;FLINK-3591&lt;/a&gt;] -         Replace Quickstart K-Means Example by Streaming Example
-&lt;/li&gt;
-&lt;/ul&gt;
-
-&lt;h2&gt;Test&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-2444&quot;&gt;FLINK-2444&lt;/a&gt;] -         Add tests for HadoopInputFormats
-&lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-2445&quot;&gt;FLINK-2445&lt;/a&gt;] -         Add tests for HadoopOutputFormats
-&lt;/li&gt;
-&lt;/ul&gt;
-</description>
-<pubDate>Wed, 06 Apr 2016 10:00:00 +0200</pubDate>
-<link>https://flink.apache.org/news/2016/04/06/release-1.0.1.html</link>
-<guid isPermaLink="true">/news/2016/04/06/release-1.0.1.html</guid>
 </item>
 
 </channel>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></h2>
+
+      <p>25 Aug 2020
+       Zhu Zhu (<a href="https://twitter.com/zhuzhv">@zhuzhv</a>)</p>
+
+      <p><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.</p>
+
+</p>
+
+      <p><a href="/news/2020/08/25/release-1.10.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></h2>
 
       <p>20 Aug 2020
@@ -318,26 +333,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/07/14/application-mode.html">Application Deployment in Flink: Current State and the new Application Mode</a></h2>
-
-      <p>14 Jul 2020
-       Kostas Kloudas (<a href="https://twitter.com/kkloudas">@kkloudas</a>)</p>
-
-      <p><p>With the rise of stream processing and real-time analytics as a critical tool for modern 
-businesses, an increasing number of organizations build platforms with Apache Flink at their
-core and offer it internally as a service. Many talks with related topics from companies 
-like <a href="https://www.youtube.com/watch?v=VX3S9POGAdU">Uber</a>, <a href="https://www.youtube.com/watch?v=VX3S9POGAdU">Netflix</a>
-and <a href="https://www.youtube.com/watch?v=cH9UdK0yYjc">Alibaba</a> in the latest editions of Flink Forward further 
-illustrate this trend.</p>
-
-</p>
-
-      <p><a href="/news/2020/07/14/application-mode.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +364,16 @@ illustrate this trend.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/10/12/release-1.1.3.html">Apache Flink 1.1.3 Released</a></h2>
+
+      <p>12 Oct 2016
+      </p>
+
+      <p><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.1. series.</p>
+
+</p>
+
+      <p><a href="/news/2016/10/12/release-1.1.3.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/09/05/release-1.1.2.html">Apache Flink 1.1.2 Released</a></h2>
 
       <p>05 Sep 2016
@@ -327,21 +342,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/04/06/release-1.0.1.html">Flink 1.0.1 Released</a></h2>
-
-      <p>06 Apr 2016
-      </p>
-
-      <p><p>Today, the Flink community released Flink version <strong>1.0.1</strong>, the first bugfix release of the 1.0 series.</p>
-
-</p>
-
-      <p><a href="/news/2016/04/06/release-1.0.1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -373,6 +373,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/04/06/release-1.0.1.html">Flink 1.0.1 Released</a></h2>
+
+      <p>06 Apr 2016
+      </p>
+
+      <p><p>Today, the Flink community released Flink version <strong>1.0.1</strong>, the first bugfix release of the 1.0 series.</p>
+
+</p>
+
+      <p><a href="/news/2016/04/06/release-1.0.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/03/08/release-1.0.0.html">Announcing Apache Flink 1.0.0</a></h2>
 
       <p>08 Mar 2016
@@ -328,21 +343,6 @@ Apache Flink started.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/09/01/release-0.9.1.html">Apache Flink 0.9.1 available</a></h2>
-
-      <p>01 Sep 2015
-      </p>
-
-      <p><p>The Flink community is happy to announce that Flink 0.9.1 is now available.</p>
-
-</p>
-
-      <p><a href="/news/2015/09/01/release-0.9.1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -374,6 +374,16 @@ Apache Flink started.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/09/01/release-0.9.1.html">Apache Flink 0.9.1 available</a></h2>
+
+      <p>01 Sep 2015
+      </p>
+
+      <p><p>The Flink community is happy to announce that Flink 0.9.1 is now available.</p>
+
+</p>
+
+      <p><a href="/news/2015/09/01/release-0.9.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/08/24/introducing-flink-gelly.html">Introducing Gelly: Graph Processing with Apache Flink</a></h2>
 
       <p>24 Aug 2015
@@ -340,21 +355,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/02/04/january-in-flink.html">January 2015 in the Flink community</a></h2>
-
-      <p>04 Feb 2015
-      </p>
-
-      <p><p>Happy 2015! Here is a (hopefully digestible) summary of what happened last month in the Flink community.</p>
-
-</p>
-
-      <p><a href="/news/2015/02/04/january-in-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -386,6 +386,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/02/04/january-in-flink.html">January 2015 in the Flink community</a></h2>
+
+      <p>04 Feb 2015
+      </p>
+
+      <p><p>Happy 2015! Here is a (hopefully digestible) summary of what happened last month in the Flink community.</p>
+
+</p>
+
+      <p><a href="/news/2015/02/04/january-in-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/01/21/release-0.8.html">Apache Flink 0.8.0 available</a></h2>
 
       <p>21 Jan 2015
@@ -334,6 +349,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -196,6 +196,26 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/07/14/application-mode.html">Application Deployment in Flink: Current State and the new Application Mode</a></h2>
+
+      <p>14 Jul 2020
+       Kostas Kloudas (<a href="https://twitter.com/kkloudas">@kkloudas</a>)</p>
+
+      <p><p>With the rise of stream processing and real-time analytics as a critical tool for modern 
+businesses, an increasing number of organizations build platforms with Apache Flink at their
+core and offer it internally as a service. Many talks with related topics from companies 
+like <a href="https://www.youtube.com/watch?v=VX3S9POGAdU">Uber</a>, <a href="https://www.youtube.com/watch?v=VX3S9POGAdU">Netflix</a>
+and <a href="https://www.youtube.com/watch?v=cH9UdK0yYjc">Alibaba</a> in the latest editions of Flink Forward further 
+illustrate this trend.</p>
+
+</p>
+
+      <p><a href="/news/2020/07/14/application-mode.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/07/06/release-1.11.0.html">Apache Flink 1.11.0 Release Announcement</a></h2>
 
       <p>06 Jul 2020
@@ -325,19 +345,6 @@ and provide a tutorial for running Streaming ETL with Flink on Zeppelin.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Memory Management Improvements with Apache Flink 1.10</a></h2>
-
-      <p>21 Apr 2020
-       Andrey Zagrebin </p>
-
-      <p>This post discusses the recent changes to the memory model of the Task Managers and configuration options for your Flink applications in Flink 1.10.</p>
-
-      <p><a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +376,16 @@ and provide a tutorial for running Streaming ETL with Flink on Zeppelin.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Memory Management Improvements with Apache Flink 1.10</a></h2>
+
+      <p>21 Apr 2020
+       Andrey Zagrebin </p>
+
+      <p>This post discusses the recent changes to the memory model of the Task Managers and configuration options for your Flink applications in Flink 1.10.</p>
+
+      <p><a href="/news/2020/04/21/memory-management-improvements-flink-1.10.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/04/15/flink-serialization-tuning-vol-1.html">Flink Serialization Tuning Vol. 1: Choosing your Serializer — if you can</a></h2>
 
       <p>15 Apr 2020
@@ -319,19 +332,6 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html">A Guide for Unit Testing in Apache Flink</a></h2>
-
-      <p>07 Feb 2020
-       Kartik Khare (<a href="https://twitter.com/khare_khote">@khare_khote</a>)</p>
-
-      <p>This post provides a detailed guide for unit testing of Apache Flink applications.</p>
-
-      <p><a href="/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -363,6 +363,16 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html">A Guide for Unit Testing in Apache Flink</a></h2>
+
+      <p>07 Feb 2020
+       Kartik Khare (<a href="https://twitter.com/khare_khote">@khare_khote</a>)</p>
+
+      <p>This post provides a detailed guide for unit testing of Apache Flink applications.</p>
+
+      <p><a href="/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/01/30/release-1.9.2.html">Apache Flink 1.9.2 Released</a></h2>
 
       <p>30 Jan 2020
@@ -320,19 +333,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/09/10/community-update.html">Flink Community Update - September'19</a></h2>
-
-      <p>10 Sep 2019
-       Marta Paes (<a href="https://twitter.com/morsapaes">@morsapaes</a>)</p>
-
-      <p>This has been an exciting, fast-paced year for the Apache Flink community. But with over 10k messages across the mailing lists, 3k Jira tickets and 2k pull requests, it is not easy to keep up with the latest state of the project. Plus everything happening around it. With that in mind, we want to bring back regular community updates to the Flink blog.</p>
-
-      <p><a href="/news/2019/09/10/community-update.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -364,6 +364,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -196,6 +196,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/09/10/community-update.html">Flink Community Update - September'19</a></h2>
+
+      <p>10 Sep 2019
+       Marta Paes (<a href="https://twitter.com/morsapaes">@morsapaes</a>)</p>
+
+      <p>This has been an exciting, fast-paced year for the Apache Flink community. But with over 10k messages across the mailing lists, 3k Jira tickets and 2k pull requests, it is not easy to keep up with the latest state of the project. Plus everything happening around it. With that in mind, we want to bring back regular community updates to the Flink blog.</p>
+
+      <p><a href="/news/2019/09/10/community-update.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/08/22/release-1.9.0.html">Apache Flink 1.9.0 Release Announcement</a></h2>
 
       <p>22 Aug 2019
@@ -319,25 +332,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/04/09/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></h2>
-
-      <p>09 Apr 2019
-       Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>)</p>
-
-      <p><p>The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
-latest release includes more than 420 resolved issues and some exciting
-additions to Flink that we describe in the following sections of this post.
-Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12344274">complete changelog</a>
-for more details.</p>
-
-</p>
-
-      <p><a href="/news/2019/04/09/release-1.8.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +363,16 @@ for more details.</p>
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -196,6 +196,25 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/04/09/release-1.8.0.html">Apache Flink 1.8.0 Release Announcement</a></h2>
+
+      <p>09 Apr 2019
+       Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>)</p>
+
+      <p><p>The Apache Flink community is pleased to announce Apache Flink 1.8.0.  The
+latest release includes more than 420 resolved issues and some exciting
+additions to Flink that we describe in the following sections of this post.
+Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12344274">complete changelog</a>
+for more details.</p>
+
+</p>
+
+      <p><a href="/news/2019/04/09/release-1.8.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/features/2019/03/11/prometheus-monitoring.html">Flink and Prometheus: Cloud-native monitoring of streaming applications</a></h2>
 
       <p>11 Mar 2019
@@ -322,23 +341,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/11/30/release-1.7.0.html">Apache Flink 1.7.0 Release Announcement</a></h2>
-
-      <p>30 Nov 2018
-       Till Rohrmann (<a href="https://twitter.com/stsffap">@stsffap</a>)</p>
-
-      <p><p>The Apache Flink community is pleased to announce Apache Flink 1.7.0. 
-The latest release includes more than 420 resolved issues and some exciting additions to Flink that we describe in the following sections of this post. 
-Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12343585">complete changelog</a> for more details.</p>
-
-</p>
-
-      <p><a href="/news/2018/11/30/release-1.7.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -370,6 +372,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -196,6 +196,23 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/11/30/release-1.7.0.html">Apache Flink 1.7.0 Release Announcement</a></h2>
+
+      <p>30 Nov 2018
+       Till Rohrmann (<a href="https://twitter.com/stsffap">@stsffap</a>)</p>
+
+      <p><p>The Apache Flink community is pleased to announce Apache Flink 1.7.0. 
+The latest release includes more than 420 resolved issues and some exciting additions to Flink that we describe in the following sections of this post. 
+Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12343585">complete changelog</a> for more details.</p>
+
+</p>
+
+      <p><a href="/news/2018/11/30/release-1.7.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/10/29/release-1.6.2.html">Apache Flink 1.6.2 Released</a></h2>
 
       <p>29 Oct 2018
@@ -330,21 +347,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/03/15/release-1.3.3.html">Apache Flink 1.3.3 Released</a></h2>
-
-      <p>15 Mar 2018
-      </p>
-
-      <p><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.3 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/03/15/release-1.3.3.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -376,6 +378,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/03/15/release-1.3.3.html">Apache Flink 1.3.3 Released</a></h2>
+
+      <p>15 Mar 2018
+      </p>
+
+      <p><p>The Apache Flink community released the third bugfix version of the Apache Flink 1.3 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/03/15/release-1.3.3.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/03/08/release-1.4.2.html">Apache Flink 1.4.2 Released</a></h2>
 
       <p>08 Mar 2018
@@ -327,21 +342,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/06/23/release-1.3.1.html">Apache Flink 1.3.1 Released</a></h2>
-
-      <p>23 Jun 2017
-      </p>
-
-      <p><p>The Apache Flink community released the first bugfix version of the Apache Flink 1.3 series.</p>
-
-</p>
-
-      <p><a href="/news/2017/06/23/release-1.3.1.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -373,6 +373,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -196,6 +196,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/06/23/release-1.3.1.html">Apache Flink 1.3.1 Released</a></h2>
+
+      <p>23 Jun 2017
+      </p>
+
+      <p><p>The Apache Flink community released the first bugfix version of the Apache Flink 1.3 series.</p>
+
+</p>
+
+      <p><a href="/news/2017/06/23/release-1.3.1.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/06/01/release-1.3.0.html">Apache Flink 1.3.0 Release Announcement</a></h2>
 
       <p>01 Jun 2017 by Robert Metzger (<a href="https://twitter.com/">@rmetzger_</a>)
@@ -323,21 +338,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/10/12/release-1.1.3.html">Apache Flink 1.1.3 Released</a></h2>
-
-      <p>12 Oct 2016
-      </p>
-
-      <p><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.1. series.</p>
-
-</p>
-
-      <p><a href="/news/2016/10/12/release-1.1.3.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +369,16 @@
     <h2>2020</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -208,7 +208,7 @@ $( document ).ready(function() {
 <div class="page-toc">
 <ul id="markdown-toc">
   <li><a href="#apache-flink-1111" id="markdown-toc-apache-flink-1111">Apache Flink 1.11.1</a></li>
-  <li><a href="#apache-flink-1101" id="markdown-toc-apache-flink-1101">Apache Flink 1.10.1</a></li>
+  <li><a href="#apache-flink-1102" id="markdown-toc-apache-flink-1102">Apache Flink 1.10.2</a></li>
   <li><a href="#apache-flink-stateful-functions-210" id="markdown-toc-apache-flink-stateful-functions-210">Apache Flink Stateful Functions 2.1.0</a></li>
   <li><a href="#apache-flink-stateful-functions-200" id="markdown-toc-apache-flink-stateful-functions-200">Apache Flink Stateful Functions 2.0.0</a></li>
   <li><a href="#additional-components" id="markdown-toc-additional-components">Additional Components</a></li>
@@ -262,33 +262,33 @@ file system connector), please check out the <a href="https://ci.apache.org/proj
 
 <hr />
 
-<h2 id="apache-flink-1101">Apache Flink 1.10.1</h2>
+<h2 id="apache-flink-1102">Apache Flink 1.10.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz" class="ga-track" id="1101-download_211">Apache Flink 1.10.1 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz" class="ga-track" id="1102-download_211">Apache Flink 1.10.2 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz" class="ga-track" id="1101-download_212">Apache Flink 1.10.1 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz" class="ga-track" id="1102-download_212">Apache Flink 1.10.2 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz" class="ga-track" id="1101-download-source">Apache Flink 1.10.1 Source Release</a>
-(<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-src.tgz" class="ga-track" id="1102-download-source">Apache Flink 1.10.2 Source Release</a>
+(<a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components-1">Optional components</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar" class="ga-track" id="1101-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar" class="ga-track" id="1102-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar" class="ga-track" id="1101-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar" class="ga-track" id="1102-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar" class="ga-track" id="1101-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar" class="ga-track" id="1102-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="release-notes-1">Release Notes</h4>
@@ -432,6 +432,17 @@ Flink 1.11.0 - 2020-07-06
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
+
+</li>
+
+<li>
+
+Flink 1.10.2 - 2020-08-25 
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -568,6 +568,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></dt>
         <dd>This blog post gives an update on the recent developments of Flink's support for Docker.</dd>
       
@@ -581,9 +586,6 @@
       
         <dt> <a href="/2020/08/04/pyflink-pandas-udf-support-flink.html">PyFlink: The integration of Pandas into PyFlink</a></dt>
         <dd>The Apache Flink community put some great effort into integrating Pandas with PyFlink in the latest Flink version 1.11. Some of the added features include support for Pandas UDF and the conversion between Pandas DataFrame and Table. In this article, we will introduce how these functionalities work and how to use them with a step-by-step example.</dd>
-      
-        <dt> <a href="/news/2020/07/30/demo-fraud-detection-3.html">Advanced Flink Application Patterns Vol.3: Custom Window Processing</a></dt>
-        <dd>In this series of blog posts you will learn about powerful Flink patterns for building streaming applications.</dd>
     
   </dl>
 

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Apache Flink: Apache Flink 1.10.2 Released</title>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/flink.css">
+    <link rel="stylesheet" href="/css/syntax.css">
+
+    <!-- Blog RSS feed -->
+    <link href="/blog/feed.xml" rel="alternate" type="application/rss+xml" title="Apache Flink Blog: RSS feed" />
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <!-- We need to load Jquery in the header for custom google analytics event tracking-->
+    <script src="/js/jquery.min.js"></script>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>  
+    
+
+    <!-- Main content. -->
+    <div class="container">
+    <div class="row">
+
+      
+     <div id="sidebar" class="col-sm-3">
+        
+
+<!-- Top navbar. -->
+    <nav class="navbar navbar-default">
+        <!-- The logo. -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="navbar-logo">
+            <a href="/">
+              <img alt="Apache Flink" src="/img/flink-header-logo.svg" width="147px" height="73px">
+            </a>
+          </div>
+        </div><!-- /.navbar-header -->
+
+        <!-- The navigation links. -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-main">
+
+            <!-- First menu section explains visitors what Flink is -->
+
+            <!-- What is Stream Processing? -->
+            <!--
+            <li><a href="/streamprocessing1.html">What is Stream Processing?</a></li>
+            -->
+
+            <!-- What is Flink? -->
+            <li><a href="/flink-architecture.html">What is Apache Flink?</a></li>
+
+            
+
+            <!-- What is Stateful Functions? -->
+
+            <li><a href="/stateful-functions.html">What is Stateful Functions?</a></li>
+
+            <!-- Use cases -->
+            <li><a href="/usecases.html">Use Cases</a></li>
+
+            <!-- Powered by -->
+            <li><a href="/poweredby.html">Powered By</a></li>
+
+
+            &nbsp;
+            <!-- Second menu section aims to support Flink users -->
+
+            <!-- Downloads -->
+            <li><a href="/downloads.html">Downloads</a></li>
+
+            <!-- Getting Started -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="/training.html">Training Course</a></li>
+              </ul>
+            </li>
+
+            <!-- Documentation -->
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#">Documentation<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11" target="_blank">Flink 1.11 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-master" target="_blank">Flink Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1" target="_blank">Flink Stateful Functions 2.1 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-master" target="_blank">Flink Stateful Functions Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+              </ul>
+            </li>
+
+            <!-- getting help -->
+            <li><a href="/gettinghelp.html">Getting Help</a></li>
+
+            <!-- Blog -->
+            <li class="active"><a href="/blog/"><b>Flink Blog</b></a></li>
+
+
+            <!-- Flink-packages -->
+            <li>
+              <a href="https://flink-packages.org" target="_blank">flink-packages.org <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+            &nbsp;
+
+            <!-- Third menu section aim to support community and contributors -->
+
+            <!-- Community -->
+            <li><a href="/community.html">Community &amp; Project Info</a></li>
+
+            <!-- Roadmap -->
+            <li><a href="/roadmap.html">Roadmap</a></li>
+
+            <!-- Contribute -->
+            <li><a href="/contributing/how-to-contribute.html">How to Contribute</a></li>
+            
+
+            <!-- GitHub -->
+            <li>
+              <a href="https://github.com/apache/flink" target="_blank">Flink on GitHub <small><span class="glyphicon glyphicon-new-window"></span></small></a>
+            </li>
+
+            &nbsp;
+
+            <!-- Language Switcher -->
+            <li>
+              
+                
+                  <!-- link to the Chinese home page when current is blog page -->
+                  <a href="/zh">中文版</a>
+                
+              
+            </li>
+
+          </ul>
+
+          <ul class="nav navbar-nav navbar-bottom">
+          <hr />
+
+            <!-- Twitter -->
+            <li><a href="https://twitter.com/apacheflink" target="_blank">@ApacheFlink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <!-- Visualizer -->
+            <li class=" hidden-md hidden-sm"><a href="/visualizer/" target="_blank">Plan Visualizer <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+          <hr />
+
+            <li><a href="https://apache.org" target="_blank">Apache Software Foundation <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+
+            <li>
+              <style>
+                .smalllinks:link {
+                  display: inline-block !important; background: none; padding-top: 0px; padding-bottom: 0px; padding-right: 0px; min-width: 75px;
+                }
+              </style>
+
+              <a class="smalllinks" href="https://www.apache.org/licenses/" target="_blank">License</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/security/" target="_blank">Security</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+
+              <a class="smalllinks" href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a> <small><span class="glyphicon glyphicon-new-window"></span></small>
+            </li>
+
+          </ul>
+        </div><!-- /.navbar-collapse -->
+    </nav>
+
+      </div>
+      <div class="col-sm-9">
+      <div class="row-fluid">
+  <div class="col-sm-12">
+    <div class="row">
+      <h1>Apache Flink 1.10.2 Released</h1>
+      <p><i></i></p>
+
+      <article>
+        <p>25 Aug 2020 Zhu Zhu (<a href="https://twitter.com/zhuzhv">@zhuzhv</a>)</p>
+
+<p>The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.</p>
+
+<p>This release includes 73 fixes and minor improvements for Flink 1.10.1. The list below includes a detailed list of all fixes and improvements.</p>
+
+<p>We highly recommend all users to upgrade to Flink 1.10.2.</p>
+
+<div class="alert alert-info">
+  <p><span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+After FLINK-18242, the deprecated <code>OptionsFactory</code> and <code>ConfigurableOptionsFactory</code> classes are removed (not applicable for release-1.10), please use <code>RocksDBOptionsFactory</code> and <code>ConfigurableRocksDBOptionsFactory</code> instead. Please also recompile your application codes if any class extending <code>DefaultConfigurableOptionsFactory</code></p>
+</div>
+
+<div class="alert alert-info">
+  <p><span class="label label-info" style="display: inline-block"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> Note</span>
+After FLINK-17800 by default we will set <code>setTotalOrderSeek</code> to true for RocksDB’s <code>ReadOptions</code>, to prevent user from miss using <code>optimizeForPointLookup</code>. Meantime we support customizing <code>ReadOptions</code> through <code>RocksDBOptionsFactory</code>. Please set <code>setTotalOrderSeek</code> back to false if any performance regression observed (normally won’t happen according to our testing).</p>
+</div>
+
+<p>Updated Maven dependencies:</p>
+
+<div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span>
+<span class="nt">&lt;dependency&gt;</span>
+  <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
+  <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.10.2<span class="nt">&lt;/version&gt;</span>
+<span class="nt">&lt;/dependency&gt;</span></code></pre></div>
+
+<p>You can find the binaries on the updated <a href="/downloads.html">Downloads page</a>.</p>
+
+<p>List of resolved issues:</p>
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15836">FLINK-15836</a>] -         Throw fatal error in KubernetesResourceManager when the pods watcher is closed with exception
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16160">FLINK-16160</a>] -         Schema#proctime and Schema#rowtime don&#39;t work in TableEnvironment#connect code path
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-13689">FLINK-13689</a>] -         Rest High Level Client for Elasticsearch6.x connector leaks threads if no connection could be established
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14369">FLINK-14369</a>] -         KafkaProducerAtLeastOnceITCase&gt;KafkaProducerTestBase.testOneToOneAtLeastOnceCustomOperator fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14836">FLINK-14836</a>] -         Unable to set yarn container number for scala shell in yarn mode
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-14894">FLINK-14894</a>] -         HybridOffHeapUnsafeMemorySegmentTest#testByteBufferWrap failed on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15758">FLINK-15758</a>] -         Investigate potential out-of-memory problems due to managed unsafe memory allocation
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-15849">FLINK-15849</a>] -         Update SQL-CLIENT document from type to data-type
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16309">FLINK-16309</a>] -         ElasticSearch 7 connector is missing in SQL connector list
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16346">FLINK-16346</a>] -         BlobsCleanupITCase.testBlobServerCleanupCancelledJob fails on Travis
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16432">FLINK-16432</a>] -         Building Hive connector gives problems
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16451">FLINK-16451</a>] -         Fix IndexOutOfBoundsException for DISTINCT AGG with constants
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16510">FLINK-16510</a>] -         Task manager safeguard shutdown may not be reliable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17092">FLINK-17092</a>] -         Pyflink test BlinkStreamDependencyTests is instable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17322">FLINK-17322</a>] -         Enable latency tracker would corrupt the broadcast state
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17420">FLINK-17420</a>] -         Cannot alias Tuple and Row fields when converting DataStream to Table
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17466">FLINK-17466</a>] -         toRetractStream doesn&#39;t work correctly with Pojo conversion class
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17555">FLINK-17555</a>] -         docstring of pyflink.table.descriptors.FileSystem:1:duplicate object description of pyflink.table.descriptors.FileSystem
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17558">FLINK-17558</a>] -         Partitions are released in TaskExecutor Main Thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17562">FLINK-17562</a>] -         POST /jars/:jarid/plan is not working
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17578">FLINK-17578</a>] -         Union of 2 SideOutputs behaviour incorrect
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17639">FLINK-17639</a>] -         Document which FileSystems are supported by the StreamingFileSink
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17643">FLINK-17643</a>] -         LaunchCoordinatorTest fails
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17700">FLINK-17700</a>] -         The callback client of JavaGatewayServer should run in a daemon thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17744">FLINK-17744</a>] -         StreamContextEnvironment#execute cannot be call JobListener#onJobExecuted
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17763">FLINK-17763</a>] -         No log files when starting scala-shell
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17788">FLINK-17788</a>] -         scala shell in yarn mode is broken
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17800">FLINK-17800</a>] -         RocksDB optimizeForPointLookup results in missing time windows
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17801">FLINK-17801</a>] -         TaskExecutorTest.testHeartbeatTimeoutWithResourceManager timeout
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17809">FLINK-17809</a>] -         BashJavaUtil script logic does not work for paths with spaces
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17822">FLINK-17822</a>] -         Nightly Flink CLI end-to-end test failed with &quot;JavaGcCleanerWrapper$PendingCleanersRunner cannot access class jdk.internal.misc.SharedSecrets&quot; in Java 11 
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17870">FLINK-17870</a>] -         dependent jars are missing to be shipped to cluster in scala shell
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17891">FLINK-17891</a>] -          FlinkYarnSessionCli sets wrong execution.target type
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17959">FLINK-17959</a>] -         Exception: &quot;CANCELLED: call already cancelled&quot; is thrown when run python udf
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18008">FLINK-18008</a>] -         HistoryServer does not log environment information on startup
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18012">FLINK-18012</a>] -         Deactivate slot timeout if TaskSlotTable.tryMarkSlotActive is called
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18035">FLINK-18035</a>] -         Executors#newCachedThreadPool could not work as expected
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18045">FLINK-18045</a>] -         Fix Kerberos credentials checking to unblock Flink on secured MapR
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18048">FLINK-18048</a>] -         &quot;--host&quot; option could not take effect for standalone application cluster
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18097">FLINK-18097</a>] -         History server doesn&#39;t clean all job json files
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18168">FLINK-18168</a>] -         Error results when use UDAF with Object Array return type
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18223">FLINK-18223</a>] -         AvroSerializer does not correctly instantiate GenericRecord
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18241">FLINK-18241</a>] -         Custom OptionsFactory in user code not working when configured via flink-conf.yaml
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18242">FLINK-18242</a>] -         Custom OptionsFactory settings seem to have no effect on RocksDB
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18297">FLINK-18297</a>] -         SQL client: setting execution.type to invalid value shuts down the session
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18329">FLINK-18329</a>] -         Dist NOTICE issues
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18352">FLINK-18352</a>] -         org.apache.flink.core.execution.DefaultExecutorServiceLoader not thread safe
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18517">FLINK-18517</a>] -         kubernetes session test failed with &quot;java.net.SocketException: Broken pipe&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18539">FLINK-18539</a>] -         StreamExecutionEnvironment#addSource(SourceFunction, TypeInformation) doesn&#39;t use the user defined type information
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18595">FLINK-18595</a>] -         Deadlock during job shutdown
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18646">FLINK-18646</a>] -         Managed memory released check can block RPC thread
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18663">FLINK-18663</a>] -         RestServerEndpoint may prevent server shutdown
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18677">FLINK-18677</a>] -         ZooKeeperLeaderRetrievalService does not invalidate leader in case of SUSPENDED connection
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18702">FLINK-18702</a>] -         Flink elasticsearch connector leaks threads and classloaders thereof
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18815">FLINK-18815</a>] -         AbstractCloseableRegistryTest.testClose unstable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18821">FLINK-18821</a>] -         Netty client retry mechanism may cause PartitionRequestClientFactory#createPartitionRequestClient to wait infinitely
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18859">FLINK-18859</a>] -         ExecutionGraphNotEnoughResourceTest.testRestartWithSlotSharingAndNotEnoughResources failed with &quot;Condition was not met in given timeout.&quot;
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18902">FLINK-18902</a>] -         Cannot serve results of asynchronous REST operations in per-job mode
+</li>
+</ul>
+
+<h2>        New Feature
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17844">FLINK-17844</a>] -         Activate japicmp-maven-plugin checks for @PublicEvolving between bug fix releases (x.y.u -&gt; x.y.v)
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16217">FLINK-16217</a>] -         SQL Client crashed when any uncatched exception is thrown
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16225">FLINK-16225</a>] -         Metaspace Out Of Memory should be handled as Fatal Error in TaskManager
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16619">FLINK-16619</a>] -         Misleading SlotManagerImpl logging for slot reports of unknown task manager
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-16717">FLINK-16717</a>] -         Use headless service for rpc and blob port when flink on K8S
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17248">FLINK-17248</a>] -         Make the thread nums of io executor of ClusterEntrypoint and MiniCluster configurable
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17503">FLINK-17503</a>] -         Make memory configuration logging more user-friendly
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17819">FLINK-17819</a>] -         Yarn error unhelpful when forgetting HADOOP_CLASSPATH
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17920">FLINK-17920</a>] -         Add the Python example of Interval Join in Table API doc
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17945">FLINK-17945</a>] -         Improve error reporting of Python CI tests
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-17970">FLINK-17970</a>] -         Increase default value of IO pool executor to 4 * #cores
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18010">FLINK-18010</a>] -         Add more logging to HistoryServer
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18501">FLINK-18501</a>] -         Mapping of Pluggable Filesystems to scheme is not properly logged
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18644">FLINK-18644</a>] -         Remove obsolete doc for hive connector
+</li>
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-18772">FLINK-18772</a>] -         Hide submit job web ui elements when running in per-job/application mode
+</li>
+</ul>
+
+
+      </article>
+    </div>
+
+    <div class="row">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = 'stratosphere-eu'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+      </script>
+    </div>
+  </div>
+</div>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="row">
+      <div class="footer text-center col-sm-12">
+        <p>Copyright © 2014-2019 <a href="http://apache.org">The Apache Software Foundation</a>. All Rights Reserved.</p>
+        <p>Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        <p><a href="/privacy-policy.html">Privacy Policy</a> &middot; <a href="/blog/feed.xml">RSS feed</a></p>
+      </div>
+    </div>
+    </div><!-- /.container -->
+
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js"></script>
+    <script src="/js/codetabs.js"></script>
+    <script src="/js/stickysidebar.js"></script>
+
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52545728-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+  </body>
+</html>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -206,7 +206,7 @@ $( document ).ready(function() {
 <div class="page-toc">
 <ul id="markdown-toc">
   <li><a href="#apache-flink-1111" id="markdown-toc-apache-flink-1111">Apache Flink 1.11.1</a></li>
-  <li><a href="#apache-flink-1101" id="markdown-toc-apache-flink-1101">Apache Flink 1.10.1</a></li>
+  <li><a href="#apache-flink-1102" id="markdown-toc-apache-flink-1102">Apache Flink 1.10.2</a></li>
   <li><a href="#section-4" id="markdown-toc-section-4">额外组件</a></li>
   <li><a href="#section-5" id="markdown-toc-section-5">验证哈希和签名</a></li>
   <li><a href="#maven-" id="markdown-toc-maven-">Maven 依赖</a></li>
@@ -253,35 +253,35 @@ Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/
 <p>如果你计划从以前的版本升级 Flink，请查看 <a href="https://ci.apache.org/projects/flink/
 flink-docs-release-1.11/release-notes/flink-1.11.html">Flink 1.11 的发布说明</a>。</p>
 
-<h2 id="apache-flink-1101">Apache Flink 1.10.1</h2>
+<h2 id="apache-flink-1102">Apache Flink 1.10.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz" class="ga-track" id="1101-download_211">Apache Flink 1.10.1 for Scala 2.11</a> (<a href="
- https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz" class="ga-track" id="1102-download_211">Apache Flink 1.10.2 for Scala 2.11</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz" class="ga-track" id="1101-download_212">Apache Flink 1.10.1 for Scala 2.12</a> (<a href="
- https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz" class="ga-track" id="1102-download_212">Apache Flink 1.10.2 for Scala 2.12</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.1/flink-1.10.1-src.tgz" class="ga-track" id="1101-download-source">Apache Flink 1.10.1 Source Release</a>
- (<a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.1/flink-1.10.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.10.2/flink-1.10.2-src.tgz" class="ga-track" id="1102-download-source">Apache Flink 1.10.2 Source Release</a>
+ (<a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.10.2/flink-1.10.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section-2">可选组件</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar" class="ga-track" id="1101-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.1/flink-avro-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar" class="ga-track" id="1102-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.10.2/flink-avro-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar" class="ga-track" id="1101-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.1/flink-csv-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar" class="ga-track" id="1102-sql-format-csv">CSV SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.10.2/flink-csv-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar" class="ga-track" id="1101-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.1/flink-json-1.10.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar" class="ga-track" id="1102-sql-format-json">JSON SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.10.2/flink-json-1.10.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="section-3">发布说明</h4>
@@ -377,6 +377,17 @@ Flink 1.11.0 - 2020-07-06
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
+
+</li>
+
+<li>
+
+Flink 1.10.2 - 2020-08-25 
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -565,6 +565,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2020/08/25/release-1.10.2.html">Apache Flink 1.10.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the second bugfix version of the Apache Flink 1.10 series.</p>
+
+</dd>
+      
         <dt> <a href="/news/2020/08/20/flink-docker.html">The State of Flink on Docker</a></dt>
         <dd>This blog post gives an update on the recent developments of Flink's support for Docker.</dd>
       
@@ -578,9 +583,6 @@
       
         <dt> <a href="/2020/08/04/pyflink-pandas-udf-support-flink.html">PyFlink: The integration of Pandas into PyFlink</a></dt>
         <dd>The Apache Flink community put some great effort into integrating Pandas with PyFlink in the latest Flink version 1.11. Some of the added features include support for Pandas UDF and the conversion between Pandas DataFrame and Table. In this article, we will introduce how these functionalities work and how to use them with a step-by-step example.</dd>
-      
-        <dt> <a href="/news/2020/07/30/demo-fraud-detection-3.html">Advanced Flink Application Patterns Vol.3: Custom Window Processing</a></dt>
-        <dd>In this series of blog posts you will learn about powerful Flink patterns for building streaming applications.</dd>
     
   </dl>
 


### PR DESCRIPTION
Adds release announcement and download link for 1.10.2
Dates on announcements are still TBD and should be updated accordingly once release happens.