### PR TITLE
[hotfix] Various Typos / Grammar / Clarity Fixes Across Documentations

### DIFF
--- a/_posts/2021-04-29-release-1.12.3.md
+++ b/_posts/2021-04-29-release-1.12.3.md
@@ -77,7 +77,7 @@ List of resolved issues:
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21431'>FLINK-21431</a>] -         UpsertKafkaTableITCase.testTemporalJoin hang
 </li>
-<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21434'>FLINK-21434</a>] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happend
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-21434'>FLINK-21434</a>] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happened
 </li>
 <li>[<a href='https://issues.apache.org/jira/browse/FLINK-21497'>FLINK-21497</a>] -         JobLeaderIdService completes leader future despite no leader being elected
 </li>

--- a/community.md
+++ b/community.md
@@ -149,7 +149,7 @@ If you send us an email with a code snippet, make sure that:
 
 Committers are watching [Stack Overflow](http://stackoverflow.com/questions/tagged/apache-flink) for the [apache-flink](http://stackoverflow.com/questions/tagged/apache-flink) tag.
 
-Make sure to tag your questions there accordingly to get answers from the Flink community.
+Make sure to tag your questions accordingly to get answers from the Flink community.
 
 ## Issue Tracker
 

--- a/content/blog/feed.xml
+++ b/content/blog/feed.xml
@@ -3409,7 +3409,7 @@ zhushang, zhuxiaoshang, Zhu Zhu, zjuwangg, zoucao, zoudan, 左元, 星, 肖佳�
 &lt;/li&gt;
 &lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21431&quot;&gt;FLINK-21431&lt;/a&gt;] -         UpsertKafkaTableITCase.testTemporalJoin hang
 &lt;/li&gt;
-&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21434&quot;&gt;FLINK-21434&lt;/a&gt;] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happend
+&lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21434&quot;&gt;FLINK-21434&lt;/a&gt;] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happened
 &lt;/li&gt;
 &lt;li&gt;[&lt;a href=&quot;https://issues.apache.org/jira/browse/FLINK-21497&quot;&gt;FLINK-21497&lt;/a&gt;] -         JobLeaderIdService completes leader future despite no leader being elected
 &lt;/li&gt;

--- a/content/community.html
+++ b/content/community.html
@@ -375,7 +375,7 @@
 
 <p>Committers are watching <a href="http://stackoverflow.com/questions/tagged/apache-flink">Stack Overflow</a> for the <a href="http://stackoverflow.com/questions/tagged/apache-flink">apache-flink</a> tag.</p>
 
-<p>Make sure to tag your questions there accordingly to get answers from the Flink community.</p>
+<p>Make sure to tag your questions accordingly to get answers from the Flink community.</p>
 
 <h2 id="issue-tracker">Issue Tracker</h2>
 

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -403,7 +403,7 @@ It is not required to strictly follow the SQL standard in regards of syntax and 
 
 <ul>
   <li>Backwards compatibility for state in streaming SQL relies on the fact that the physical execution plan remains stable. Otherwise the generated Operator Names/IDs change and state cannot be matched and restored.</li>
-  <li>Every bug fix that leads to changes in the optimized physical plan of a streaming pipeline hences breaks compatibility.</li>
+  <li>Every bug fix that leads to changes in the optimized physical plan of a streaming pipeline hence breaks compatibility.</li>
   <li>As a consequence, changes of the kind that lead to different optimizer plans can only be merged in major releases for now.</li>
 </ul>
 

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -276,7 +276,7 @@
   <ol>
     <li id="fn:1">
 
-      <p>In earlier days, we (the Flink community) did not always pay sufficient attention to this, making some components of Flink harder to evolve and to contribute to. <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>In earlier days, we (the Flink community) did not always pay sufficient attention to this, making some components of Flink harder to evolve and contribute to. <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -711,7 +711,7 @@ implementation details and to describe the expected output.</p>
   <li>
     <p><strong>Commands in code blocks.</strong> Commands can be documented using <code>bash</code> syntax 
 highlighted code blocks. The following items should be considered when adding 
-commands to the docummentation:</p>
+commands to the documentation:</p>
     <ul>
       <li><strong>Use long parameter names.</strong> Long parameter names help the reader to 
 understand the purpose of the command. They should be preferred over their 

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -289,7 +289,7 @@ If the implementation is different from the agreed approach in the consensus dis
 
 <h3 id="does-the-implementation-follow-the-agreed-upon-overall-approacharchitecture">4. Does the Implementation Follow the Agreed Upon Overall Approach/Architecture?</h3>
 
-<p>In this step, we check if a contribution folllows the agreed upon approach from the previous discussion in Jira or the mailing lists.</p>
+<p>In this step, we check if a contribution follows the agreed upon approach from the previous discussion in Jira or the mailing lists.</p>
 
 <p>This question should be answerable from the Pull Request description (or the linked Jira) as much as possible.</p>
 

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -200,7 +200,7 @@
 
 <div class="page-toc">
 <ul id="markdown-toc">
-  <li><a href="#having-a-question" id="markdown-toc-having-a-question">Having a Question?</a>    <ul>
+  <li><a href="#have-a-question" id="markdown-toc-have-a-question">Have a Question?</a>    <ul>
       <li><a href="#user-mailing-list" id="markdown-toc-user-mailing-list">User Mailing List</a></li>
       <li><a href="#stack-overflow" id="markdown-toc-stack-overflow">Stack Overflow</a></li>
     </ul>
@@ -220,7 +220,7 @@
 
 </div>
 
-<h2 id="having-a-question">Having a Question?</h2>
+<h2 id="have-a-question">Have a Question?</h2>
 
 <p>The Apache Flink community answers many user questions every day. You can search for answers and advice in the archives or reach out to the community for help and guidance.</p>
 

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -252,7 +252,7 @@
 
 <p>If you observe an unexpected behavior that might be caused by a bug, you can search for reported bugs or file a bug report in <a href="https://issues.apache.org/jira/issues/?jql=project %3D FLINK">Flink’s JIRA</a>.</p>
 
-<p>If you are unsure whether the unexpected behavior happend due to a bug or not, please post a question to the <a href="#user-mailing-list">user mailing list</a>.</p>
+<p>If you are unsure whether the unexpected behavior happened due to a bug or not, please post a question to the <a href="#user-mailing-list">user mailing list</a>.</p>
 
 <h2 id="got-an-error-message">Got an Error Message?</h2>
 

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -267,7 +267,7 @@
 </li>
 <li>[<a href="https://issues.apache.org/jira/browse/FLINK-21431">FLINK-21431</a>] -         UpsertKafkaTableITCase.testTemporalJoin hang
 </li>
-<li>[<a href="https://issues.apache.org/jira/browse/FLINK-21434">FLINK-21434</a>] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happend
+<li>[<a href="https://issues.apache.org/jira/browse/FLINK-21434">FLINK-21434</a>] -         When UDAF return ROW type, and the number of fields is more than 14, the crash happened
 </li>
 <li>[<a href="https://issues.apache.org/jira/browse/FLINK-21497">FLINK-21497</a>] -         JobLeaderIdService completes leader future despite no leader being elected
 </li>

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -445,7 +445,7 @@ job as a self contained application.</p>
 <ul>
   <li>
     <p>Reactive Scaling lets Flink applications change their parallelism in response to growing and shrinking
-worker pools, and makes Flink compatibel with standard auto-scalers:
+worker pools, and makes Flink compatible with standard auto-scalers:
 <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-159%3A+Reactive+Mode">FLIP-159</a></p>
   </li>
   <li>

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -307,7 +307,7 @@ integrations. With user feedback, those are continuously improved.</p>
 
 <ul>
   <li>Change-Data-Capture: Capturing a stream of data changes, directly from databases, by attaching to the
-transaction log. The community is adding more CDC intrgrations.
+transaction log. The community is adding more CDC integrations.
     <ul>
       <li>External CDC connectors: <a href="https://flink-packages.org/packages/cdc-connectors">https://flink-packages.org/packages/cdc-connectors</a></li>
       <li>Background: <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=147427289">FLIP-105</a>

--- a/contributing/code-style-and-quality-components.md
+++ b/contributing/code-style-and-quality-components.md
@@ -128,7 +128,7 @@ Avoid full integration tests
 Don’t introduce physical plan changes in minor releases!
 
 * Backwards compatibility for state in streaming SQL relies on the fact that the physical execution plan remains stable. Otherwise the generated Operator Names/IDs change and state cannot be matched and restored.
-* Every bug fix that leads to changes in the optimized physical plan of a streaming pipeline hences breaks compatibility.
+* Every bug fix that leads to changes in the optimized physical plan of a streaming pipeline hence breaks compatibility.
 * As a consequence, changes of the kind that lead to different optimizer plans can only be merged in major releases for now.
 
 

--- a/contributing/code-style-and-quality-preamble.md
+++ b/contributing/code-style-and-quality-preamble.md
@@ -22,4 +22,4 @@ A big part of high-quality open source contributions is about helping the review
 <hr>
 
 [^1]:
-     In earlier days, we (the Flink community) did not always pay sufficient attention to this, making some components of Flink harder to evolve and to contribute to.
+     In earlier days, we (the Flink community) did not always pay sufficient attention to this, making some components of Flink harder to evolve and contribute to.

--- a/contributing/docs-style.md
+++ b/contributing/docs-style.md
@@ -465,7 +465,7 @@ Or using plain HTML:
 
 * **Commands in code blocks.** Commands can be documented using `bash` syntax 
   highlighted code blocks. The following items should be considered when adding 
-  commands to the docummentation:
+  commands to the documentation:
   * **Use long parameter names.** Long parameter names help the reader to 
     understand the purpose of the command. They should be preferred over their 
     short counterparts.

--- a/contributing/reviewing-prs.md
+++ b/contributing/reviewing-prs.md
@@ -61,7 +61,7 @@ This question can be answered with
 
 ### 4. Does the Implementation Follow the Agreed Upon Overall Approach/Architecture?
 
-In this step, we check if a contribution folllows the agreed upon approach from the previous discussion in Jira or the mailing lists.
+In this step, we check if a contribution follows the agreed upon approach from the previous discussion in Jira or the mailing lists.
 
 This question should be answerable from the Pull Request description (or the linked Jira) as much as possible.
 

--- a/gettinghelp.md
+++ b/gettinghelp.md
@@ -34,7 +34,7 @@ Many members of the Flink community are active on [Stack Overflow](https://stack
 
 If you observe an unexpected behavior that might be caused by a bug, you can search for reported bugs or file a bug report in [Flink's JIRA](https://issues.apache.org/jira/issues/?jql=project %3D FLINK).
 
-If you are unsure whether the unexpected behavior happend due to a bug or not, please post a question to the [user mailing list](#user-mailing-list).
+If you are unsure whether the unexpected behavior happened due to a bug or not, please post a question to the [user mailing list](#user-mailing-list).
 
 ## Got an Error Message?
 

--- a/gettinghelp.md
+++ b/gettinghelp.md
@@ -6,7 +6,7 @@ title: "Getting Help"
 
 {% toc %}
 
-## Having a Question?
+## Have a Question?
 
 The Apache Flink community answers many user questions every day. You can search for answers and advice in the archives or reach out to the community for help and guidance.
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -85,7 +85,7 @@ integrations. With user feedback, those are continuously improved.
 **More Connector and Change Data Capture Support**
 
   - Change-Data-Capture: Capturing a stream of data changes, directly from databases, by attaching to the
-    transaction log. The community is adding more CDC intrgrations.
+    transaction log. The community is adding more CDC integrations.
       - External CDC connectors: [https://flink-packages.org/packages/cdc-connectors](https://flink-packages.org/packages/cdc-connectors)
       - Background: [FLIP-105](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=147427289)
         (CDC support for SQL) and [Debezium](https://debezium.io/).

--- a/roadmap.md
+++ b/roadmap.md
@@ -193,7 +193,7 @@ Deploy Flink jobs as self-contained Applications works for all deployment target
 ([FLIP-85](https://cwiki.apache.org/confluence/display/FLINK/FLIP-85+Flink+Application+Mode)).
 
   - Reactive Scaling lets Flink applications change their parallelism in response to growing and shrinking
-    worker pools, and makes Flink compatibel with standard auto-scalers:
+    worker pools, and makes Flink compatible with standard auto-scalers:
     [FLIP-159](https://cwiki.apache.org/confluence/display/FLINK/FLIP-159%3A+Reactive+Mode)
 
   - Kubernetes-based HA-services let Flink applications run on Kubernetes without requiring a ZooKeeper dependency:


### PR DESCRIPTION
Added a series of fixes related to obvious typos (e.g. 'happend' to 'happened', 'docummentation' to 'documentation', etc.). Additionally included a series of grammatical fixes to help with clarity.