### PR TITLE
[hotfix] Add Analytics GA4 implementation to be prepared for migration

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     {% comment %} Includes are found in the _includes directory. {% endcomment %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -83,6 +83,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -398,6 +398,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -364,6 +364,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -383,6 +383,7 @@ With Flink 1.8.0, users can only define a state TTL in terms of processing time.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -628,6 +628,7 @@ If you need to turn off credit-based flow control, you can add this to your <cod
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -456,6 +456,7 @@ The website implements a streaming application that detects a pattern on the str
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -624,6 +624,7 @@ Enabling latency metrics can significantly impact the performance of the cluster
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -432,6 +432,7 @@ Please note that Python 3.5 or higher is required to install and run PyFlink</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -463,6 +463,7 @@ In this scenario, we keep customer orders in Hive (<code>dev_orders</code>) beca
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -546,6 +546,7 @@ As the maximum time is also a part of the primary key of the sink, the final res
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -473,6 +473,7 @@ With the function, you can register and use it in the same way as the <a href="h
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -471,6 +471,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -376,6 +376,7 @@ and become part of the discussion.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -380,6 +380,7 @@ In addition, many applications hold state internally as a way to support their i
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -567,6 +567,7 @@ Another example is to schedule <em>subtasks</em> which are connected with <em>pi
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/01/07/pulsar-flink-connector-270.html
+++ b/content/2021/01/07/pulsar-flink-connector-270.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/01/07/pulsar-flink-connector-270.html
+++ b/content/2021/01/07/pulsar-flink-connector-270.html
@@ -428,6 +428,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/01/18/rocksdb.html
+++ b/content/2021/01/18/rocksdb.html
@@ -374,6 +374,7 @@ Enabling RocksDB’s native metrics in Flink may have a negative performance imp
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/01/18/rocksdb.html
+++ b/content/2021/01/18/rocksdb.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/02/10/native-k8s-with-ha.html
+++ b/content/2021/02/10/native-k8s-with-ha.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/02/10/native-k8s-with-ha.html
+++ b/content/2021/02/10/native-k8s-with-ha.html
@@ -404,6 +404,7 @@ This work is already in progress and will be added in the upcoming 1.13 release!
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/03/11/batch-execution-mode.html
+++ b/content/2021/03/11/batch-execution-mode.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/03/11/batch-execution-mode.html
+++ b/content/2021/03/11/batch-execution-mode.html
@@ -492,6 +492,7 @@ Number of late records: 1514
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/05/06/reactive-mode.html
+++ b/content/2021/05/06/reactive-mode.html
@@ -413,6 +413,7 @@ cp ./examples/streaming/TopSpeedWindowing.jar usrlib/
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/05/06/reactive-mode.html
+++ b/content/2021/05/06/reactive-mode.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/07/07/backpressure.html
+++ b/content/2021/07/07/backpressure.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/07/07/backpressure.html
+++ b/content/2021/07/07/backpressure.html
@@ -463,6 +463,7 @@ the downstream task will have empty input buffers, while upstream output buffers
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/09/07/connector-table-sql-api-part1.html
+++ b/content/2021/09/07/connector-table-sql-api-part1.html
@@ -492,6 +492,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/2021/09/07/connector-table-sql-api-part1.html
+++ b/content/2021/09/07/connector-table-sql-api-part1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/09/07/connector-table-sql-api-part2.html
+++ b/content/2021/09/07/connector-table-sql-api-part2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/2021/09/07/connector-table-sql-api-part2.html
+++ b/content/2021/09/07/connector-table-sql-api-part2.html
@@ -746,6 +746,7 @@ user
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -2071,6 +2071,7 @@ This new release brings various improvements to the StateFun runtime, a leaner w
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -2074,6 +2074,7 @@ Please check the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -2068,6 +2068,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -2074,6 +2074,7 @@ what’s coming in Flink 1.4.0 as well as a preview of what the Flink community 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -2069,6 +2069,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -2067,6 +2067,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -2082,6 +2082,7 @@ release is a preview release that contains known issues.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page16/index.html
+++ b/content/blog/page16/index.html
@@ -2079,6 +2079,7 @@ and offers a new API including definition of flexible windows.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page16/index.html
+++ b/content/blog/page16/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page17/index.html
+++ b/content/blog/page17/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page17/index.html
+++ b/content/blog/page17/index.html
@@ -1957,6 +1957,7 @@ academic and open source project that Flink originates from.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -2068,6 +2068,7 @@ to develop scalable, consistent, and elastic distributed applications.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -2060,6 +2060,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -2066,6 +2066,7 @@ as well as increased observability for operational purposes.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -2074,6 +2074,7 @@ and provide a tutorial for running Streaming ETL with Flink on Zeppelin.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -2063,6 +2063,7 @@ This release marks a big milestone: Stateful Functions 2.0 is not only an API up
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -2060,6 +2060,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -2063,6 +2063,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -2066,6 +2066,7 @@ for more details.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -1199,6 +1199,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -749,6 +749,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -1605,6 +1605,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -1727,6 +1727,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/community.html
+++ b/content/community.html
@@ -907,6 +907,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/community.html
+++ b/content/community.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -703,6 +703,7 @@ Examples are in the RPC system, Network Stack, in the Task’s mailbox model, or
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -462,6 +462,7 @@ It is not required to strictly follow the SQL standard in regards of syntax and 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -455,6 +455,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -449,6 +449,7 @@ map.computeIfAbsent(key, Loader::load);
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -324,6 +324,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -399,6 +399,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -400,6 +400,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -514,6 +514,7 @@ Only committers have the permission to assign somebody.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -338,6 +338,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -830,6 +830,7 @@ translation effort.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -383,6 +383,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -374,6 +374,7 @@ git checkout asf-site
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -391,6 +391,7 @@ Please see the [Pull Request Review Guide](https://flink.apache.org/contributing
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -256,6 +256,7 @@ under the License.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -1303,6 +1303,7 @@ Flink Stateful Functions 2.0.0 - 2020-04-02
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -244,6 +244,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -408,6 +408,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -375,6 +375,7 @@ You can check the following articles for more details and here’s a list of <a 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -307,6 +307,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -444,6 +444,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -343,6 +343,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -408,6 +408,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -388,6 +388,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -391,6 +391,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -446,6 +446,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -345,6 +345,7 @@ Flink features two deployment modes for applications, the *framework mode* and t
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -316,6 +316,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -403,6 +403,7 @@ classpath from the cluster.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/index.html
+++ b/content/index.html
@@ -488,6 +488,7 @@ This new release brings various improvements to the StateFun runtime, a leaner w
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/index.html
+++ b/content/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/material.html
+++ b/content/material.html
@@ -361,6 +361,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/material.html
+++ b/content/material.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -336,6 +336,7 @@ robust, as well as breaking API changes.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -267,6 +267,7 @@ of the system. We suggest all users of Flink to work with this newest version.</
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -352,6 +352,7 @@ properties, some algorithms)</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -325,6 +325,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -340,6 +340,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -315,6 +315,7 @@ Flink serialization system improved a lot over time and by now surpasses the cap
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -339,6 +339,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -302,6 +302,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -899,6 +899,7 @@ internally, fault tolerance, and performance measurements!</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -369,6 +369,7 @@ a standalone Flink setup is now available.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -440,6 +440,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -320,6 +320,7 @@ programs.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -505,6 +505,7 @@ Improve usability of command line interface</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -444,6 +444,7 @@ The following figure shows how two objects are compared.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -292,6 +292,7 @@ including Apache Flink.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -504,6 +504,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -722,6 +722,7 @@ tools, graph database systems and sampling techniques.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -314,6 +314,7 @@ for this release:</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -317,6 +317,7 @@ register for the conference.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -1144,6 +1144,7 @@ Either <code>0 + absolutePointer</code> or <code>objectRefAddress + offset</code
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -428,6 +428,7 @@ Also note that some methods in the DataStream API had to be renamed as part of t
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -312,6 +312,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -410,6 +410,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -400,6 +400,7 @@ While you can embed Spouts/Bolts in a Flink program and mix-and-match them with 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -477,6 +477,7 @@ on the Flink mailing lists.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -290,6 +290,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -380,6 +380,7 @@ When using this backend, active state in streaming programs can grow well beyond
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -446,6 +446,7 @@ This feature will allow to prune unpromising event sequences early.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -324,6 +324,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -278,6 +278,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -299,6 +299,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -297,6 +297,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -382,6 +382,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -475,6 +475,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -284,6 +284,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -273,6 +273,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -327,6 +327,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -357,6 +357,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -447,6 +447,7 @@ enable the joining of a main, high-throughput stream with one more more inputs w
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -468,6 +468,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -527,6 +527,7 @@ If you have, for example, a flatMap() operator that keeps a running aggregate pe
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -326,6 +326,7 @@ We highly recommend all users to upgrade to Flink 1.1.5.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -430,6 +430,7 @@ The following paragraphs are not only supposed to give you a general overview of
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -438,6 +438,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -469,6 +469,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -282,6 +282,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -429,6 +429,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -400,6 +400,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -465,6 +465,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -388,6 +388,7 @@ list</a>.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -503,6 +503,7 @@ zhangminglei, zhe li, zhouhai02, zjureel, 付典, 军长, 宝牛, 淘江, 金竹
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -394,6 +394,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -428,6 +428,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -344,6 +344,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -313,6 +313,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -388,6 +388,7 @@ Feedback through the Flink <a href="http://flink.apache.org/community.html#maili
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -461,6 +461,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -394,6 +394,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -464,6 +464,7 @@ This allows only Flink components to talk to each other, making it impossible fo
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -366,6 +366,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -346,6 +346,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -433,6 +433,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -361,6 +361,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -387,6 +387,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -375,6 +375,7 @@ Special credits go to the following members for contributing to the 1.7.0 releas
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -357,6 +357,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -477,6 +477,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -402,6 +402,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -405,6 +405,7 @@ Once this effort is finished, we can add Blink’s scheduling and recovery strat
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -404,6 +404,7 @@ We highly recommend all users to upgrade to Flink 1.7.2.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -844,6 +844,7 @@ for a full reference of Flink’s metrics system.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -350,6 +350,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -303,6 +303,7 @@ I’m looking forward to meet you at Flink Forward San Francisco.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -533,6 +533,7 @@ release.  Special credits go to the following members for contributing to the
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -314,6 +314,7 @@ The documentation of Flink’s relational APIs has organically grown and can be 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -400,6 +400,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -627,6 +627,7 @@ zhangxin516, zhangxinxing, zhaofaxian, zhijiang, zjuwangg, 林小铂,
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -461,6 +461,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -344,6 +344,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -478,6 +478,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -447,6 +447,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -407,6 +407,7 @@ Transaction{timestamp=1563395831000, origin=1, target='3', amount=160}}
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -393,6 +393,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -465,6 +465,7 @@ To understand why this is the case, let us start with articulating a realistic s
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -492,6 +492,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -537,6 +537,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -484,6 +484,7 @@ However, you need to take care of another aspect, which is providing timestamps 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -476,6 +476,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -378,6 +378,7 @@ We encourage you to sign up for the <a href="https://flink.apache.org/community.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -448,6 +448,7 @@ There are actually a few more specialized data partitioning schemes in Flink whi
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -407,6 +407,7 @@ The upcoming release will focus on new features and integrations that broaden th
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -510,6 +510,7 @@ Because of this, Stateful Functions 2.0 can be thought of as an “Event-driven 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -566,6 +566,7 @@ Registering types with Kryo significantly improves its performance with only 64%
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -362,6 +362,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -384,6 +384,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -336,6 +336,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -489,6 +489,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -640,6 +640,7 @@ FLINK-16683 Flink no longer supports starting clusters with .bat scripts. Users 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -347,6 +347,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -384,6 +384,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -361,6 +361,7 @@ And here’s a list of <a href="https://www.youtube.com/watch?v=YxPo0Fosjjg&amp;
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -604,6 +604,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -550,6 +550,7 @@ and, hopefully, see you (virtually) at one of our conferences or meetups soon!</
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -401,6 +401,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -487,6 +487,7 @@ As a reminder, you no longer need to ask for contributor permissions to start co
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -918,6 +918,7 @@ face of ever-increasing data volumes.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -388,6 +388,7 @@ is finished. If you have any suggestions or questions for the community, we enco
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -357,6 +357,7 @@ Please refer to the user@flink.apache.org (<a href="https://flink.apache.org/com
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -465,6 +465,7 @@ After FLINK-17800 by default we will set <code>setTotalOrderSeek</code> to true 
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -510,6 +510,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -500,6 +500,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -445,6 +445,7 @@ for a detailed list of changes and new features if you plan to upgrade your setu
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -478,6 +478,7 @@ StateFun cluster, and an AWS S3 bucket to store the periodic checkpoints. You ca
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -316,6 +316,7 @@ mailing lists as soon as this is ready, so please subscribe to the mailing lists
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -617,6 +617,7 @@ With the new release, Flink SQL supports <strong>metadata columns</strong> to re
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/12/18/release-1.11.3.html
+++ b/content/news/2020/12/18/release-1.11.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2020/12/18/release-1.11.3.html
+++ b/content/news/2020/12/18/release-1.11.3.html
@@ -620,6 +620,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/01/02/release-statefun-2.2.2.html
+++ b/content/news/2021/01/02/release-statefun-2.2.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/01/02/release-statefun-2.2.2.html
+++ b/content/news/2021/01/02/release-statefun-2.2.2.html
@@ -295,6 +295,7 @@ older versions earlier than StateFun 2.2.1. Previously, restoring from savepoint
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
+++ b/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
@@ -383,6 +383,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
+++ b/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/01/19/release-1.12.1.html
+++ b/content/news/2021/01/19/release-1.12.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/01/19/release-1.12.1.html
+++ b/content/news/2021/01/19/release-1.12.1.html
@@ -477,6 +477,7 @@ Using <b>unaligned checkpoints in Flink 1.12.0</b> combined with two/multiple in
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/01/29/release-1.10.3.html
+++ b/content/news/2021/01/29/release-1.10.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/01/29/release-1.10.3.html
+++ b/content/news/2021/01/29/release-1.10.3.html
@@ -375,6 +375,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/03/03/release-1.12.2.html
+++ b/content/news/2021/03/03/release-1.12.2.html
@@ -480,6 +480,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/03/03/release-1.12.2.html
+++ b/content/news/2021/03/03/release-1.12.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/04/15/release-statefun-3.0.0.html
+++ b/content/news/2021/04/15/release-statefun-3.0.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/04/15/release-statefun-3.0.0.html
+++ b/content/news/2021/04/15/release-statefun-3.0.0.html
@@ -461,6 +461,7 @@ or <a href="https://issues.apache.org/jira/browse/">JIRA</a></p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -447,6 +447,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/05/03/release-1.13.0.html
+++ b/content/news/2021/05/03/release-1.13.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/05/03/release-1.13.0.html
+++ b/content/news/2021/05/03/release-1.13.0.html
@@ -882,6 +882,7 @@ zhushang, zhuxiaoshang, Zhu Zhu, zjuwangg, zoucao, zoudan, 左元, 星, 肖佳�
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/05/21/release-1.12.4.html
+++ b/content/news/2021/05/21/release-1.12.4.html
@@ -341,6 +341,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/05/21/release-1.12.4.html
+++ b/content/news/2021/05/21/release-1.12.4.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/05/28/release-1.13.1.html
+++ b/content/news/2021/05/28/release-1.13.1.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/05/28/release-1.13.1.html
+++ b/content/news/2021/05/28/release-1.13.1.html
@@ -409,6 +409,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/06/release-1.12.5.html
+++ b/content/news/2021/08/06/release-1.12.5.html
@@ -451,6 +451,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/06/release-1.12.5.html
+++ b/content/news/2021/08/06/release-1.12.5.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/08/06/release-1.13.2.html
+++ b/content/news/2021/08/06/release-1.13.2.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/08/06/release-1.13.2.html
+++ b/content/news/2021/08/06/release-1.13.2.html
@@ -565,6 +565,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/09/release-1.11.4.html
+++ b/content/news/2021/08/09/release-1.11.4.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/08/09/release-1.11.4.html
+++ b/content/news/2021/08/09/release-1.11.4.html
@@ -461,6 +461,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/31/release-1.14.0-rc0.html
+++ b/content/news/2021/08/31/release-1.14.0-rc0.html
@@ -288,6 +288,7 @@ the <a href="https://flink.apache.org/gettinghelp.html#user-mailing-list">mailin
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/31/release-1.14.0-rc0.html
+++ b/content/news/2021/08/31/release-1.14.0-rc0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/08/31/release-statefun-3.1.0.html
+++ b/content/news/2021/08/31/release-statefun-3.1.0.html
@@ -478,6 +478,7 @@ for a detailed list of changes and new features if you plan to upgrade your setu
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/news/2021/08/31/release-statefun-3.1.0.html
+++ b/content/news/2021/08/31/release-statefun-3.1.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/09/29/release-1.14.0.html
+++ b/content/news/2021/09/29/release-1.14.0.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/news/2021/09/29/release-1.14.0.html
+++ b/content/news/2021/09/29/release-1.14.0.html
@@ -632,6 +632,7 @@ Zhu, zlzhang0122, zoran, Zor X. LIU, zoucao, Zsombor Chikan, 子扬, 莫辞</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -396,6 +396,7 @@ $(document).ready(function() {
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -265,6 +265,7 @@ manner and for the purpose described above.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/project.html
+++ b/content/project.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/project.html
+++ b/content/project.html
@@ -247,6 +247,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -579,6 +579,7 @@ of the documentation.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/security.html
+++ b/content/security.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/security.html
+++ b/content/security.html
@@ -316,6 +316,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/slides.html
+++ b/content/slides.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/slides.html
+++ b/content/slides.html
@@ -256,6 +256,7 @@ under the License.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -449,6 +449,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/training.html
+++ b/content/training.html
@@ -345,6 +345,7 @@ Hence the margin-bottom on the div above.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/training.html
+++ b/content/training.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -349,6 +349,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -882,6 +882,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -701,6 +701,7 @@ Examples are in the RPC system, Network Stack, in the Task’s mailbox model, or
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -458,6 +458,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -453,6 +453,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -447,6 +447,7 @@ map.computeIfAbsent(key, Loader::load);
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-preamble.html
+++ b/content/zh/contributing/code-style-and-quality-preamble.html
@@ -314,6 +314,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-preamble.html
+++ b/content/zh/contributing/code-style-and-quality-preamble.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -397,6 +397,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -398,6 +398,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -511,6 +511,7 @@ Flink 社区考虑了以下几个方面：
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -334,6 +334,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -801,6 +801,7 @@ translation effort.</p>
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -383,6 +383,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -368,6 +368,7 @@ git checkout asf-site
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -390,6 +390,7 @@ Please see the [Pull Request Review Guide](https://flink.apache.org/contributing
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -1207,6 +1207,7 @@ Flink 0.6-incubating - 2014-08-26
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -239,6 +239,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -458,6 +458,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -355,6 +355,7 @@ Flink 提供了两种应用程序部署模式，即 *框架模式* 和 *库模�
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -327,6 +327,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -384,6 +384,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -485,6 +485,7 @@ This new release brings various improvements to the StateFun runtime, a leaner w
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -359,6 +359,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -395,6 +395,7 @@ $(document).ready(function() {
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -565,6 +565,7 @@ Flink的容错机制多年来运行非常稳定，但是我们还是想让整个
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/security.html
+++ b/content/zh/security.html
@@ -314,6 +314,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/security.html
+++ b/content/zh/security.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -447,6 +447,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -448,6 +448,7 @@ Hence the margin-bottom on the div above.
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -27,6 +27,17 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
+
   </head>
   <body>  
     

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -346,6 +346,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-52545728-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </body>


### PR DESCRIPTION
Google has a new implementation to track website behaviour, called GA4. This will replace the existing UA implementations and is not compatible with the current version of tracking behaviour. 

This PR implements the GA4 tracking next to the UA tracking, so that at a later stage the UA tracking can be removed. 

Commit a928385c0f8ccc66bdf8f29ae8e968a1b1754563 makes sure that the old implementation anonymises IP addresses by default. The new implementation already does this by default. See https://support.google.com/analytics/answer/2763052?hl=en