### PR TITLE
[FLINK-25096] Adds pointer to custom Assert implementations in flink-test-utils-junit

### DIFF
--- a/contributing/code-style-and-quality-common.md
+++ b/contributing/code-style-and-quality-common.md
@@ -322,6 +322,10 @@ assertThat(list)
     .allMatch(item -> item.length() < 10);
 ```
 
+Flink-specific custom Asserts are located in `flink-test-utils-junit` under `org.apache.flink.core.testutils.assertj`.
+Classes in this package should replace the deprecated `org.apache.flink.core.testutils.FlinkMatchers` in the long run.
+See`FlinkThrowableAssert` on details about how to implement a custom `Assert` and how to use it in tests.
+
 ### Write targeted tests
 
 * <span style="text-decoration:underline;">Test contracts not implementations</span>: Test that after a sequence of actions, the components are in a certain state, rather than testing that the components followed a sequence of internal state modifications.


### PR DESCRIPTION
Adds pointer to custom Flink Assert implementations that were added in the context of FLINK-25096. (related [Flink PR #17967](https://github.com/apache/flink/pull/17967)