### PR TITLE
[hotfix] Correct formatting in 1.13 release blogpost.

### DIFF
--- a/_posts/2021-05-03-release-1.13.0.md
+++ b/_posts/2021-05-03-release-1.13.0.md
@@ -439,6 +439,7 @@ The Python Table API now supports row-based operations, i.e., custom transformat
 These functions are an easy way to apply data transformations on tables beyond the built-in functions.
 
 This is an example of using a `map()` operation in Python Table API:
+
 ```python
 @udf(result_type=DataTypes.ROW(
   [DataTypes.FIELD("c1", DataTypes.BIGINT()),


### PR DESCRIPTION
One of the Python code snippets renders incorrectly due to a missing paragraph.

<img width="981" alt="Screen Shot 2021-05-03 at 15 57 02" src="https://user-images.githubusercontent.com/23521087/116886475-6864b880-ac29-11eb-9c3a-4f5b98466a8e.png">
