### PR TITLE
[hotfix] Add missed JOIN keyword for sql example in the announcement

### DIFF
--- a/_posts/2020-12-10-release-1.12.0.md
+++ b/_posts/2020-12-10-release-1.12.0.md
@@ -200,7 +200,7 @@ SELECT
     o.order_time, 
     o.amount * r.currency_rate AS amount,
     r.currency
-FROM orders AS o, latest_rates FOR SYSTEM_TIME AS OF o.order_time r
+FROM orders AS o JOIN latest_rates FOR SYSTEM_TIME AS OF o.order_time r
 ON o.currency = r.currency;
 ```
 


### PR DESCRIPTION
Add missed AS keyword for sql example in the announcement.

* checked in plan test