### PR TITLE
Fix the broken Getting-started link of flink project

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -69,7 +69,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ site.data.i18n[page.language].getting_started }}<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="{{ site.docs-stable }}/{% if page.language != 'en' %}{{ page.language }}/{% endif %}getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ site.docs-stable }}/{% if page.language != 'en' %}{{ page.language }}/{% endif %}try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-statefun-stable }}/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ baseurl_i18n }}/training.html">{{ site.data.i18n[page.language].training_course }}</a></li>
               </ul>

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/community.html
+++ b/content/community.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/index.html
+++ b/content/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/material.html
+++ b/content/material.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/project.html
+++ b/content/project.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/slides.html
+++ b/content/slides.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/training.html
+++ b/content/training.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Getting Started<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-preamble.html
+++ b/content/zh/contributing/code-style-and-quality-preamble.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -104,7 +104,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -92,7 +92,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/getting-started/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/try-flink/index.html" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>


### PR DESCRIPTION
# change:
the link https://ci.apache.org/projects/flink/flink-docs-release-1.12/getting-started/index.html is broken
update the link to https://ci.apache.org/projects/flink/flink-docs-release-1.12/try-flink/index.html 