### PR TITLE
Missing ending doublequote for defaultFlinkVersion.

### DIFF
--- a/q/gradle-quickstart.sh
+++ b/q/gradle-quickstart.sh
@@ -41,7 +41,7 @@ function mkPackage() {
 defaultProjectName="quickstart"
 defaultOrganization="org.myorg.quickstart"
 defaultVersion="0.1-SNAPSHOT"
-defaultFlinkVersion="${1:-1.12.1}
+defaultFlinkVersion="${1:-1.12.1}"
 defaultScalaBinaryVersion="${2:-2.11}"
 
 echo "This script creates a Flink project using Java and Gradle."


### PR DESCRIPTION
The "Run the quickstart script" gradle quickstart example fails because of a missing ending quotation mark.