### PR TITLE
[FLINK-21723] Remove link to Hadoop integration from downloads page

### DIFF
--- a/content/downloads.html
+++ b/content/downloads.html
@@ -236,10 +236,6 @@ $( document ).ready(function() {
 
 <p>Apache Flink® 1.12.2 is our latest stable release.</p>
 
-<p>If you plan to use Apache Flink together with Apache Hadoop (run Flink
-on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
-file system connector), please check out the <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/ops/deployment/hadoop.html">Hadoop Integration</a> documentation.</p>
-
 <h2 id="apache-flink-1122">Apache Flink 1.12.2</h2>
 
 <p>
@@ -436,671 +432,671 @@ The <code>statefun-flink-harness</code> dependency includes a local execution en
 
 <li>
 
-Flink 1.12.2 - 2021-03-03 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.2 - 2021-03-03
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.12.1 - 2021-01-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.1 - 2021-01-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.12.0 - 2020-12-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.0 - 2020-12-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.3 - 2020-12-18 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.3/flink-1.11.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.3 - 2020-12-18
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.3/flink-1.11.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.2 - 2020-09-17 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.2 - 2020-09-17
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.1 - 2020-07-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.1/flink-1.11.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.1 - 2020-07-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.1/flink-1.11.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.0 - 2020-07-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.0/flink-1.11.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.0 - 2020-07-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.0/flink-1.11.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.3 - 2021-01-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.3/flink-1.10.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.3 - 2021-01-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.3/flink-1.10.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.2 - 2020-08-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.2 - 2020-08-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.1 - 2020-05-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.1 - 2020-05-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.0 - 2020-02-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.0 - 2020-02-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.3 - 2020-04-24 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.3 - 2020-04-24
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.2 - 2020-01-30 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.2 - 2020-01-30
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.1 - 2019-10-18 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.1 - 2019-10-18
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.0 - 2019-08-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.0/flink-1.9.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.0 - 2019-08-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.0/flink-1.9.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.3 - 2019-12-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.3 - 2019-12-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.2 - 2019-09-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.2 - 2019-09-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.1 - 2019-07-02 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.1 - 2019-07-02
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.0 - 2019-04-09 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.0 - 2019-04-09
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.2 - 2019-02-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.2 - 2019-02-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.1 - 2018-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.1 - 2018-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.0 - 2018-11-30 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.0 - 2018-11-30
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.4 - 2019-02-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.4 - 2019-02-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.3 - 2018-12-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.3 - 2018-12-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.2 - 2018-10-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.2 - 2018-10-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.1 - 2018-09-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.1 - 2018-09-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.0 - 2018-08-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.0 - 2018-08-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.6 - 2018-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.6">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.6 - 2018-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.6">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.5 - 2018-10-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.5">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.5 - 2018-10-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.5">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.4 - 2018-09-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.4/flink-1.5.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.4 - 2018-09-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.4/flink-1.5.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.3 - 2018-08-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.3 - 2018-08-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.2 - 2018-07-31 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.2/flink-1.5.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.2 - 2018-07-31
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.2/flink-1.5.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.1 - 2018-07-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.1/flink-1.5.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.1 - 2018-07-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.1/flink-1.5.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.0 - 2018-05-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.0/flink-1.5.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.0 - 2018-05-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.0/flink-1.5.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.2 - 2018-03-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.2/flink-1.4.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.2 - 2018-03-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.2/flink-1.4.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.1 - 2018-02-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.1/flink-1.4.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.1 - 2018-02-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.1/flink-1.4.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.0 - 2017-11-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.0/flink-1.4.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.0 - 2017-11-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.0/flink-1.4.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.3 - 2018-03-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.3/flink-1.3.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.3 - 2018-03-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.3/flink-1.3.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.2 - 2017-08-05 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.2/flink-1.3.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.2 - 2017-08-05
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.2/flink-1.3.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.1 - 2017-06-23 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.1/flink-1.3.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.1 - 2017-06-23
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.1/flink-1.3.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.0 - 2017-06-01 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.0/flink-1.3.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.0 - 2017-06-01
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.0/flink-1.3.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.2.1 - 2017-04-26 
-(<a href="https://archive.apache.org/dist/flink/flink-1.2.1/flink-1.2.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.2.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>, 
+Flink 1.2.1 - 2017-04-26
+(<a href="https://archive.apache.org/dist/flink/flink-1.2.1/flink-1.2.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.2.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.2.0 - 2017-02-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.2.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>, 
+Flink 1.2.0 - 2017-02-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.2.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.5 - 2017-03-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.5/flink-1.1.5-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.5">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.5 - 2017-03-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.5/flink-1.1.5-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.5">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.4 - 2016-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.4/flink-1.1.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.4 - 2016-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.4/flink-1.1.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.3 - 2016-10-13 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.3/flink-1.1.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.3 - 2016-10-13
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.3/flink-1.1.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.2 - 2016-09-05 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.2 - 2016-09-05
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.1 - 2016-08-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.1/flink-1.1.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.1 - 2016-08-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.1/flink-1.1.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.0 - 2016-08-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.0/flink-1.1.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.0 - 2016-08-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.0/flink-1.1.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.3 - 2016-05-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.3 - 2016-05-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.2 - 2016-04-23 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.2 - 2016-04-23
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.1 - 2016-04-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.1 - 2016-04-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.0 - 2016-03-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.0 - 2016-03-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.2 - 2016-02-11 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-src.tgz">Source</a>, 
+Flink 0.10.2 - 2016-02-11
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.2">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.1 - 2015-11-27 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-src.tgz">Source</a>, 
+Flink 0.10.1 - 2015-11-27
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.0 - 2015-11-16 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-src.tgz">Source</a>, 
+Flink 0.10.0 - 2015-11-16
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.1 - 2015-09-01 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.1/flink-0.9.1-src.tgz">Source</a>, 
+Flink 0.9.1 - 2015-09-01
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.1/flink-0.9.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.0 - 2015-06-24 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-src.tgz">Source</a>, 
+Flink 0.9.0 - 2015-06-24
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.0-milestone-1 - 2015-04-13 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1/flink-0.9.0-milestone-1-src.tgz">Source</a>, 
+Flink 0.9.0-milestone-1 - 2015-04-13
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1/flink-0.9.0-milestone-1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.8.1 - 2015-02-20 
-(<a href="https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-src.tgz">Source</a>, 
+Flink 0.8.1 - 2015-02-20
+(<a href="https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.8.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.8.0 - 2015-01-22 
-(<a href="https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-src.tgz">Source</a>, 
+Flink 0.8.0 - 2015-01-22
+(<a href="https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.8.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.7.0-incubating - 2014-11-04 
-(<a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz">Source</a>, 
+Flink 0.7.0-incubating - 2014-11-04
+(<a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.6.1-incubating - 2014-09-26 
-(<a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz">Source</a>, 
+Flink 0.6.1-incubating - 2014-09-26
+(<a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.6-incubating - 2014-08-26 
-(<a href="https://archive.apache.org/dist/flink/flink-0.6-incubating/flink-0.6-incubating-src.tgz">Source</a>, 
+Flink 0.6-incubating - 2014-08-26
+(<a href="https://archive.apache.org/dist/flink/flink-0.6-incubating/flink-0.6-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.6-incubating">Binaries</a>)
 
 </li>
@@ -1112,38 +1108,38 @@ Flink 0.6-incubating - 2014-08-26
 <ul>
 
 <li>
-Flink Stateful Functions 2.2.2 - 2021-01-02 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.2/flink-statefun-2.2.2-src.tgz">Source</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>) 
+Flink Stateful Functions 2.2.2 - 2021-01-02
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.2/flink-statefun-2.2.2-src.tgz">Source</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>)
 </li>
 
 <li>
-Flink Stateful Functions 2.2.1 - 2020-11-09 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.1/flink-statefun-2.2.1-src.tgz">Source</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>) 
+Flink Stateful Functions 2.2.1 - 2020-11-09
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.1/flink-statefun-2.2.1-src.tgz">Source</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>)
 </li>
 
 <li>
-Flink Stateful Functions 2.2.0 - 2020-09-28 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.0/flink-statefun-2.2.0-src.tgz">Source</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>) 
+Flink Stateful Functions 2.2.0 - 2020-09-28
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.2.0/flink-statefun-2.2.0-src.tgz">Source</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.2/api/java">Javadocs</a>)
 </li>
 
 <li>
-Flink Stateful Functions 2.1.0 - 2020-06-08 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.1.0/flink-statefun-2.1.0-src.tgz">Source</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1/api/java">Javadocs</a>) 
+Flink Stateful Functions 2.1.0 - 2020-06-08
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.1.0/flink-statefun-2.1.0-src.tgz">Source</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.1/api/java">Javadocs</a>)
 </li>
 
 <li>
-Flink Stateful Functions 2.0.0 - 2020-04-02 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.0.0/flink-statefun-2.0.0-src.tgz">Source</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0/api/java">Javadocs</a>) 
+Flink Stateful Functions 2.0.0 - 2020-04-02
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-2.0.0/flink-statefun-2.0.0-src.tgz">Source</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-statefun-docs-release-2.0/api/java">Javadocs</a>)
 </li>
 
 </ul>
@@ -1177,7 +1173,6 @@ Flink Stateful Functions 2.0.0 - 2020-04-02
 <li>Flink-shaded 1.0 - 2017-07-27 (<a href="https://archive.apache.org/dist/flink/flink-shaded-1.0/flink-shaded-1.0-src.tgz">Source</a>)</li>
 
 </ul>
-
 
 
   </div>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -228,9 +228,6 @@ $( document ).ready(function() {
 
 <p>Apache Flink® 1.12.2 是我们最新的稳定版本。</p>
 
-<p>如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
-Hadoop 文件系统的 connector ），请查看 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/zh/ops/deployment/hadoop.html">Hadoop 集成</a>文档。</p>
-
 <h2 id="apache-flink-1122">Apache Flink 1.12.2</h2>
 
 <p>
@@ -394,671 +391,671 @@ flink-docs-release-1.10/release-notes/flink-1.10.html">Flink 1.10 的发布说�
 
 <li>
 
-Flink 1.12.2 - 2021-03-03 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.2 - 2021-03-03
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.2/flink-1.12.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.12.1 - 2021-01-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.1 - 2021-01-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.1/flink-1.12.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.12.0 - 2020-12-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.12.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>, 
+Flink 1.12.0 - 2020-12-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.12.0/flink-1.12.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.12.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.12/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.3 - 2020-12-18 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.3/flink-1.11.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.3 - 2020-12-18
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.3/flink-1.11.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.2 - 2020-09-17 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.2 - 2020-09-17
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.1 - 2020-07-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.1/flink-1.11.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.1 - 2020-07-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.1/flink-1.11.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.11.0 - 2020-07-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.11.0/flink-1.11.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.11.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>, 
+Flink 1.11.0 - 2020-07-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.11.0/flink-1.11.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.11.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.11/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.3 - 2021-01-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.3/flink-1.10.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.3 - 2021-01-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.3/flink-1.10.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.2 - 2020-08-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.2 - 2020-08-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.2/flink-1.10.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.1 - 2020-05-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.1 - 2020-05-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.1/flink-1.10.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.10.0 - 2020-02-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.10.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>, 
+Flink 1.10.0 - 2020-02-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.10.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.3 - 2020-04-24 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.3 - 2020-04-24
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.3/flink-1.9.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.2 - 2020-01-30 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.2 - 2020-01-30
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.2/flink-1.9.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.1 - 2019-10-18 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.1 - 2019-10-18
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.1/flink-1.9.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.9.0 - 2019-08-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.9.0/flink-1.9.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.9.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>, 
+Flink 1.9.0 - 2019-08-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.9.0/flink-1.9.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.9.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.9/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.3 - 2019-12-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.3 - 2019-12-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.3/flink-1.8.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.2 - 2019-09-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.2 - 2019-09-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.2/flink-1.8.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.1 - 2019-07-02 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.1 - 2019-07-02
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.1/flink-1.8.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.8.0 - 2019-04-09 
-(<a href="https://archive.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.8.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>, 
+Flink 1.8.0 - 2019-04-09
+(<a href="https://archive.apache.org/dist/flink/flink-1.8.0/flink-1.8.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.8.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.8/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.2 - 2019-02-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.2 - 2019-02-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.2/flink-1.7.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.1 - 2018-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.1 - 2018-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.1/flink-1.7.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.7.0 - 2018-11-30 
-(<a href="https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.7.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>, 
+Flink 1.7.0 - 2018-11-30
+(<a href="https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.7.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.7/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.4 - 2019-02-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.4 - 2019-02-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.4/flink-1.6.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.3 - 2018-12-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.3 - 2018-12-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.3/flink-1.6.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.2 - 2018-10-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.2 - 2018-10-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.2/flink-1.6.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.1 - 2018-09-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.1 - 2018-09-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.1/flink-1.6.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.6.0 - 2018-08-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.6.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>, 
+Flink 1.6.0 - 2018-08-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.6.0/flink-1.6.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.6.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.6/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.6 - 2018-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.6">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.6 - 2018-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.6/flink-1.5.6-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.6">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.5 - 2018-10-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.5">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.5 - 2018-10-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.5/flink-1.5.5-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.5">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.4 - 2018-09-19 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.4/flink-1.5.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.4 - 2018-09-19
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.4/flink-1.5.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.3 - 2018-08-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.3 - 2018-08-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.2 - 2018-07-31 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.2/flink-1.5.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.2 - 2018-07-31
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.2/flink-1.5.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.1 - 2018-07-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.1/flink-1.5.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.1 - 2018-07-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.1/flink-1.5.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.5.0 - 2018-05-25 
-(<a href="https://archive.apache.org/dist/flink/flink-1.5.0/flink-1.5.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.5.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>, 
+Flink 1.5.0 - 2018-05-25
+(<a href="https://archive.apache.org/dist/flink/flink-1.5.0/flink-1.5.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.5.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.2 - 2018-03-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.2/flink-1.4.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.2 - 2018-03-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.2/flink-1.4.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.1 - 2018-02-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.1/flink-1.4.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.1 - 2018-02-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.1/flink-1.4.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.4.0 - 2017-11-29 
-(<a href="https://archive.apache.org/dist/flink/flink-1.4.0/flink-1.4.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.4.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>, 
+Flink 1.4.0 - 2017-11-29
+(<a href="https://archive.apache.org/dist/flink/flink-1.4.0/flink-1.4.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.4.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.4/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.3 - 2018-03-15 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.3/flink-1.3.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.3 - 2018-03-15
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.3/flink-1.3.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.2 - 2017-08-05 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.2/flink-1.3.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.2 - 2017-08-05
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.2/flink-1.3.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.1 - 2017-06-23 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.1/flink-1.3.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.1 - 2017-06-23
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.1/flink-1.3.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.3.0 - 2017-06-01 
-(<a href="https://archive.apache.org/dist/flink/flink-1.3.0/flink-1.3.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.3.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>, 
+Flink 1.3.0 - 2017-06-01
+(<a href="https://archive.apache.org/dist/flink/flink-1.3.0/flink-1.3.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.3.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.3/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.2.1 - 2017-04-26 
-(<a href="https://archive.apache.org/dist/flink/flink-1.2.1/flink-1.2.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.2.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>, 
+Flink 1.2.1 - 2017-04-26
+(<a href="https://archive.apache.org/dist/flink/flink-1.2.1/flink-1.2.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.2.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.2.0 - 2017-02-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.2.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>, 
+Flink 1.2.0 - 2017-02-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.2.0/flink-1.2.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.2.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.2/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.5 - 2017-03-22 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.5/flink-1.1.5-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.5">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.5 - 2017-03-22
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.5/flink-1.1.5-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.5">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.4 - 2016-12-21 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.4/flink-1.1.4-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.4">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.4 - 2016-12-21
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.4/flink-1.1.4-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.4">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.3 - 2016-10-13 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.3/flink-1.1.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.3 - 2016-10-13
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.3/flink-1.1.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.2 - 2016-09-05 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.2 - 2016-09-05
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.2/flink-1.1.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.1 - 2016-08-11 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.1/flink-1.1.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.1 - 2016-08-11
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.1/flink-1.1.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.1.0 - 2016-08-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.1.0/flink-1.1.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.1.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>, 
+Flink 1.1.0 - 2016-08-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.1.0/flink-1.1.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.1.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.1/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.3 - 2016-05-12 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.3">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.3 - 2016-05-12
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.3">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.2 - 2016-04-23 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.2">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.2 - 2016-04-23
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.2">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.1 - 2016-04-06 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.1">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.1 - 2016-04-06
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.1">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 1.0.0 - 2016-03-08 
-(<a href="https://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-1.0.0">Binaries</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>, 
-<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>, 
+Flink 1.0.0 - 2016-03-08
+(<a href="https://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-1.0.0">Binaries</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0">Docs</a>,
+<a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/java">Javadocs</a>,
 <a href="https://ci.apache.org/projects/flink/flink-docs-release-1.0/api/scala/index.html">Scaladocs</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.2 - 2016-02-11 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-src.tgz">Source</a>, 
+Flink 0.10.2 - 2016-02-11
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.2">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.1 - 2015-11-27 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-src.tgz">Source</a>, 
+Flink 0.10.1 - 2015-11-27
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.10.0 - 2015-11-16 
-(<a href="https://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-src.tgz">Source</a>, 
+Flink 0.10.0 - 2015-11-16
+(<a href="https://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.10.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.1 - 2015-09-01 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.1/flink-0.9.1-src.tgz">Source</a>, 
+Flink 0.9.1 - 2015-09-01
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.1/flink-0.9.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.0 - 2015-06-24 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-src.tgz">Source</a>, 
+Flink 0.9.0 - 2015-06-24
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.9.0-milestone-1 - 2015-04-13 
-(<a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1/flink-0.9.0-milestone-1-src.tgz">Source</a>, 
+Flink 0.9.0-milestone-1 - 2015-04-13
+(<a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1/flink-0.9.0-milestone-1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.9.0-milestone-1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.8.1 - 2015-02-20 
-(<a href="https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-src.tgz">Source</a>, 
+Flink 0.8.1 - 2015-02-20
+(<a href="https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.8.1">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.8.0 - 2015-01-22 
-(<a href="https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-src.tgz">Source</a>, 
+Flink 0.8.0 - 2015-01-22
+(<a href="https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.8.0">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.7.0-incubating - 2014-11-04 
-(<a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz">Source</a>, 
+Flink 0.7.0-incubating - 2014-11-04
+(<a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating/flink-0.7.0-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.7.0-incubating">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.6.1-incubating - 2014-09-26 
-(<a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz">Source</a>, 
+Flink 0.6.1-incubating - 2014-09-26
+(<a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating/flink-0.6.1-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.6.1-incubating">Binaries</a>)
 
 </li>
 
 <li>
 
-Flink 0.6-incubating - 2014-08-26 
-(<a href="https://archive.apache.org/dist/flink/flink-0.6-incubating/flink-0.6-incubating-src.tgz">Source</a>, 
+Flink 0.6-incubating - 2014-08-26
+(<a href="https://archive.apache.org/dist/flink/flink-0.6-incubating/flink-0.6-incubating-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-0.6-incubating">Binaries</a>)
 
 </li>

--- a/downloads.md
+++ b/downloads.md
@@ -87,7 +87,7 @@ file system connector), please check out the [Hadoop Integration]({{ site.DOCS_B
 <p>
 <a href="{{ flink_release.sql_components_url }}" class="ga-track">SQL components download page</a>
 </p>
-{% endif %} 
+{% endif %}
 
 {% if flink_release.alternative_binaries %}
 #### Alternative Binaries
@@ -216,20 +216,20 @@ Note that the community is always open to discussing bugfix releases for even ol
 All Flink releases are available via [https://archive.apache.org/dist/flink/](https://archive.apache.org/dist/flink/) including checksums and cryptographic signatures. At the time of writing, this includes the following versions:
 
 ### Flink
-{% assign flink_releases = site.release_archive.flink %} 
+{% assign flink_releases = site.release_archive.flink %}
 <ul>
 {% for flink_release in flink_releases %}
 <li>
 {% if flink_release.version_short %}
-Flink {{ flink_release.version_long }} - {{ flink_release.release_date }} 
-(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}">Docs</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/java">Javadocs</a>, 
+Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}">Docs</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/java">Javadocs</a>,
 <a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/scala/index.html">Scaladocs</a>)
 {% else %}
-Flink {{ flink_release.version_long }} - {{ flink_release.release_date }} 
-(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>, 
+Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>)
 {% endif %}
 </li>
@@ -241,19 +241,18 @@ Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
 <ul>
 {% for flink_statefun_release in flink_statefun_releases %}
 <li>
-Flink Stateful Functions {{ flink_statefun_release.version_long }} - {{ flink_statefun_release.release_date }} 
-(<a href="https://archive.apache.org/dist/flink/flink-statefun-{{ flink_statefun_release.version_long }}/flink-statefun-{{ flink_statefun_release.version_long }}-src.tgz">Source</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}">Docs</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}/api/java">Javadocs</a>) 
+Flink Stateful Functions {{ flink_statefun_release.version_long }} - {{ flink_statefun_release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-statefun-{{ flink_statefun_release.version_long }}/flink-statefun-{{ flink_statefun_release.version_long }}-src.tgz">Source</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}">Docs</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-statefun-docs-release-{{ flink_statefun_release.version_short }}/api/java">Javadocs</a>)
 </li>
 {% endfor %}
 </ul>
 
 ### Flink-shaded
-{% assign shaded_releases = site.release_archive.flink_shaded | sort: 'release_date' | reverse %} 
+{% assign shaded_releases = site.release_archive.flink_shaded | sort: 'release_date' | reverse %}
 <ul>
 {% for shaded_release in shaded_releases %}
 <li>Flink-shaded {{ shaded_release.version }} - {{ shaded_release.release_date }} (<a href="https://archive.apache.org/dist/flink/flink-shaded-{{ shaded_release.version }}/flink-shaded-{{ shaded_release.version }}-src.tgz">Source</a>)</li>
 {% endfor %}
 </ul>
-

--- a/downloads.md
+++ b/downloads.md
@@ -20,10 +20,6 @@ $( document ).ready(function() {
 
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} is our latest stable release.
 
-If you plan to use Apache Flink together with Apache Hadoop (run Flink
-on YARN, connect to HDFS, connect to HBase, or use some Hadoop-based
-file system connector), please check out the [Hadoop Integration]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ site.FLINK_VERSION_STABLE_SHORT }}/ops/deployment/hadoop.html) documentation.
-
 {% for flink_release in site.flink_releases %}
 
 ## {{ flink_release.binary_release.name }}

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -99,7 +99,7 @@ Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BA
 <p>
 <a href="{{ flink_release.sql_components_url }}" class="ga-track">SQL 组件下载页面</a>
 </p>
-{% endif %} 
+{% endif %}
 
 {% if flink_release.alternative_binaries %}
 #### 其他替代执行包
@@ -188,20 +188,20 @@ flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flin
 所有的 Flink 版本均可通过 [https://archive.apache.org/dist/flink/](https://archive.apache.org/dist/flink/) 获得，包括校验和加密签名。在撰写本文时，这包括以下版本：
 
 ### Flink
-{% assign flink_releases = site.release_archive.flink %} 
+{% assign flink_releases = site.release_archive.flink %}
 <ul>
 {% for flink_release in flink_releases %}
 <li>
 {% if flink_release.version_short %}
-Flink {{ flink_release.version_long }} - {{ flink_release.release_date }} 
-(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>, 
-<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}">Docs</a>, 
-<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/java">Javadocs</a>, 
+Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
+<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}">Docs</a>,
+<a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/java">Javadocs</a>,
 <a href="{{ site.DOCS_BASE_URL }}flink-docs-release-{{ flink_release.version_short }}/api/scala/index.html">Scaladocs</a>)
 {% else %}
-Flink {{ flink_release.version_long }} - {{ flink_release.release_date }} 
-(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>, 
+Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>)
 {% endif %}
 </li>
@@ -209,7 +209,7 @@ Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
 </ul>
 
 ### Flink-shaded
-{% assign shaded_releases = site.release_archive.flink_shaded | sort: 'release_date' | reverse %} 
+{% assign shaded_releases = site.release_archive.flink_shaded | sort: 'release_date' | reverse %}
 <ul>
 {% for shaded_release in shaded_releases %}
 <li>Flink-shaded {{ shaded_release.version }} - {{ shaded_release.release_date }} (<a href="https://archive.apache.org/dist/flink/flink-shaded-{{ shaded_release.version }}/flink-shaded-{{ shaded_release.version }}-src.tgz">Source</a>)</li>

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -20,8 +20,6 @@ $( document ).ready(function() {
 
 Apache Flink® {{ site.FLINK_VERSION_STABLE }} 是我们最新的稳定版本。
 
-如果你计划将 Apache Flink 与 Apache Hadoop 一起使用（在 YARN 上运行 Flink ，连接到 HDFS ，连接到 HBase ，或使用一些基于
-Hadoop 文件系统的 connector ），请查看 [Hadoop 集成]({{ site.DOCS_BASE_URL }}flink-docs-release-{{ site.FLINK_VERSION_STABLE_SHORT }}/zh/ops/deployment/hadoop.html)文档。
 
 {% for flink_release in site.flink_releases %}
 


### PR DESCRIPTION
Yarn is no longer the only resource provider Flink users can use. Hence,
we should no longer directly point from the downloads page to this one
resource provider implementation.