### PR TITLE
Add Apache Flink release 1.11.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: https://flink.apache.org
 
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
-FLINK_VERSION_STABLE: 1.11.1
+FLINK_VERSION_STABLE: 1.11.2
 FLINK_VERSION_STABLE_SHORT: "1.11"
 
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
@@ -58,32 +58,32 @@ flink_releases:
   -
       version_short: "1.11"
       binary_release:
-          name: "Apache Flink 1.11.1"
+          name: "Apache Flink 1.11.2"
           scala_211:
-              id: "1111-download_211"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.11.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.11.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.11.tgz.sha512"
+              id: "1112-download_211"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.11.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.11.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.11.tgz.sha512"
           scala_212:
-              id: "1111-download_212"
-              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.12.tgz"
-              asc_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.12.tgz.asc"
-              sha512_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-bin-scala_2.12.tgz.sha512"
+              id: "1112-download_212"
+              url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.12.tgz"
+              asc_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.12.tgz.asc"
+              sha512_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.12.tgz.sha512"
       source_release:
-          name: "Apache Flink 1.11.1"
-          id: "1111-download-source"
-          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.1/flink-1.11.1-src.tgz"
-          asc_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-src.tgz.asc"
-          sha512_url: "https://downloads.apache.org/flink/flink-1.11.1/flink-1.11.1-src.tgz.sha512"
+          name: "Apache Flink 1.11.2"
+          id: "1112-download-source"
+          url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.11.2/flink-1.11.2-src.tgz"
+          asc_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-src.tgz.asc"
+          sha512_url: "https://downloads.apache.org/flink/flink-1.11.2/flink-1.11.2-src.tgz.sha512"
       optional_components:
         -
           name: "Avro SQL Format"
           category: "SQL Formats"
           scala_dependent: false
-          id: 1111-sql-format-avro
-          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.1/flink-avro-1.11.1.jar
-          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.1/flink-avro-1.11.1.jar.asc
-          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.1/flink-avro-1.11.1.jar.sha1
+          id: 1112-sql-format-avro
+          url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.2/flink-avro-1.11.2.jar
+          asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.2/flink-avro-1.11.2.jar.asc
+          sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.11.2/flink-avro-1.11.2.jar.sha1
   -
       version_short: "1.10"
       binary_release:
@@ -185,6 +185,10 @@ component_releases:
 
 release_archive:
     flink:
+      -
+        version_short: "1.11"
+        version_long: 1.11.2
+        release_date: 2020-09-17
       -
         version_short: "1.11"
         version_long: 1.11.1

--- a/_posts/2020-09-17-release-1.11.2.md
+++ b/_posts/2020-09-17-release-1.11.2.md
@@ -1,0 +1,252 @@
+---
+layout: post
+title:  "Apache Flink 1.11.2 Released"
+date:   2020-09-17 00:00:00
+categories: news
+authors:
+- zhuzhu:
+  name: "Zhu Zhu"
+  twitter: "zhuzhv"
+---
+
+The Apache Flink community released the second bugfix version of the Apache Flink 1.11 series.
+
+This release includes 96 fixes and minor improvements for Flink 1.11.1. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.11.2.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.11.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.11.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.11.2</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16087'>FLINK-16087</a>] -         Translate &quot;Detecting Patterns&quot; page of &quot;Streaming Concepts&quot; into Chinese 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18264'>FLINK-18264</a>] -         Translate the &quot;External Resource Framework&quot; page into Chinese
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18628'>FLINK-18628</a>] -         Invalid error message for overloaded methods with same parameter name
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18801'>FLINK-18801</a>] -         Add a &quot;10 minutes to Table API&quot; document under  the &quot;Python API&quot; -&gt; &quot;User Guide&quot; -&gt; &quot;Table API&quot; section
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18910'>FLINK-18910</a>] -         Create the new document structure for Python documentation according to FLIP-133
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18912'>FLINK-18912</a>] -         Add a Table API tutorial link(linked to try-flink/python_table_api.md) under  the &quot;Python API&quot; -&gt; &quot;GettingStart&quot; -&gt; &quot;Tutorial&quot; section
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18913'>FLINK-18913</a>] -         Add a &quot;TableEnvironment&quot; document under  the &quot;Python API&quot; -&gt; &quot;User Guide&quot; -&gt; &quot;Table API&quot; section
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18917'>FLINK-18917</a>] -         Add a &quot;Built-in Functions&quot; link (linked to dev/table/functions/systemFunctions.md) under the &quot;Python API&quot; -&gt; &quot;User Guide&quot; -&gt; &quot;Table API&quot; section
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19110'>FLINK-19110</a>] -         Flatten current PyFlink documentation structure
+</li>
+</ul>
+            
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-14087'>FLINK-14087</a>] -         throws java.lang.ArrayIndexOutOfBoundsException  when emiting the data using RebalancePartitioner. 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-15467'>FLINK-15467</a>] -         Should wait for the end of the source thread during the Task cancellation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16510'>FLINK-16510</a>] -         Task manager safeguard shutdown may not be reliable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16827'>FLINK-16827</a>] -         StreamExecTemporalSort should require a distribution trait in StreamExecTemporalSortRule
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18081'>FLINK-18081</a>] -         Fix broken links in &quot;Kerberos Authentication Setup and Configuration&quot; doc
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18212'>FLINK-18212</a>] -         Init lookup join failed when use udf on lookup table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18341'>FLINK-18341</a>] -         Building Flink Walkthrough Table Java 0.1 COMPILATION ERROR
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18421'>FLINK-18421</a>] -         Elasticsearch (v6.3.1) sink end-to-end test instable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18468'>FLINK-18468</a>] -         TaskExecutorITCase.testJobReExecutionAfterTaskExecutorTermination fails with DuplicateJobSubmissionException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18552'>FLINK-18552</a>] -         Update migration tests in master to cover migration from release-1.11
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18581'>FLINK-18581</a>] -         Cannot find GC cleaner with java version previous jdk8u72(-b01)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18588'>FLINK-18588</a>] -         hive ddl create table should support &#39;if not exists&#39;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18595'>FLINK-18595</a>] -         Deadlock during job shutdown
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18600'>FLINK-18600</a>] -         Kerberized YARN per-job on Docker test failed to download JDK 8u251
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18608'>FLINK-18608</a>] -         CustomizedConvertRule#convertCast drops nullability
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18612'>FLINK-18612</a>] -         WordCount example failure when setting relative output path
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18632'>FLINK-18632</a>] -         RowData&#39;s row kind do not assigned from input row data when sink code generate and physical type info is pojo type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18639'>FLINK-18639</a>] -         Error messages from BashJavaUtils are eaten
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18641'>FLINK-18641</a>] -         &quot;Failure to finalize checkpoint&quot; error in MasterTriggerRestoreHook
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18646'>FLINK-18646</a>] -         Managed memory released check can block RPC thread
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18650'>FLINK-18650</a>] -         The description of dispatcher in Flink Architecture document is not accurate
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18655'>FLINK-18655</a>] -         Set failOnUnableToExtractRepoInfo to false for git-commit-id-plugin in module flink-runtime
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18656'>FLINK-18656</a>] -         Start Delay metric is always zero for unaligned checkpoints
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18659'>FLINK-18659</a>] -         FileNotFoundException when writing Hive orc tables
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18663'>FLINK-18663</a>] -         RestServerEndpoint may prevent server shutdown
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18665'>FLINK-18665</a>] -         Filesystem connector should use TableSchema exclude computed columns
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18672'>FLINK-18672</a>] -         Fix Scala code examples for UDF type inference annotations
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18677'>FLINK-18677</a>] -         ZooKeeperLeaderRetrievalService does not invalidate leader in case of SUSPENDED connection
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18682'>FLINK-18682</a>] -         Vector orc reader cannot read Hive 2.0.0 table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18697'>FLINK-18697</a>] -         Adding flink-table-api-java-bridge_2.11 to a Flink job kills the IDE logging
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18700'>FLINK-18700</a>] -         Debezium-json format throws Exception when PG table&#39;s IDENTITY config is not FULL
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18705'>FLINK-18705</a>] -         Debezium-JSON throws NPE when tombstone message is received
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18708'>FLINK-18708</a>] -         The links of the connector sql jar of Kafka 0.10 and 0.11 are extinct
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18710'>FLINK-18710</a>] -         ResourceProfileInfo is not serializable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18748'>FLINK-18748</a>] -         Savepoint would be queued unexpected if pendingCheckpoints less than maxConcurrentCheckpoints
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18749'>FLINK-18749</a>] -         Correct dependencies in Kubernetes pom
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18750'>FLINK-18750</a>] -         SqlValidatorException thrown when select from a view which contains a UDTF call
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18769'>FLINK-18769</a>] -         MiniBatch doesn&#39;t work with FLIP-95 source
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18821'>FLINK-18821</a>] -         Netty client retry mechanism may cause PartitionRequestClientFactory#createPartitionRequestClient to wait infinitely
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18832'>FLINK-18832</a>] -         BoundedBlockingSubpartition does not work with StreamTask
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18856'>FLINK-18856</a>] -         CheckpointCoordinator ignores checkpointing.min-pause
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18859'>FLINK-18859</a>] -         ExecutionGraphNotEnoughResourceTest.testRestartWithSlotSharingAndNotEnoughResources failed with &quot;Condition was not met in given timeout.&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18862'>FLINK-18862</a>] -         Fix LISTAGG throws BinaryRawValueData cannot be cast to StringData exception in runtime
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18867'>FLINK-18867</a>] -         Generic table stored in Hive catalog is incompatible between 1.10 and 1.11
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18900'>FLINK-18900</a>] -         HiveCatalog should error out when listing partitions with an invalid spec
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18902'>FLINK-18902</a>] -         Cannot serve results of asynchronous REST operations in per-job mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18941'>FLINK-18941</a>] -         There are some typos in &quot;Set up JobManager Memory&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18942'>FLINK-18942</a>] -         HiveTableSink shouldn&#39;t try to create BulkWriter factory when using MR writer
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18956'>FLINK-18956</a>] -         StreamTask.invoke should catch Throwable instead of Exception
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18959'>FLINK-18959</a>] -         Fail to archiveExecutionGraph because job is not finished when dispatcher close
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18992'>FLINK-18992</a>] -         Table API renameColumns method annotation error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18993'>FLINK-18993</a>] -         Invoke sanityCheckTotalFlinkMemory method incorrectly in JobManagerFlinkMemoryUtils.java
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18994'>FLINK-18994</a>] -         There is one typo in &quot;Set up TaskManager Memory&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19040'>FLINK-19040</a>] -         SourceOperator is not closing SourceReader
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19061'>FLINK-19061</a>] -         HiveCatalog fails to get partition column stats if partition value contains special characters
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19094'>FLINK-19094</a>] -         Revise the description of watermark strategy in Flink Table document 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19108'>FLINK-19108</a>] -         Stop expanding the identifiers with scope aliased by the system with &#39;EXPR$&#39; prefix
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19109'>FLINK-19109</a>] -         Split Reader eats chained periodic watermarks
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19121'>FLINK-19121</a>] -         Avoid accessing HDFS frequently in HiveBulkWriterFactory
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19133'>FLINK-19133</a>] -         User provided kafka partitioners are not initialized correctly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19148'>FLINK-19148</a>] -         Table crashed in Flink Table API &amp; SQL  Docs 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19166'>FLINK-19166</a>] -         StreamingFileWriter should register Listener before the initialization of buckets
+</li>
+</ul>
+                
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16619'>FLINK-16619</a>] -         Misleading SlotManagerImpl logging for slot reports of unknown task manager
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17075'>FLINK-17075</a>] -         Add task status reconciliation between TM and JM
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17285'>FLINK-17285</a>] -         Translate &quot;Python Table API&quot; page into Chinese 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-17503'>FLINK-17503</a>] -         Make memory configuration logging more user-friendly
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18598'>FLINK-18598</a>] -         Add instructions for asynchronous execute in PyFlink doc
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18618'>FLINK-18618</a>] -         Docker e2e tests are failing on CI
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18619'>FLINK-18619</a>] -         Update training to use WatermarkStrategy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18635'>FLINK-18635</a>] -         Typo in &#39;concepts/timely stream processing&#39; part of the website
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18643'>FLINK-18643</a>] -         Migrate Jenkins jobs to ci-builds.apache.org
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18644'>FLINK-18644</a>] -         Remove obsolete doc for hive connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18730'>FLINK-18730</a>] -         Remove Beta tag from SQL Client docs
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18772'>FLINK-18772</a>] -         Hide submit job web ui elements when running in per-job/application mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18793'>FLINK-18793</a>] -         Fix Typo for api.common.eventtime.WatermarkStrategy Description
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18797'>FLINK-18797</a>] -         docs and examples use deprecated forms of keyBy
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18816'>FLINK-18816</a>] -         Correct API usage in Pyflink Dependency Management page
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18831'>FLINK-18831</a>] -         Improve the Python documentation about the operations in Table
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18839'>FLINK-18839</a>] -         Add documentation about how to use catalog in Python Table API
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18847'>FLINK-18847</a>] -         Add documentation about data types in Python Table API
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18849'>FLINK-18849</a>] -         Improve the code tabs of the Flink documents
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18881'>FLINK-18881</a>] -         Modify the Access Broken Link
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19055'>FLINK-19055</a>] -         MemoryManagerSharedResourcesTest contains three tests running extraordinary long
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19105'>FLINK-19105</a>] -         Table API Sample Code Error
+</li>
+</ul>
+            
+<h2>        Task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18666'>FLINK-18666</a>] -         Update japicmp configuration for 1.11.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18667'>FLINK-18667</a>] -         Data Types documentation misunderstand users
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-18678'>FLINK-18678</a>] -         Hive connector fails to create vector orc reader if user specifies incorrect hive version
+</li>
+</ul>


### PR DESCRIPTION
Adds release announcement and download link for 1.11.2
Dates on announcements are still TBD and should be updated accordingly once release happens.