### PR TITLE
Add Apache Flink 1.12.2 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -207,7 +207,7 @@ release_archive:
     flink:
       - version_short: "1.12"
         version_long: 1.12.2
-        release_date: 2021-02-16
+        release_date: 2021-02-27
       -
         version_short: "1.12"
         version_long: 1.12.1

--- a/_config.yml
+++ b/_config.yml
@@ -207,7 +207,7 @@ release_archive:
     flink:
       - version_short: "1.12"
         version_long: 1.12.2
-        release_date: 2021-02-27
+        release_date: 2021-03-03
       -
         version_short: "1.12"
         version_long: 1.12.1

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: https://flink.apache.org
 
 DOCS_BASE_URL: https://ci.apache.org/projects/flink/
 
-FLINK_VERSION_STABLE: 1.12.1
+FLINK_VERSION_STABLE: 1.12.2
 FLINK_VERSION_STABLE_SHORT: "1.12"
 
 FLINK_ISSUES_URL: https://issues.apache.org/jira/browse/FLINK
@@ -58,32 +58,32 @@ flink_releases:
   -
     version_short: "1.12"
     binary_release:
-      name: "Apache Flink 1.12.1"
+      name: "Apache Flink 1.12.2"
       scala_211:
-        id: "1121-download_211"
-        url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz"
-        asc_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.asc"
-        sha512_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.sha512"
+        id: "1122-download_211"
+        url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz"
+        asc_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.asc"
+        sha512_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.sha512"
       scala_212:
-        id: "1121-download_212"
-        url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz"
-        asc_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.asc"
-        sha512_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.sha512"
+        id: "1122-download_212"
+        url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz"
+        asc_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.asc"
+        sha512_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.sha512"
     source_release:
-      name: "Apache Flink 1.12.1"
-      id: "1121-download-source"
-      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-src.tgz"
-      asc_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.asc"
-      sha512_url: "https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.sha512"
+      name: "Apache Flink 1.12.2"
+      id: "1122-download-source"
+      url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-src.tgz"
+      asc_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.asc"
+      sha512_url: "https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.sha512"
     optional_components:
       -
         name: "Avro SQL Format"
         category: "SQL Formats"
         scala_dependent: false
-        id: 1121-sql-format-avro
-        url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar
-        asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.asc
-        sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.sha1
+        id: 1122-sql-format-avro
+        url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar
+        asc_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.asc
+        sha_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.sha1
   -
       version_short: "1.11"
       binary_release:
@@ -206,6 +206,10 @@ component_releases:
 release_archive:
     flink:
       - version_short: "1.12"
+        version_long: 1.12.2
+        release_date: 2021-02-16
+      -
+        version_short: "1.12"
         version_long: 1.12.1
         release_date: 2021-01-19
       -

--- a/_posts/2021-02-16-release-1.12.2.md
+++ b/_posts/2021-02-16-release-1.12.2.md
@@ -1,0 +1,205 @@
+---
+layout: post
+title:  "Apache Flink 1.12.2 Released"
+date:   2021-02-16 00:00:00
+categories: news
+authors:
+- yuan:
+  name: "Yuan Mei"
+- roman:
+  name: "Roman Khachatryan"
+
+---
+
+The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.
+
+This release includes 69 fixes and minor improvements for Flink 1.12.1. The list below includes a detailed list of all fixes and improvements.
+
+We highly recommend all users to upgrade to Flink 1.12.2.
+
+Updated Maven dependencies:
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.12.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java_2.11</artifactId>
+  <version>1.12.2</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients_2.11</artifactId>
+  <version>1.12.2</version>
+</dependency>
+```
+
+You can find the binaries on the updated [Downloads page]({{ site.baseurl }}/downloads.html).
+
+List of resolved issues:
+
+<h2>        Sub-task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21070'>FLINK-21070</a>] -         Overloaded aggregate functions cause converter errors
+</li>
+</ul>
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-12461'>FLINK-12461</a>] -         Document binary compatibility situation with Scala beyond 2.12.8
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-16443'>FLINK-16443</a>] -         Fix wrong fix for user-code CheckpointExceptions
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-19771'>FLINK-19771</a>] -         NullPointerException when accessing null array from postgres in JDBC Connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20309'>FLINK-20309</a>] -         UnalignedCheckpointTestBase.execute is failed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20462'>FLINK-20462</a>] -         MailboxOperatorTest.testAvoidTaskStarvation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20500'>FLINK-20500</a>] -         UpsertKafkaTableITCase.testTemporalJoin test failed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20565'>FLINK-20565</a>] -         Fix typo in EXPLAIN Statements docs.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20654'>FLINK-20654</a>] -         Unaligned checkpoint recovery may lead to corrupted data stream
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20663'>FLINK-20663</a>] -         Managed memory may not be released in time when operators use managed memory frequently
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20675'>FLINK-20675</a>] -         Asynchronous checkpoint failure would not fail the job anymore
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20680'>FLINK-20680</a>] -         Fails to call var-arg function with no parameters
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20798'>FLINK-20798</a>] -         Using PVC as high-availability.storageDir could not work
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20832'>FLINK-20832</a>] -         Deliver bootstrap resouces ourselves for website and documentation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20848'>FLINK-20848</a>] -         Kafka consumer ID is not specified correctly in new KafkaSource
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20913'>FLINK-20913</a>] -         Improve new HiveConf(jobConf, HiveConf.class)
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20921'>FLINK-20921</a>] -         Fix Date/Time/Timestamp in Python DataStream
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20933'>FLINK-20933</a>] -         Config Python Operator Use Managed Memory In Python DataStream
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20942'>FLINK-20942</a>] -         Digest of FLOAT literals throws UnsupportedOperationException
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20944'>FLINK-20944</a>] -         Launching in application mode requesting a ClusterIP rest service type results in an Exception
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20947'>FLINK-20947</a>] -         Idle source doesn&#39;t work when pushing watermark into the source
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20961'>FLINK-20961</a>] -         Flink throws NullPointerException for tables created from DataStream with no assigned timestamps and watermarks
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20992'>FLINK-20992</a>] -         Checkpoint cleanup can kill JobMaster
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20998'>FLINK-20998</a>] -         flink-raw-1.12.jar does not exist
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21009'>FLINK-21009</a>] -         Can not disable certain options in Elasticsearch 7 connector
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21013'>FLINK-21013</a>] -         Blink planner does not ingest timestamp into StreamRecord
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21024'>FLINK-21024</a>] -         Dynamic properties get exposed to job&#39;s main method if user parameters are passed
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21059'>FLINK-21059</a>] -         KafkaSourceEnumerator does not honor consumer properties
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21069'>FLINK-21069</a>] -         Configuration &quot;parallelism.default&quot; doesn&#39;t take effect for TableEnvironment#explainSql
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21071'>FLINK-21071</a>] -         Snapshot branches running against flink-docker dev-master branch
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21104'>FLINK-21104</a>] -         UnalignedCheckpointITCase.execute failed with &quot;IllegalStateException&quot;
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21132'>FLINK-21132</a>] -         BoundedOneInput.endInput is called when taking synchronous savepoint
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21138'>FLINK-21138</a>] -         KvStateServerHandler is not invoked with user code classloader
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21140'>FLINK-21140</a>] -         Extract zip file dependencies before adding to PYTHONPATH
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21144'>FLINK-21144</a>] -         KubernetesResourceManagerDriver#tryResetPodCreationCoolDown causes fatal error
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21155'>FLINK-21155</a>] -         FileSourceTextLinesITCase.testBoundedTextFileSourceWithTaskManagerFailover does not pass
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21158'>FLINK-21158</a>] -         wrong jvm metaspace and overhead size show in  taskmanager metric page
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21163'>FLINK-21163</a>] -         Python dependencies specified via CLI should not override the dependencies specified in configuration
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21169'>FLINK-21169</a>] -         Kafka flink-connector-base dependency should be scope compile
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21208'>FLINK-21208</a>] -         pyarrow exception when using window with pandas udaf
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21215'>FLINK-21215</a>] -         Checkpoint was declined because one input stream is finished
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21216'>FLINK-21216</a>] -         StreamPandasConversionTests Fails
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21225'>FLINK-21225</a>] -         OverConvertRule does not consider distinct
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21226'>FLINK-21226</a>] -         Reintroduce TableColumn.of for backwards compatibility
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21274'>FLINK-21274</a>] -         At per-job mode, during the exit of the JobManager process, if ioExecutor exits at the end, the System.exit() method will not be executed.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21277'>FLINK-21277</a>] -         SQLClientSchemaRegistryITCase fails to download testcontainers/ryuk:0.3.0
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21312'>FLINK-21312</a>] -         SavepointITCase.testStopSavepointWithBoundedInputConcurrently is unstable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21323'>FLINK-21323</a>] -         Stop-with-savepoint is not supported by SourceOperatorStreamTask
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21361'>FLINK-21361</a>] -         FlinkRelMdUniqueKeys matches on AbstractCatalogTable instead of CatalogTable
+</li>
+</ul>
+
+<h2>        New Feature
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20359'>FLINK-20359</a>] -         Support adding Owner Reference to Job Manager in native kubernetes setup
+</li>
+</ul>
+    
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-9844'>FLINK-9844</a>] -         PackagedProgram does not close URLClassLoader
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20417'>FLINK-20417</a>] -         Handle &quot;Too old resource version&quot; exception in Kubernetes watch more gracefully
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20491'>FLINK-20491</a>] -         Support Broadcast Operation in BATCH execution mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20517'>FLINK-20517</a>] -         Support mixed keyed/non-keyed operations in BATCH execution mode
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20770'>FLINK-20770</a>] -         Incorrect description for config option kubernetes.rest-service.exposed.type
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20907'>FLINK-20907</a>] -         Table API documentation promotes deprecated syntax
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21020'>FLINK-21020</a>] -         Bump Jackson to 20.10.5[.1] / 2.12.1
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21034'>FLINK-21034</a>] -         Rework jemalloc switch to use an environment variable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21035'>FLINK-21035</a>] -         Deduplicate copy_plugins_if_required calls
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21036'>FLINK-21036</a>] -         Consider removing automatic configuration fo number of slots from docker
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21037'>FLINK-21037</a>] -         Deduplicate configuration logic in docker entrypoint
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21042'>FLINK-21042</a>] -         Fix code example in &quot;Aggregate Functions&quot; section in Table UDF page
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21048'>FLINK-21048</a>] -         Refactor documentation related to switch memory allocator 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21123'>FLINK-21123</a>] -         Upgrade Beanutils 1.9.x to 1.9.4
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21164'>FLINK-21164</a>] -         Jar handlers don&#39;t cleanup temporarily extracted jars
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21210'>FLINK-21210</a>] -         ApplicationClusterEntryPoints should explicitly close PackagedProgram
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21381'>FLINK-21381</a>] -         Kubernetes HA documentation does not state required service account and role
+</li>
+</ul>
+
+<h2>        Task
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20529'>FLINK-20529</a>] -         Publish Dockerfiles for release 1.12.0
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20960'>FLINK-20960</a>] -         Add warning in 1.12 release notes about potential corrupt data stream with unaligned checkpoint 
+</li>
+</ul>

--- a/_posts/2021-02-27-release-1.12.2.md
+++ b/_posts/2021-02-27-release-1.12.2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Apache Flink 1.12.2 Released"
-date:   2021-02-16 00:00:00
+date:   2021-02-27 00:00:00
 categories: news
 authors:
 - yuan:
@@ -13,7 +13,7 @@ authors:
 
 The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.
 
-This release includes 69 fixes and minor improvements for Flink 1.12.1. The list below includes a detailed list of all fixes and improvements.
+This release includes 83 fixes and minor improvements for Flink 1.12.1. The list below includes a detailed list of all fixes and improvements.
 
 We highly recommend all users to upgrade to Flink 1.12.2.
 
@@ -46,6 +46,8 @@ List of resolved issues:
 <ul>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21070'>FLINK-21070</a>] -         Overloaded aggregate functions cause converter errors
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21486'>FLINK-21486</a>] -         Add sanity check when switching from Rocks to Heap timers
+</li>
 </ul>
 
 <h2>        Bug
@@ -64,6 +66,8 @@ List of resolved issues:
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-20500'>FLINK-20500</a>] -         UpsertKafkaTableITCase.testTemporalJoin test failed
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-20565'>FLINK-20565</a>] -         Fix typo in EXPLAIN Statements docs.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20580'>FLINK-20580</a>] -         Missing null value handling for SerializedValue&#39;s getByteArray() 
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-20654'>FLINK-20654</a>] -         Unaligned checkpoint recovery may lead to corrupted data stream
 </li>
@@ -103,6 +107,10 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21024'>FLINK-21024</a>] -         Dynamic properties get exposed to job&#39;s main method if user parameters are passed
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21028'>FLINK-21028</a>] -         Streaming application didn&#39;t stop properly 
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21030'>FLINK-21030</a>] -         Broken job restart for job with disjoint graph
+</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21059'>FLINK-21059</a>] -         KafkaSourceEnumerator does not honor consumer properties
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21069'>FLINK-21069</a>] -         Configuration &quot;parallelism.default&quot; doesn&#39;t take effect for TableEnvironment#explainSql
@@ -129,6 +137,8 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21208'>FLINK-21208</a>] -         pyarrow exception when using window with pandas udaf
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21213'>FLINK-21213</a>] -         e2e test fail with &#39;As task is already not running, no longer decline checkpoint&#39;
+</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21215'>FLINK-21215</a>] -         Checkpoint was declined because one input stream is finished
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21216'>FLINK-21216</a>] -         StreamPandasConversionTests Fails
@@ -145,7 +155,19 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21323'>FLINK-21323</a>] -         Stop-with-savepoint is not supported by SourceOperatorStreamTask
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21351'>FLINK-21351</a>] -         Incremental checkpoint data would be lost once a non-stop savepoint completed
+</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21361'>FLINK-21361</a>] -         FlinkRelMdUniqueKeys matches on AbstractCatalogTable instead of CatalogTable
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21412'>FLINK-21412</a>] -         pyflink DataTypes.DECIMAL is not available
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21452'>FLINK-21452</a>] -         FLIP-27 sources cannot reliably downscale
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21453'>FLINK-21453</a>] -         BoundedOneInput.endInput is NOT called when doing stop with savepoint WITH drain
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21490'>FLINK-21490</a>] -         UnalignedCheckpointITCase fails on azure
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21492'>FLINK-21492</a>] -         ActiveResourceManager swallows exception stack trace
 </li>
 </ul>
 
@@ -200,6 +222,13 @@ List of resolved issues:
 <ul>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-20529'>FLINK-20529</a>] -         Publish Dockerfiles for release 1.12.0
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20534'>FLINK-20534</a>] -         Add Flink 1.12 MigrationVersion
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-20536'>FLINK-20536</a>] -         Update migration tests in master to cover migration from release-1.12
+</li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-20960'>FLINK-20960</a>] -         Add warning in 1.12 release notes about potential corrupt data stream with unaligned checkpoint 
 </li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21358'>FLINK-21358</a>] -         Missing snapshot version compatibility for 1.12
+</li>
 </ul>
+

--- a/_posts/2021-03-03-release-1.12.2.md
+++ b/_posts/2021-03-03-release-1.12.2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Apache Flink 1.12.2 Released"
-date:   2021-02-27 00:00:00
+date:   2021-03-03 00:00:00
 categories: news
 authors:
 - yuan:

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -7,6 +7,233 @@
 <atom:link href="https://flink.apache.org/blog/feed.xml" rel="self" type="application/rss+xml" />
 
 <item>
+<title>Apache Flink 1.12.2 Released</title>
+<description>&lt;p&gt;The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.&lt;/p&gt;
+
+&lt;p&gt;This release includes 83 fixes and minor improvements for Flink 1.12.1. The list below includes a detailed list of all fixes and improvements.&lt;/p&gt;
+
+&lt;p&gt;We highly recommend all users to upgrade to Flink 1.12.2.&lt;/p&gt;
+
+&lt;p&gt;Updated Maven dependencies:&lt;/p&gt;
+
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-xml&quot;&gt;&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-java&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.12.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-streaming-java_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.12.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;dependency&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;groupId&amp;gt;&lt;/span&gt;org.apache.flink&lt;span class=&quot;nt&quot;&gt;&amp;lt;/groupId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;artifactId&amp;gt;&lt;/span&gt;flink-clients_2.11&lt;span class=&quot;nt&quot;&gt;&amp;lt;/artifactId&amp;gt;&lt;/span&gt;
+  &lt;span class=&quot;nt&quot;&gt;&amp;lt;version&amp;gt;&lt;/span&gt;1.12.2&lt;span class=&quot;nt&quot;&gt;&amp;lt;/version&amp;gt;&lt;/span&gt;
+&lt;span class=&quot;nt&quot;&gt;&amp;lt;/dependency&amp;gt;&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;You can find the binaries on the updated &lt;a href=&quot;/downloads.html&quot;&gt;Downloads page&lt;/a&gt;.&lt;/p&gt;
+
+&lt;p&gt;List of resolved issues:&lt;/p&gt;
+
+&lt;h2&gt;        Sub-task
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21070&quot;&gt;FLINK-21070&lt;/a&gt;] -         Overloaded aggregate functions cause converter errors
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21486&quot;&gt;FLINK-21486&lt;/a&gt;] -         Add sanity check when switching from Rocks to Heap timers
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Bug
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-12461&quot;&gt;FLINK-12461&lt;/a&gt;] -         Document binary compatibility situation with Scala beyond 2.12.8
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-16443&quot;&gt;FLINK-16443&lt;/a&gt;] -         Fix wrong fix for user-code CheckpointExceptions
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-19771&quot;&gt;FLINK-19771&lt;/a&gt;] -         NullPointerException when accessing null array from postgres in JDBC Connector
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20309&quot;&gt;FLINK-20309&lt;/a&gt;] -         UnalignedCheckpointTestBase.execute is failed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20462&quot;&gt;FLINK-20462&lt;/a&gt;] -         MailboxOperatorTest.testAvoidTaskStarvation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20500&quot;&gt;FLINK-20500&lt;/a&gt;] -         UpsertKafkaTableITCase.testTemporalJoin test failed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20565&quot;&gt;FLINK-20565&lt;/a&gt;] -         Fix typo in EXPLAIN Statements docs.
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20580&quot;&gt;FLINK-20580&lt;/a&gt;] -         Missing null value handling for SerializedValue&amp;#39;s getByteArray() 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20654&quot;&gt;FLINK-20654&lt;/a&gt;] -         Unaligned checkpoint recovery may lead to corrupted data stream
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20663&quot;&gt;FLINK-20663&lt;/a&gt;] -         Managed memory may not be released in time when operators use managed memory frequently
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20675&quot;&gt;FLINK-20675&lt;/a&gt;] -         Asynchronous checkpoint failure would not fail the job anymore
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20680&quot;&gt;FLINK-20680&lt;/a&gt;] -         Fails to call var-arg function with no parameters
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20798&quot;&gt;FLINK-20798&lt;/a&gt;] -         Using PVC as high-availability.storageDir could not work
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20832&quot;&gt;FLINK-20832&lt;/a&gt;] -         Deliver bootstrap resouces ourselves for website and documentation
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20848&quot;&gt;FLINK-20848&lt;/a&gt;] -         Kafka consumer ID is not specified correctly in new KafkaSource
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20913&quot;&gt;FLINK-20913&lt;/a&gt;] -         Improve new HiveConf(jobConf, HiveConf.class)
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20921&quot;&gt;FLINK-20921&lt;/a&gt;] -         Fix Date/Time/Timestamp in Python DataStream
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20933&quot;&gt;FLINK-20933&lt;/a&gt;] -         Config Python Operator Use Managed Memory In Python DataStream
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20942&quot;&gt;FLINK-20942&lt;/a&gt;] -         Digest of FLOAT literals throws UnsupportedOperationException
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20944&quot;&gt;FLINK-20944&lt;/a&gt;] -         Launching in application mode requesting a ClusterIP rest service type results in an Exception
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20947&quot;&gt;FLINK-20947&lt;/a&gt;] -         Idle source doesn&amp;#39;t work when pushing watermark into the source
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20961&quot;&gt;FLINK-20961&lt;/a&gt;] -         Flink throws NullPointerException for tables created from DataStream with no assigned timestamps and watermarks
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20992&quot;&gt;FLINK-20992&lt;/a&gt;] -         Checkpoint cleanup can kill JobMaster
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20998&quot;&gt;FLINK-20998&lt;/a&gt;] -         flink-raw-1.12.jar does not exist
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21009&quot;&gt;FLINK-21009&lt;/a&gt;] -         Can not disable certain options in Elasticsearch 7 connector
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21013&quot;&gt;FLINK-21013&lt;/a&gt;] -         Blink planner does not ingest timestamp into StreamRecord
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21024&quot;&gt;FLINK-21024&lt;/a&gt;] -         Dynamic properties get exposed to job&amp;#39;s main method if user parameters are passed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21028&quot;&gt;FLINK-21028&lt;/a&gt;] -         Streaming application didn&amp;#39;t stop properly 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21030&quot;&gt;FLINK-21030&lt;/a&gt;] -         Broken job restart for job with disjoint graph
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21059&quot;&gt;FLINK-21059&lt;/a&gt;] -         KafkaSourceEnumerator does not honor consumer properties
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21069&quot;&gt;FLINK-21069&lt;/a&gt;] -         Configuration &amp;quot;parallelism.default&amp;quot; doesn&amp;#39;t take effect for TableEnvironment#explainSql
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21071&quot;&gt;FLINK-21071&lt;/a&gt;] -         Snapshot branches running against flink-docker dev-master branch
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21104&quot;&gt;FLINK-21104&lt;/a&gt;] -         UnalignedCheckpointITCase.execute failed with &amp;quot;IllegalStateException&amp;quot;
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21132&quot;&gt;FLINK-21132&lt;/a&gt;] -         BoundedOneInput.endInput is called when taking synchronous savepoint
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21138&quot;&gt;FLINK-21138&lt;/a&gt;] -         KvStateServerHandler is not invoked with user code classloader
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21140&quot;&gt;FLINK-21140&lt;/a&gt;] -         Extract zip file dependencies before adding to PYTHONPATH
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21144&quot;&gt;FLINK-21144&lt;/a&gt;] -         KubernetesResourceManagerDriver#tryResetPodCreationCoolDown causes fatal error
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21155&quot;&gt;FLINK-21155&lt;/a&gt;] -         FileSourceTextLinesITCase.testBoundedTextFileSourceWithTaskManagerFailover does not pass
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21158&quot;&gt;FLINK-21158&lt;/a&gt;] -         wrong jvm metaspace and overhead size show in  taskmanager metric page
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21163&quot;&gt;FLINK-21163&lt;/a&gt;] -         Python dependencies specified via CLI should not override the dependencies specified in configuration
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21169&quot;&gt;FLINK-21169&lt;/a&gt;] -         Kafka flink-connector-base dependency should be scope compile
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21208&quot;&gt;FLINK-21208&lt;/a&gt;] -         pyarrow exception when using window with pandas udaf
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21213&quot;&gt;FLINK-21213&lt;/a&gt;] -         e2e test fail with &amp;#39;As task is already not running, no longer decline checkpoint&amp;#39;
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21215&quot;&gt;FLINK-21215&lt;/a&gt;] -         Checkpoint was declined because one input stream is finished
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21216&quot;&gt;FLINK-21216&lt;/a&gt;] -         StreamPandasConversionTests Fails
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21225&quot;&gt;FLINK-21225&lt;/a&gt;] -         OverConvertRule does not consider distinct
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21226&quot;&gt;FLINK-21226&lt;/a&gt;] -         Reintroduce TableColumn.of for backwards compatibility
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21274&quot;&gt;FLINK-21274&lt;/a&gt;] -         At per-job mode, during the exit of the JobManager process, if ioExecutor exits at the end, the System.exit() method will not be executed.
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21277&quot;&gt;FLINK-21277&lt;/a&gt;] -         SQLClientSchemaRegistryITCase fails to download testcontainers/ryuk:0.3.0
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21312&quot;&gt;FLINK-21312&lt;/a&gt;] -         SavepointITCase.testStopSavepointWithBoundedInputConcurrently is unstable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21323&quot;&gt;FLINK-21323&lt;/a&gt;] -         Stop-with-savepoint is not supported by SourceOperatorStreamTask
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21351&quot;&gt;FLINK-21351&lt;/a&gt;] -         Incremental checkpoint data would be lost once a non-stop savepoint completed
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21361&quot;&gt;FLINK-21361&lt;/a&gt;] -         FlinkRelMdUniqueKeys matches on AbstractCatalogTable instead of CatalogTable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21412&quot;&gt;FLINK-21412&lt;/a&gt;] -         pyflink DataTypes.DECIMAL is not available
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21452&quot;&gt;FLINK-21452&lt;/a&gt;] -         FLIP-27 sources cannot reliably downscale
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21453&quot;&gt;FLINK-21453&lt;/a&gt;] -         BoundedOneInput.endInput is NOT called when doing stop with savepoint WITH drain
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21490&quot;&gt;FLINK-21490&lt;/a&gt;] -         UnalignedCheckpointITCase fails on azure
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21492&quot;&gt;FLINK-21492&lt;/a&gt;] -         ActiveResourceManager swallows exception stack trace
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        New Feature
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20359&quot;&gt;FLINK-20359&lt;/a&gt;] -         Support adding Owner Reference to Job Manager in native kubernetes setup
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Improvement
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-9844&quot;&gt;FLINK-9844&lt;/a&gt;] -         PackagedProgram does not close URLClassLoader
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20417&quot;&gt;FLINK-20417&lt;/a&gt;] -         Handle &amp;quot;Too old resource version&amp;quot; exception in Kubernetes watch more gracefully
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20491&quot;&gt;FLINK-20491&lt;/a&gt;] -         Support Broadcast Operation in BATCH execution mode
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20517&quot;&gt;FLINK-20517&lt;/a&gt;] -         Support mixed keyed/non-keyed operations in BATCH execution mode
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20770&quot;&gt;FLINK-20770&lt;/a&gt;] -         Incorrect description for config option kubernetes.rest-service.exposed.type
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20907&quot;&gt;FLINK-20907&lt;/a&gt;] -         Table API documentation promotes deprecated syntax
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21020&quot;&gt;FLINK-21020&lt;/a&gt;] -         Bump Jackson to 20.10.5[.1] / 2.12.1
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21034&quot;&gt;FLINK-21034&lt;/a&gt;] -         Rework jemalloc switch to use an environment variable
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21035&quot;&gt;FLINK-21035&lt;/a&gt;] -         Deduplicate copy_plugins_if_required calls
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21036&quot;&gt;FLINK-21036&lt;/a&gt;] -         Consider removing automatic configuration fo number of slots from docker
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21037&quot;&gt;FLINK-21037&lt;/a&gt;] -         Deduplicate configuration logic in docker entrypoint
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21042&quot;&gt;FLINK-21042&lt;/a&gt;] -         Fix code example in &amp;quot;Aggregate Functions&amp;quot; section in Table UDF page
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21048&quot;&gt;FLINK-21048&lt;/a&gt;] -         Refactor documentation related to switch memory allocator 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21123&quot;&gt;FLINK-21123&lt;/a&gt;] -         Upgrade Beanutils 1.9.x to 1.9.4
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21164&quot;&gt;FLINK-21164&lt;/a&gt;] -         Jar handlers don&amp;#39;t cleanup temporarily extracted jars
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21210&quot;&gt;FLINK-21210&lt;/a&gt;] -         ApplicationClusterEntryPoints should explicitly close PackagedProgram
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21381&quot;&gt;FLINK-21381&lt;/a&gt;] -         Kubernetes HA documentation does not state required service account and role
+&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;h2&gt;        Task
+&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20529&quot;&gt;FLINK-20529&lt;/a&gt;] -         Publish Dockerfiles for release 1.12.0
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20534&quot;&gt;FLINK-20534&lt;/a&gt;] -         Add Flink 1.12 MigrationVersion
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20536&quot;&gt;FLINK-20536&lt;/a&gt;] -         Update migration tests in master to cover migration from release-1.12
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-20960&quot;&gt;FLINK-20960&lt;/a&gt;] -         Add warning in 1.12 release notes about potential corrupt data stream with unaligned checkpoint 
+&lt;/li&gt;
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21358&quot;&gt;FLINK-21358&lt;/a&gt;] -         Missing snapshot version compatibility for 1.12
+&lt;/li&gt;
+&lt;/ul&gt;
+
+</description>
+<pubDate>Wed, 03 Mar 2021 01:00:00 +0100</pubDate>
+<link>https://flink.apache.org/news/2021/03/03/release-1.12.2.html</link>
+<guid isPermaLink="true">/news/2021/03/03/release-1.12.2.html</guid>
+</item>
+
+<item>
 <title>How to natively deploy Flink on Kubernetes with High-Availability (HA)</title>
 <description>&lt;p&gt;Flink has supported resource management systems like YARN and Mesos since the early days; however, these were not designed for the fast-moving cloud-native architectures that are increasingly gaining popularity these days, or the growing need to support complex, mixed workloads (e.g. batch, streaming, deep learning, web services).
 For these reasons, more and more users are using Kubernetes to automate the deployment, scaling and management of their Flink applications.&lt;/p&gt;
@@ -18465,35 +18692,6 @@ list&lt;/a&gt;.&lt;/p&gt;
 <pubDate>Thu, 01 Jun 2017 14:00:00 +0200</pubDate>
 <link>https://flink.apache.org/news/2017/06/01/release-1.3.0.html</link>
 <guid isPermaLink="true">/news/2017/06/01/release-1.3.0.html</guid>
-</item>
-
-<item>
-<title>Introducing Docker Images for Apache Flink</title>
-<description>&lt;p&gt;For some time, the Apache Flink community has provided scripts to build a Docker image to run Flink. Now, starting with version 1.2.1, Flink will have a &lt;a href=&quot;https://hub.docker.com/r/_/flink/&quot;&gt;Docker image&lt;/a&gt; on the Docker Hub. This image is maintained by the Flink community and curated by the &lt;a href=&quot;https://github.com/docker-library/official-images&quot;&gt;Docker&lt;/a&gt; team to ensure it meets the quality standards for container images of the Docker community.&lt;/p&gt;
-
-&lt;p&gt;A community-maintained way to run Apache Flink on Docker and other container runtimes and orchestrators is part of the ongoing effort by the Flink community to make Flink a first-class citizen of the container world.&lt;/p&gt;
-
-&lt;p&gt;If you want to use the Docker image today you can get the latest version by running:&lt;/p&gt;
-
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code&gt;docker pull flink
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-
-&lt;p&gt;And to run a local Flink cluster with one TaskManager and the Web UI exposed on port 8081, run:&lt;/p&gt;
-
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code&gt;docker run -t -p 8081:8081 flink local
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-
-&lt;p&gt;With this image there are various ways to start a Flink cluster, both locally and in a distributed environment. Take a look at the &lt;a href=&quot;https://hub.docker.com/r/_/flink/&quot;&gt;documentation&lt;/a&gt; that shows how to run a Flink cluster with multiple TaskManagers locally using Docker Compose or across multiple machines using Docker Swarm. You can also use the examples as a reference to create configurations for other platforms like Mesos and Kubernetes.&lt;/p&gt;
-
-&lt;p&gt;While this announcement is an important milestone, it’s just the first step to help users run containerized Flink in production. There are &lt;a href=&quot;https://issues.apache.org/jira/issues/?jql=project%20%3D%20FLINK%20AND%20component%20%3D%20Docker%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20due%20ASC%2C%20priority%20DESC%2C%20created%20ASC&quot;&gt;improvements&lt;/a&gt; to be made in Flink itself and we will continue to improve these Docker images and for the documentation and examples surrounding them.&lt;/p&gt;
-
-&lt;p&gt;This is of course a team effort, so any contribution is welcome. The &lt;a href=&quot;https://github.com/docker-flink&quot;&gt;docker-flink&lt;/a&gt; GitHub organization hosts the source files to &lt;a href=&quot;https://github.com/docker-flink/docker-flink&quot;&gt;generate the images&lt;/a&gt; and the &lt;a href=&quot;https://github.com/docker-flink/docs/tree/master/flink&quot;&gt;documentation&lt;/a&gt; that is presented alongside the images on Docker Hub.&lt;/p&gt;
-
-&lt;p&gt;&lt;em&gt;Disclaimer: The docker images are provided as a community project by individuals on a best-effort basis. They are not official releases by the Apache Flink PMC.&lt;/em&gt;&lt;/p&gt;
-</description>
-<pubDate>Tue, 16 May 2017 11:00:00 +0200</pubDate>
-<link>https://flink.apache.org/news/2017/05/16/official-docker-image.html</link>
-<guid isPermaLink="true">/news/2017/05/16/official-docker-image.html</guid>
 </item>
 
 </channel>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></h2>
+
+      <p>03 Mar 2021
+       Yuan Mei  &amp; Roman Khachatryan </p>
+
+      <p><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.</p>
+
+</p>
+
+      <p><a href="/news/2021/03/03/release-1.12.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></h2>
 
       <p>10 Feb 2021
@@ -325,19 +340,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/12/10/release-1.12.0.html">Apache Flink 1.12.0 Release Announcement</a></h2>
-
-      <p>10 Dec 2020
-       Marta Paes (<a href="https://twitter.com/morsapaes">@morsapaes</a>) &amp; Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>)</p>
-
-      <p>The Apache Flink community is excited to announce the release of Flink 1.12.0! Close to 300 contributors worked on over 1k threads to bring significant improvements to usability as well as new features to Flink users across the whole API stack. We're particularly excited about adding efficient batch execution to the DataStream API, Kubernetes HA as an alternative to ZooKeeper, support for upsert mode in the Kafka SQL connector and the new Python DataStream API! Read on for all major new features and improvements, important changes to be aware of and what to expect moving forward!</p>
-
-      <p><a href="/news/2020/12/10/release-1.12.0.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -369,6 +371,16 @@
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">An Overview of End-to-End Exactly-Once Processing in Apache Flink (with Apache Kafka, too!)</a></h2>
+
+      <p>01 Mar 2018
+       Piotr Nowojski (<a href="https://twitter.com/PiotrNowojski">@PiotrNowojski</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
+
+      <p>Flink 1.4.0 introduced a new feature that makes it possible to build end-to-end exactly-once applications with Flink and data sources and sinks that support transactions.</p>
+
+      <p><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/02/15/release-1.4.1.html">Apache Flink 1.4.1 Released</a></h2>
 
       <p>15 Feb 2018
@@ -334,21 +347,6 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2017/05/16/official-docker-image.html">Introducing Docker Images for Apache Flink</a></h2>
-
-      <p>16 May 2017 by Patrick Lucas (Data Artisans) and Ismaël Mejía (Talend) (<a href="https://twitter.com/">@iemejia</a>)
-      </p>
-
-      <p><p>For some time, the Apache Flink community has provided scripts to build a Docker image to run Flink. Now, starting with version 1.2.1, Flink will have a <a href="https://hub.docker.com/r/_/flink/">Docker image</a> on the Docker Hub. This image is maintained by the Flink community and curated by the <a href="https://github.com/docker-library/official-images">Docker</a> team to ensure it meets the quality standards for container images of the Docker community.</p>
-
-</p>
-
-      <p><a href="/news/2017/05/16/official-docker-image.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -380,6 +378,16 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2017/05/16/official-docker-image.html">Introducing Docker Images for Apache Flink</a></h2>
+
+      <p>16 May 2017 by Patrick Lucas (Data Artisans) and Ismaël Mejía (Talend) (<a href="https://twitter.com/">@iemejia</a>)
+      </p>
+
+      <p><p>For some time, the Apache Flink community has provided scripts to build a Docker image to run Flink. Now, starting with version 1.2.1, Flink will have a <a href="https://hub.docker.com/r/_/flink/">Docker image</a> on the Docker Hub. This image is maintained by the Flink community and curated by the <a href="https://github.com/docker-library/official-images">Docker</a> team to ensure it meets the quality standards for container images of the Docker community.</p>
+
+</p>
+
+      <p><a href="/news/2017/05/16/official-docker-image.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2017/04/26/release-1.2.1.html">Apache Flink 1.2.1 Released</a></h2>
 
       <p>26 Apr 2017
@@ -328,21 +343,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/08/24/ff16-keynotes-panels.html">Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion</a></h2>
-
-      <p>24 Aug 2016
-      </p>
-
-      <p><p>An update for the Flink community: the <a href="http://flink-forward.org/kb_day/day-1/">Flink Forward 2016 schedule</a> is now available online. This year's event will include 2 days of talks from stream processing experts at Google, MapR, Alibaba, Netflix, Cloudera, and more. Following the talks is a full day of hands-on Flink training.</p>
-
-</p>
-
-      <p><a href="/news/2016/08/24/ff16-keynotes-panels.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -374,6 +374,16 @@
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/08/24/ff16-keynotes-panels.html">Flink Forward 2016: Announcing Schedule, Keynotes, and Panel Discussion</a></h2>
+
+      <p>24 Aug 2016
+      </p>
+
+      <p><p>An update for the Flink community: the <a href="http://flink-forward.org/kb_day/day-1/">Flink Forward 2016 schedule</a> is now available online. This year's event will include 2 days of talks from stream processing experts at Google, MapR, Alibaba, Netflix, Cloudera, and more. Following the talks is a full day of hands-on Flink training.</p>
+
+</p>
+
+      <p><a href="/news/2016/08/24/ff16-keynotes-panels.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2016/08/11/release-1.1.1.html">Flink 1.1.1 Released</a></h2>
 
       <p>11 Aug 2016
@@ -332,21 +347,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2016/02/11/release-0.10.2.html">Flink 0.10.2 Released</a></h2>
-
-      <p>11 Feb 2016
-      </p>
-
-      <p><p>Today, the Flink community released Flink version <strong>0.10.2</strong>, the second bugfix release of the 0.10 series.</p>
-
-</p>
-
-      <p><a href="/news/2016/02/11/release-0.10.2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -378,6 +378,16 @@
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2016/02/11/release-0.10.2.html">Flink 0.10.2 Released</a></h2>
+
+      <p>11 Feb 2016
+      </p>
+
+      <p><p>Today, the Flink community released Flink version <strong>0.10.2</strong>, the second bugfix release of the 0.10 series.</p>
+
+</p>
+
+      <p><a href="/news/2016/02/11/release-0.10.2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/12/18/a-year-in-review.html">Flink 2015: A year in review, and a lookout to 2016</a></h2>
 
       <p>18 Dec 2015 by Robert Metzger (<a href="https://twitter.com/">@rmetzger_</a>)
@@ -336,21 +351,6 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Announcing Apache Flink 0.9.0</a></h2>
-
-      <p>24 Jun 2015
-      </p>
-
-      <p><p>The Apache Flink community is pleased to announce the availability of the 0.9.0 release. The release is the result of many months of hard work within the Flink community. It contains many new features and improvements which were previewed in the 0.9.0-milestone1 release and have been polished since then. This is the largest Flink release so far.</p>
-
-</p>
-
-      <p><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -382,6 +382,16 @@ vertex-centric or gather-sum-apply to Flink dataflows.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Announcing Apache Flink 0.9.0</a></h2>
+
+      <p>24 Jun 2015
+      </p>
+
+      <p><p>The Apache Flink community is pleased to announce the availability of the 0.9.0 release. The release is the result of many months of hard work within the Flink community. It contains many new features and improvements which were previewed in the 0.9.0-milestone1 release and have been polished since then. This is the largest Flink release so far.</p>
+
+</p>
+
+      <p><a href="/news/2015/06/24/announcing-apache-flink-0.9.0-release.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2015/05/14/Community-update-April.html">April 2015 in the Flink community</a></h2>
 
       <p>14 May 2015 by Kostas Tzoumas (<a href="https://twitter.com/">@kostas_tzoumas</a>)
@@ -342,21 +357,6 @@ and offers a new API including definition of flexible windows.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2015/01/06/december-in-flink.html">December 2014 in the Flink community</a></h2>
-
-      <p>06 Jan 2015
-      </p>
-
-      <p><p>This is the first blog post of a “newsletter” like series where we give a summary of the monthly activity in the Flink community. As the Flink project grows, this can serve as a “tl;dr” for people that are not following the Flink dev and user mailing lists, or those that are simply overwhelmed by the traffic.</p>
-
-</p>
-
-      <p><a href="/news/2015/01/06/december-in-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -388,6 +388,16 @@ and offers a new API including definition of flexible windows.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2015/01/06/december-in-flink.html">December 2014 in the Flink community</a></h2>
+
+      <p>06 Jan 2015
+      </p>
+
+      <p><p>This is the first blog post of a “newsletter” like series where we give a summary of the monthly activity in the Flink community. As the Flink project grows, this can serve as a “tl;dr” for people that are not following the Flink dev and user mailing lists, or those that are simply overwhelmed by the traffic.</p>
+
+</p>
+
+      <p><a href="/news/2015/01/06/december-in-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2014/11/18/hadoop-compatibility.html">Hadoop Compatibility in Flink</a></h2>
 
       <p>18 Nov 2014 by Fabian Hüske (<a href="https://twitter.com/">@fhueske</a>)
@@ -309,6 +324,16 @@ academic and open source project that Flink originates from.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/12/10/release-1.12.0.html">Apache Flink 1.12.0 Release Announcement</a></h2>
+
+      <p>10 Dec 2020
+       Marta Paes (<a href="https://twitter.com/morsapaes">@morsapaes</a>) &amp; Aljoscha Krettek (<a href="https://twitter.com/aljoscha">@aljoscha</a>)</p>
+
+      <p>The Apache Flink community is excited to announce the release of Flink 1.12.0! Close to 300 contributors worked on over 1k threads to bring significant improvements to usability as well as new features to Flink users across the whole API stack. We're particularly excited about adding efficient batch execution to the DataStream API, Kubernetes HA as an alternative to ZooKeeper, support for upsert mode in the Kafka SQL connector and the new Python DataStream API! Read on for all major new features and improvements, important changes to be aware of and what to expect moving forward!</p>
+
+      <p><a href="/news/2020/12/10/release-1.12.0.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/11/11/release-statefun-2.2.1.html">Stateful Functions 2.2.1 Release Announcement</a></h2>
 
       <p>11 Nov 2020
@@ -329,21 +342,6 @@ as well as increased observability for operational purposes.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/2020/08/19/statefun.html">Monitoring and Controlling Networks of IoT Devices with Flink Stateful Functions</a></h2>
-
-      <p>19 Aug 2020
-       Igal Shilman (<a href="https://twitter.com/IgalShilman">@IgalShilman</a>)</p>
-
-      <p><p>In this blog post, we’ll take a look at a class of use cases that is a natural fit for <a href="https://flink.apache.org/stateful-functions.html">Flink Stateful Functions</a>: monitoring and controlling networks of connected devices (often called the “Internet of Things” (IoT)).</p>
-
-</p>
-
-      <p><a href="/2020/08/19/statefun.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -375,6 +373,16 @@ as well as increased observability for operational purposes.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/2020/08/19/statefun.html">Monitoring and Controlling Networks of IoT Devices with Flink Stateful Functions</a></h2>
+
+      <p>19 Aug 2020
+       Igal Shilman (<a href="https://twitter.com/IgalShilman">@IgalShilman</a>)</p>
+
+      <p><p>In this blog post, we’ll take a look at a class of use cases that is a natural fit for <a href="https://flink.apache.org/stateful-functions.html">Flink Stateful Functions</a>: monitoring and controlling networks of connected devices (often called the “Internet of Things” (IoT)).</p>
+
+</p>
+
+      <p><a href="/2020/08/19/statefun.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/08/06/external-resource.html">Accelerating your workload with GPU and other external resources</a></h2>
 
       <p>06 Aug 2020
@@ -328,22 +343,6 @@ illustrate this trend.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/ecosystem/2020/06/23/flink-on-zeppelin-part2.html">Flink on Zeppelin Notebooks for Interactive Data Analysis - Part 2</a></h2>
-
-      <p>23 Jun 2020
-       Jeff Zhang (<a href="https://twitter.com/zjffdu">@zjffdu</a>)</p>
-
-      <p><p>In a previous post, we introduced the basics of Flink on Zeppelin and how to do Streaming ETL. In this second part of the “Flink on Zeppelin” series of posts, I will share how to 
-perform streaming data visualization via Flink on Zeppelin and how to use Apache Flink UDFs in Zeppelin.</p>
-
-</p>
-
-      <p><a href="/ecosystem/2020/06/23/flink-on-zeppelin-part2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -375,6 +374,16 @@ perform streaming data visualization via Flink on Zeppelin and how to use Apache
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -201,6 +201,22 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/ecosystem/2020/06/23/flink-on-zeppelin-part2.html">Flink on Zeppelin Notebooks for Interactive Data Analysis - Part 2</a></h2>
+
+      <p>23 Jun 2020
+       Jeff Zhang (<a href="https://twitter.com/zjffdu">@zjffdu</a>)</p>
+
+      <p><p>In a previous post, we introduced the basics of Flink on Zeppelin and how to do Streaming ETL. In this second part of the “Flink on Zeppelin” series of posts, I will share how to 
+perform streaming data visualization via Flink on Zeppelin and how to use Apache Flink UDFs in Zeppelin.</p>
+
+</p>
+
+      <p><a href="/ecosystem/2020/06/23/flink-on-zeppelin-part2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/06/15/flink-on-zeppelin-part1.html">Flink on Zeppelin Notebooks for Interactive Data Analysis - Part 1</a></h2>
 
       <p>15 Jun 2020
@@ -327,19 +343,6 @@ and provide a tutorial for running Streaming ETL with Flink on Zeppelin.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/2020/04/09/pyflink-udf-support-flink.html">PyFlink: Introducing Python Support for UDFs in Flink's Table API</a></h2>
-
-      <p>09 Apr 2020
-       Jincheng Sun (<a href="https://twitter.com/sunjincheng121">@sunjincheng121</a>) &amp; Markos Sfikas (<a href="https://twitter.com/MarkSfik">@MarkSfik</a>)</p>
-
-      <p>Flink 1.10 extends its support for Python by adding Python UDFs in PyFlink. This post explains how UDFs work in PyFlink and gives some practical examples of how to use UDFs in PyFlink.</p>
-
-      <p><a href="/2020/04/09/pyflink-udf-support-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -371,6 +374,16 @@ and provide a tutorial for running Streaming ETL with Flink on Zeppelin.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/2020/04/09/pyflink-udf-support-flink.html">PyFlink: Introducing Python Support for UDFs in Flink's Table API</a></h2>
+
+      <p>09 Apr 2020
+       Jincheng Sun (<a href="https://twitter.com/sunjincheng121">@sunjincheng121</a>) &amp; Markos Sfikas (<a href="https://twitter.com/MarkSfik">@MarkSfik</a>)</p>
+
+      <p>Flink 1.10 extends its support for Python by adding Python UDFs in PyFlink. This post explains how UDFs work in PyFlink and gives some practical examples of how to use UDFs in PyFlink.</p>
+
+      <p><a href="/2020/04/09/pyflink-udf-support-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/04/07/release-statefun-2.0.0.html">Stateful Functions 2.0 - An Event-driven Database on Apache Flink</a></h2>
 
       <p>07 Apr 2020
@@ -326,19 +339,6 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></h2>
-
-      <p>29 Jan 2020
-       Seth Wiesman (<a href="https://twitter.com/sjwiesman">@sjwiesman</a>)</p>
-
-      <p>This post discusses the efforts of the Flink community as they relate to state management in Apache Flink. We showcase some practical examples of how the different features and APIs can be utilized and cover some future ideas for new and improved ways of managing state in Apache Flink.</p>
-
-      <p><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -370,6 +370,16 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">State Unlocked: Interacting with State in Apache Flink</a></h2>
+
+      <p>29 Jan 2020
+       Seth Wiesman (<a href="https://twitter.com/sjwiesman">@sjwiesman</a>)</p>
+
+      <p>This post discusses the efforts of the Flink community as they relate to state management in Apache Flink. We showcase some practical examples of how the different features and APIs can be utilized and cover some future ideas for new and improved ways of managing state in Apache Flink.</p>
+
+      <p><a href="/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2020/01/15/demo-fraud-detection.html">Advanced Flink Application Patterns Vol.1: Case Study of a Fraud Detection System</a></h2>
 
       <p>15 Jan 2020
@@ -326,19 +339,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/2019/07/23/flink-network-stack-2.html">Flink Network Stack Vol. 2: Monitoring, Metrics, and that Backpressure Thing</a></h2>
-
-      <p>23 Jul 2019
-       Nico Kruber  &amp; Piotr Nowojski </p>
-
-      <p>In a previous blog post, we presented how Flink’s network stack works from the high-level abstractions to the low-level details. This second  post discusses monitoring network-related metrics to identify backpressure or bottlenecks in throughput and latency.</p>
-
-      <p><a href="/2019/07/23/flink-network-stack-2.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -370,6 +370,16 @@
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/2019/07/23/flink-network-stack-2.html">Flink Network Stack Vol. 2: Monitoring, Metrics, and that Backpressure Thing</a></h2>
+
+      <p>23 Jul 2019
+       Nico Kruber  &amp; Piotr Nowojski </p>
+
+      <p>In a previous blog post, we presented how Flink’s network stack works from the high-level abstractions to the low-level details. This second  post discusses monitoring network-related metrics to identify backpressure or bottlenecks in throughput and latency.</p>
+
+      <p><a href="/2019/07/23/flink-network-stack-2.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/07/02/release-1.8.1.html">Apache Flink 1.8.1 Released</a></h2>
 
       <p>02 Jul 2019
@@ -327,19 +340,6 @@ for more details.</p>
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2019/03/06/ffsf-preview.html">What to expect from Flink Forward San Francisco 2019</a></h2>
-
-      <p>06 Mar 2019
-       Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>)</p>
-
-      <p>The third annual Flink Forward conference in San Francisco is just a few weeks away. Let's see what Flink Forward SF 2019 has in store for the Apache Flink and stream processing communities. This post covers some of its highlights!</p>
-
-      <p><a href="/news/2019/03/06/ffsf-preview.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -371,6 +371,16 @@ for more details.</p>
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -201,6 +201,19 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2019/03/06/ffsf-preview.html">What to expect from Flink Forward San Francisco 2019</a></h2>
+
+      <p>06 Mar 2019
+       Fabian Hueske (<a href="https://twitter.com/fhueske">@fhueske</a>)</p>
+
+      <p>The third annual Flink Forward conference in San Francisco is just a few weeks away. Let's see what Flink Forward SF 2019 has in store for the Apache Flink and stream processing communities. This post covers some of its highlights!</p>
+
+      <p><a href="/news/2019/03/06/ffsf-preview.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2019/02/25/monitoring-best-practices.html">Monitoring Apache Flink Applications 101</a></h2>
 
       <p>25 Feb 2019
@@ -333,21 +346,6 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.5.5.html">Apache Flink 1.5.5 Released</a></h2>
-
-      <p>29 Oct 2018
-      </p>
-
-      <p><p>The Apache Flink community released the fifth bugfix version of the Apache Flink 1.5 series.</p>
-
-</p>
-
-      <p><a href="/news/2018/10/29/release-1.5.5.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -379,6 +377,16 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -201,6 +201,21 @@
     <!-- Blog posts -->
     
     <article>
+      <h2 class="blog-title"><a href="/news/2018/10/29/release-1.5.5.html">Apache Flink 1.5.5 Released</a></h2>
+
+      <p>29 Oct 2018
+      </p>
+
+      <p><p>The Apache Flink community released the fifth bugfix version of the Apache Flink 1.5 series.</p>
+
+</p>
+
+      <p><a href="/news/2018/10/29/release-1.5.5.html">Continue reading &raquo;</a></p>
+    </article>
+
+    <hr>
+    
+    <article>
       <h2 class="blog-title"><a href="/news/2018/09/20/release-1.6.1.html">Apache Flink 1.6.1 Released</a></h2>
 
       <p>20 Sep 2018
@@ -335,19 +350,6 @@
 
     <hr>
     
-    <article>
-      <h2 class="blog-title"><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">An Overview of End-to-End Exactly-Once Processing in Apache Flink (with Apache Kafka, too!)</a></h2>
-
-      <p>01 Mar 2018
-       Piotr Nowojski (<a href="https://twitter.com/PiotrNowojski">@PiotrNowojski</a>) &amp; Mike Winters (<a href="https://twitter.com/wints">@wints</a>)</p>
-
-      <p>Flink 1.4.0 introduced a new feature that makes it possible to build end-to-end exactly-once applications with Flink and data sources and sinks that support transactions.</p>
-
-      <p><a href="/features/2018/03/01/end-to-end-exactly-once-apache-flink.html">Continue reading &raquo;</a></p>
-    </article>
-
-    <hr>
-    
 
     <!-- Pagination links -->
     
@@ -379,6 +381,16 @@
     <h2>2021</h2>
 
     <ul id="markdown-toc">
+      
+      <li><a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></li>
+
+      
+        
+      
+    
+      
+      
+
       
       <li><a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -212,7 +212,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-1121" id="markdown-toc-apache-flink-1121">Apache Flink 1.12.1</a></li>
+  <li><a href="#apache-flink-1122" id="markdown-toc-apache-flink-1122">Apache Flink 1.12.2</a></li>
   <li><a href="#apache-flink-1113" id="markdown-toc-apache-flink-1113">Apache Flink 1.11.3</a></li>
   <li><a href="#apache-flink-1103" id="markdown-toc-apache-flink-1103">Apache Flink 1.10.3</a></li>
   <li><a href="#apache-flink-stateful-functions-222" id="markdown-toc-apache-flink-stateful-functions-222">Apache Flink Stateful Functions 2.2.2</a></li>
@@ -234,31 +234,31 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.12.1 is our latest stable release.</p>
+<p>Apache Flink® 1.12.2 is our latest stable release.</p>
 
 <p>If you plan to use Apache Flink together with Apache Hadoop (run Flink
 on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
 file system connector), please check out the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/ops/deployment/hadoop.html">Hadoop Integration</a> documentation.</p>
 
-<h2 id="apache-flink-1121">Apache Flink 1.12.1</h2>
+<h2 id="apache-flink-1122">Apache Flink 1.12.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz" class="ga-track" id="1121-download_211">Apache Flink 1.12.1 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz" class="ga-track" id="1122-download_211">Apache Flink 1.12.2 for Scala 2.11</a> (<a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz" class="ga-track" id="1121-download_212">Apache Flink 1.12.1 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz" class="ga-track" id="1122-download_212">Apache Flink 1.12.2 for Scala 2.12</a> (<a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-src.tgz" class="ga-track" id="1121-download-source">Apache Flink 1.12.1 Source Release</a>
-(<a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-src.tgz" class="ga-track" id="1122-download-source">Apache Flink 1.12.2 Source Release</a>
+(<a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="optional-components">Optional components</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar" class="ga-track" id="1121-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar" class="ga-track" id="1122-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="release-notes">Release Notes</h4>
@@ -389,17 +389,17 @@ main Flink release:</p>
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h3 id="apache-flink-stateful-functions">Apache Flink Stateful Functions</h3>
@@ -433,6 +433,17 @@ The <code>statefun-flink-harness</code> dependency includes a local execution en
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.12.2 - 2021-03-03 
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -573,6 +573,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.</p>
+
+</dd>
+      
         <dt> <a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></dt>
         <dd>Kubernetes provides built-in functionalities that Flink can leverage for JobManager failover. In Flink 1.12 (FLIP-144), the community implemented a Kubernetes High Availability (HA) service as an alternative to ZooKeeper for highly available production setups. In this blogpost, we will have a close look at how to deploy Flink applications natively on Kubernetes cluster with HA.</dd>
       
@@ -588,9 +593,6 @@
       
         <dt> <a href="/2021/01/18/rocksdb.html">Using RocksDB State Backend in Apache Flink: When and How</a></dt>
         <dd>This blog post will guide you through the benefits of using RocksDB to manage your application’s state, explain when and how to use it and also clear up a few common misconceptions.</dd>
-      
-        <dt> <a href="/news/2021/01/11/batch-fine-grained-fault-tolerance.html">Exploring fine-grained recovery of bounded data sets on Flink</a></dt>
-        <dd>Apache Flink 1.9 introduced fine-grained recovery through FLIP-1. The Flink APIs that are made for bounded workloads benefit from this change by individually recovering failed operators, re-using results from the previous processing step. This blog post gives an overview over these changes and evaluates their effectiveness.</dd>
     
   </dl>
 

--- a/content/q/gradle-quickstart.sh
+++ b/content/q/gradle-quickstart.sh
@@ -41,7 +41,7 @@ function mkPackage() {
 defaultProjectName="quickstart"
 defaultOrganization="org.myorg.quickstart"
 defaultVersion="0.1-SNAPSHOT"
-defaultFlinkVersion="${1:-1.12.1}
+defaultFlinkVersion="${1:-1.12.2}"
 defaultScalaBinaryVersion="${2:-2.11}"
 
 echo "This script creates a Flink project using Java and Gradle."

--- a/content/q/quickstart-scala.sh
+++ b/content/q/quickstart-scala.sh
@@ -24,7 +24,7 @@ PACKAGE=quickstart
 mvn archetype:generate								\
   -DarchetypeGroupId=org.apache.flink				\
   -DarchetypeArtifactId=flink-quickstart-scala		\
-  -DarchetypeVersion=${1:-1.12.1}							\
+  -DarchetypeVersion=${1:-1.12.2}							\
   -DgroupId=org.myorg.quickstart					\
   -DartifactId=$PACKAGE								\
   -Dversion=0.1										\

--- a/content/q/quickstart.sh
+++ b/content/q/quickstart.sh
@@ -24,7 +24,7 @@ PACKAGE=quickstart
 mvn archetype:generate								\
   -DarchetypeGroupId=org.apache.flink				\
   -DarchetypeArtifactId=flink-quickstart-java		\
-  -DarchetypeVersion=${1:-1.12.1}							\
+  -DarchetypeVersion=${1:-1.12.2}							\
   -DgroupId=org.myorg.quickstart					\
   -DartifactId=$PACKAGE								\
   -Dversion=0.1										\

--- a/content/q/sbt-quickstart.sh
+++ b/content/q/sbt-quickstart.sh
@@ -42,7 +42,7 @@ defaultProjectName="Flink Project"
 defaultOrganization="org.example"
 defaultVersion="0.1-SNAPSHOT"
 defaultScalaVersion="2.12.7"
-defaultFlinkVersion="1.12.1"
+defaultFlinkVersion="1.12.2"
 
 echo "This script creates a Flink project using Scala and SBT."
 

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -210,7 +210,7 @@ $( document ).ready(function() {
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#apache-flink-1121" id="markdown-toc-apache-flink-1121">Apache Flink 1.12.1</a></li>
+  <li><a href="#apache-flink-1122" id="markdown-toc-apache-flink-1122">Apache Flink 1.12.2</a></li>
   <li><a href="#apache-flink-1113" id="markdown-toc-apache-flink-1113">Apache Flink 1.11.3</a></li>
   <li><a href="#apache-flink-1103" id="markdown-toc-apache-flink-1103">Apache Flink 1.10.3</a></li>
   <li><a href="#section-6" id="markdown-toc-section-6">额外组件</a></li>
@@ -226,32 +226,32 @@ $( document ).ready(function() {
 
 </div>
 
-<p>Apache Flink® 1.12.1 是我们最新的稳定版本。</p>
+<p>Apache Flink® 1.12.2 是我们最新的稳定版本。</p>
 
 <p>如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
 Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/ops/deployment/hadoop.html">Hadoop 集成</a>文档。</p>
 
-<h2 id="apache-flink-1121">Apache Flink 1.12.1</h2>
+<h2 id="apache-flink-1122">Apache Flink 1.12.2</h2>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz" class="ga-track" id="1121-download_211">Apache Flink 1.12.1 for Scala 2.11</a> (<a href="
- https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.11.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz" class="ga-track" id="1122-download_211">Apache Flink 1.12.2 for Scala 2.11</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.11.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz" class="ga-track" id="1121-download_212">Apache Flink 1.12.1 for Scala 2.12</a> (<a href="
- https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-bin-scala_2.12.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz" class="ga-track" id="1122-download_212">Apache Flink 1.12.2 for Scala 2.12</a> (<a href="
+ https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-bin-scala_2.12.tgz.sha512">sha512</a>)
 </p>
 
 <p>
-<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.1/flink-1.12.1-src.tgz" class="ga-track" id="1121-download-source">Apache Flink 1.12.1 Source Release</a>
- (<a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.1/flink-1.12.1-src.tgz.sha512">sha512</a>)
+<a href="https://www.apache.org/dyn/closer.lua/flink/flink-1.12.2/flink-1.12.2-src.tgz" class="ga-track" id="1122-download-source">Apache Flink 1.12.2 Source Release</a>
+ (<a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/flink/flink-1.12.2/flink-1.12.2-src.tgz.sha512">sha512</a>)
 </p>
 
 <h4 id="section">可选组件</h4>
 
 <p>
-<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar" class="ga-track" id="1121-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.1/flink-avro-1.12.1.jar.sha1">sha1</a>)
+<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar" class="ga-track" id="1122-sql-format-avro">Avro SQL Format</a> (<a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.asc">asc</a>, <a href="https://repo.maven.apache.org/maven2/org/apache/flink/flink-avro/1.12.2/flink-avro-1.12.2.jar.sha1">sha1</a>)
 </p>
 
 <h4 id="section-1">发布说明</h4>
@@ -367,17 +367,17 @@ flink-docs-release-1.10/release-notes/flink-1.10.html">Flink 1.10 的发布说�
 <div class="highlight"><pre><code class="language-xml"><span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-java<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-streaming-java_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span>
 <span class="nt">&lt;dependency&gt;</span>
   <span class="nt">&lt;groupId&gt;</span>org.apache.flink<span class="nt">&lt;/groupId&gt;</span>
   <span class="nt">&lt;artifactId&gt;</span>flink-clients_2.11<span class="nt">&lt;/artifactId&gt;</span>
-  <span class="nt">&lt;version&gt;</span>1.12.1<span class="nt">&lt;/version&gt;</span>
+  <span class="nt">&lt;version&gt;</span>1.12.2<span class="nt">&lt;/version&gt;</span>
 <span class="nt">&lt;/dependency&gt;</span></code></pre></div>
 
 <h2 id="section-8">旧版本的更新策略</h2>
@@ -391,6 +391,17 @@ flink-docs-release-1.10/release-notes/flink-1.10.html">Flink 1.10 的发布说�
 <h3 id="flink">Flink</h3>
 
 <ul>
+
+<li>
+
+Flink 1.12.2 - 2021-03-03 
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>, 
+<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
+
+</li>
 
 <li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -570,6 +570,11 @@
 
   <dl>
       
+        <dt> <a href="/news/2021/03/03/release-1.12.2.html">Apache Flink 1.12.2 Released</a></dt>
+        <dd><p>The Apache Flink community released the next bugfix version of the Apache Flink 1.12 series.</p>
+
+</dd>
+      
         <dt> <a href="/2021/02/10/native-k8s-with-ha.html">How to natively deploy Flink on Kubernetes with High-Availability (HA)</a></dt>
         <dd>Kubernetes provides built-in functionalities that Flink can leverage for JobManager failover. In Flink 1.12 (FLIP-144), the community implemented a Kubernetes High Availability (HA) service as an alternative to ZooKeeper for highly available production setups. In this blogpost, we will have a close look at how to deploy Flink applications natively on Kubernetes cluster with HA.</dd>
       
@@ -585,9 +590,6 @@
       
         <dt> <a href="/2021/01/18/rocksdb.html">Using RocksDB State Backend in Apache Flink: When and How</a></dt>
         <dd>This blog post will guide you through the benefits of using RocksDB to manage your application’s state, explain when and how to use it and also clear up a few common misconceptions.</dd>
-      
-        <dt> <a href="/news/2021/01/11/batch-fine-grained-fault-tolerance.html">Exploring fine-grained recovery of bounded data sets on Flink</a></dt>
-        <dd>Apache Flink 1.9 introduced fine-grained recovery through FLIP-1. The Flink APIs that are made for bounded workloads benefit from this change by individually recovering failed operators, re-using results from the previous processing step. This blog post gives an overview over these changes and evaluates their effectiveness.</dd>
     
   </dl>
 

--- a/q/gradle-quickstart.sh
+++ b/q/gradle-quickstart.sh
@@ -41,7 +41,7 @@ function mkPackage() {
 defaultProjectName="quickstart"
 defaultOrganization="org.myorg.quickstart"
 defaultVersion="0.1-SNAPSHOT"
-defaultFlinkVersion="${1:-1.12.1}"
+defaultFlinkVersion="${1:-1.12.2}"
 defaultScalaBinaryVersion="${2:-2.11}"
 
 echo "This script creates a Flink project using Java and Gradle."

--- a/q/quickstart-scala.sh
+++ b/q/quickstart-scala.sh
@@ -24,7 +24,7 @@ PACKAGE=quickstart
 mvn archetype:generate								\
   -DarchetypeGroupId=org.apache.flink				\
   -DarchetypeArtifactId=flink-quickstart-scala		\
-  -DarchetypeVersion=${1:-1.12.1}							\
+  -DarchetypeVersion=${1:-1.12.2}							\
   -DgroupId=org.myorg.quickstart					\
   -DartifactId=$PACKAGE								\
   -Dversion=0.1										\

--- a/q/quickstart.sh
+++ b/q/quickstart.sh
@@ -24,7 +24,7 @@ PACKAGE=quickstart
 mvn archetype:generate								\
   -DarchetypeGroupId=org.apache.flink				\
   -DarchetypeArtifactId=flink-quickstart-java		\
-  -DarchetypeVersion=${1:-1.12.1}							\
+  -DarchetypeVersion=${1:-1.12.2}							\
   -DgroupId=org.myorg.quickstart					\
   -DartifactId=$PACKAGE								\
   -Dversion=0.1										\

--- a/q/sbt-quickstart.sh
+++ b/q/sbt-quickstart.sh
@@ -42,7 +42,7 @@ defaultProjectName="Flink Project"
 defaultOrganization="org.example"
 defaultVersion="0.1-SNAPSHOT"
 defaultScalaVersion="2.12.7"
-defaultFlinkVersion="1.12.1"
+defaultFlinkVersion="1.12.2"
 
 echo "This script creates a Flink project using Scala and SBT."
 


### PR DESCRIPTION
The PR adds 1.12.2 release by restoring a commit erroneously added the `asf-site` branch.

The site has not been rebuilt (changes from `bash docker-build.sh` are not included in the commit).

cc: @curcur @rmetzger @zentol 