### PR TITLE
[hotfix] Update 1.11.3 release note.

### DIFF
--- a/_posts/2020-12-18-release-1.11.3.md
+++ b/_posts/2020-12-18-release-1.11.3.md
@@ -11,7 +11,7 @@ authors:
 
 The Apache Flink community released the third bugfix version of the Apache Flink 1.11 series.
 
-This release includes 152 fixes and minor improvements for Flink 1.11.2. The list below includes a detailed list of all fixes and improvements.
+This release includes 151 fixes and minor improvements for Flink 1.11.2. The list below includes a detailed list of all fixes and improvements.
 
 We highly recommend all users to upgrade to Flink 1.11.3.
 
@@ -314,8 +314,6 @@ List of resolved issues:
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-18545'>FLINK-18545</a>] -         Sql api cannot specify flink job name
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-18715'>FLINK-18715</a>] -         add cpu usage metric of  jobmanager/taskmanager
-</li>
-<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19125'>FLINK-19125</a>] -         Avoid memory fragmentation when running flink docker image
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-19193'>FLINK-19193</a>] -         Recommend stop-with-savepoint in upgrade guidelines
 </li>


### PR DESCRIPTION
Remove FLINK-19125, which was not fixed for this release and was included by mistake.