### PR TITLE
[FLINK-23038][docs] fix glossary link

### DIFF
--- a/contributing/docs-style.md
+++ b/contributing/docs-style.md
@@ -82,7 +82,7 @@ Principles](#general-guiding-principles).
 Use clear definitions of terms or provide additional instructions on what
 something means by adding a link to a helpful resource, such as other
 documentation pages or the [Flink
-Glossary](https://ci.apache.org/projects/flink/flink-docs-master/concepts/glossary.html).
+Glossary](https://ci.apache.org/projects/flink/flink-docs-master/docs/concepts/glossary).
 The Glossary is a work in progress, so you can also propose new terms by
 opening a pull-request.
 


### PR DESCRIPTION
The glossary link on https://flink.apache.org/contributing/docs-style.html needs to be updated. 