### PR TITLE
[FLINK-21720] Updates documentation style guides for the new (Hugo) build system

### DIFF
--- a/contributing/docs-style.md
+++ b/contributing/docs-style.md
@@ -115,7 +115,7 @@ intermix.
 ### Front Matter
 
 In addition to Markdown, each file contains a YAML [front matter
-block](https://jekyllrb.com/docs/front-matter/) that will be used to set
+block](https://gohugo.io/content-management/front-matter/) that will be used to set
 variables and metadata on the page. The front matter must be the first thing in
 the file and must be specified as a valid YAML set between triple-dashed lines.
 

--- a/contributing/improve-website.md
+++ b/contributing/improve-website.md
@@ -33,7 +33,7 @@ git checkout asf-site
 
 ## Directory structure and files
 
-Flink's website is written in [Markdown](http://daringfireball.net/projects/markdown/). Markdown is a lightweight markup language which can be translated to HTML. We use [Jekyll](http://jekyllrb.com/) to generate static HTML files from Markdown.
+Flink's website is written in [Markdown](http://daringfireball.net/projects/markdown/). Markdown is a lightweight markup language which can be translated to HTML. We use [Hugo](https://gohugo.io/documentation/) to generate static HTML files from Markdown.
 
 The files and directories in the website git repository have the following roles:
 
@@ -42,7 +42,7 @@ The files and directories in the website git repository have the following roles
 - The `_posts` directory contains blog posts. Each blog post is written as one Markdown file. To contribute a post, add a new file there.
 - The `_includes/` directory contains includeable files such as the navigation bar or the footer.
 - The `docs/` directory contains copies of the documentation of Flink for different releases. There is a directory inside `docs/` for each stable release and the latest SNAPSHOT version. The build script is taking care of the maintenance of this directory.
-- The `content/` directory contains the generated HTML files from Jekyll. It is important to place the files in this directory since the Apache Infrastructure to host the Flink website is pulling the HTML content from his directory. (For committers: When pushing changes to the website git, push also the updates in the `content/` directory!)
+- The `content/` directory contains the generated HTML files from Hugo. It is important to place the files in this directory since the Apache Infrastructure that hosts the Flink website is pulling the HTML content from his directory. (For committers: When pushing changes to the website git, push also the updates in the `content/` directory!)
 
 ## Update or extend the documentation
 


### PR DESCRIPTION
[FLINK-21720 Jira Ticket](https://issues.apache.org/jira/browse/FLINK-21720)

### Description

The docs build recently changed from Jekyll to Hugo (FLIP-157), so this updates the [style guide](https://flink.apache.org/contributing/docs-style.html) and related files accordingly. 

**Note:** The original ticket specified that this PR should also include the Chinese translation specification. However this needs to be done by a Chinese language-fluent contributor. It was decided to have this person also modify the corresponding `zh` files.  @sjwiesman has agreed to open up a follow-up translation ticket for this. 

### Reviewer(s)

@sjwiesman 