### PR TITLE
[hotfix][doc] Some typos in the Release Announcement

### DIFF
--- a/_posts/2021-09-29-release-1.14.0.md
+++ b/_posts/2021-09-29-release-1.14.0.md
@@ -125,7 +125,7 @@ seamlessly switching over from one source to the other.
 The motivating use case for the Hybrid Source was to read streams from tiered storage setups as if there was one
 stream that spans all tiers. For example, new data may land in Kafa and is eventually
 migrated to S3 (typically in compressed columnar format, for cost efficiency and performance).
-The Hybrid Source can read this as one contiguous logical stream, starting with the the historic data on S3
+The Hybrid Source can read this as one contiguous logical stream, starting with the historic data on S3
 and transitioning over to the more recent data in Kafka.
 
 <figure style="align-content: center">
@@ -181,7 +181,7 @@ reduce the amount of in-flight data stored in unaliged checkpoints under backpre
   <img src="{{ site.baseurl }}/img/blog/2021-09-25-release-1.14.0/buffer_debloating.svg" style="display: block; margin-left: auto; margin-right: auto; width: 600px"/>
 </figure>
 
-Buffer Deloating acts as a complementary feature, or even alternative, to unaligned checkpoints.
+Buffer Debloating acts as a complementary feature, or even alternative, to unaligned checkpoints.
 Checkout the [documentation](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/deployment/memory/network_mem_tuning/#the-buffer-debloating-mechanism)
 to see how to activate this feature.
 


### PR DESCRIPTION
Add fixes related to typos found in Apache Flink 1.14.0 Release Announcement.