### PR TITLE
[hotfix] Adjust phrasing for FlameGraph performance

### DIFF
--- a/_posts/2021-05-03-release-1.13.0.md
+++ b/_posts/2021-05-03-release-1.13.0.md
@@ -125,8 +125,8 @@ in the samples. When enabled, the graphs are shown in a new UI component for the
   <img src="{{ site.baseurl }}/img/blog/2021-05-03-release-1.13.0/7.png" style="display: block; margin-left: auto; margin-right: auto; width: 600px"/>
 </figure>
 
-Flame graphs are expensive to create: They may cause processing overhead and can put a heavy load
-on Flink's metric system. Because of that, users need to explicitly enable them in the configuration.
+The [Flame Graphs documentation]({{ site.DOCS_BASE_URL }}flink-docs-release-1.13/docs/ops/debugging/flame_graphs)
+contains more details and instructions for enabling this feature.
 
 **Access Latency Metrics for State**
 


### PR DESCRIPTION
The current 1.13 blog post contains a note for flamegraphs that they are a) expensive and b) may overload the metric system.
Point b) is simply incorrect, while a) is not generally the case, and the existing documentation provides better information.

So I just replaced the current note with a link to the docs.