### PR TITLE
[FLINK-22116] Setup .asf.yaml for publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,2 @@
+publish:
+  whoami: asf-site


### PR DESCRIPTION
Publishing websites from git without an .asf.yaml will not work from June onwards.