### PR TITLE
[FLINK-23257] Update docker-build.sh

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -17,4 +17,4 @@
 # limitations under the License.
 ################################################################################
 
-docker run --rm --volume="$PWD:/srv/flink-web" --expose=4000 -p 4000:4000 -it ruby:2.5 bash -c "cd /srv/flink-web && ./build.sh $@"
+docker run --rm --volume="$PWD:/srv/flink-web" --expose=4000 -p 4000:4000 -it ruby:2.6 bash -c "cd /srv/flink-web && gem install bundler && ./build.sh $@"


### PR DESCRIPTION
We need Ruby 2.6 to build the docs. The newer image does not ship with bundler being installed by default, so we have to do it manually.