### PR TITLE
[FLINK-25881][Website] Fix subdomain tracking and update privacy policy

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/01/07/pulsar-flink-connector-270.html
+++ b/content/2021/01/07/pulsar-flink-connector-270.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/01/18/rocksdb.html
+++ b/content/2021/01/18/rocksdb.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/02/10/native-k8s-with-ha.html
+++ b/content/2021/02/10/native-k8s-with-ha.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/03/11/batch-execution-mode.html
+++ b/content/2021/03/11/batch-execution-mode.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/05/06/reactive-mode.html
+++ b/content/2021/05/06/reactive-mode.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/07/07/backpressure.html
+++ b/content/2021/07/07/backpressure.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/09/07/connector-table-sql-api-part1.html
+++ b/content/2021/09/07/connector-table-sql-api-part1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/09/07/connector-table-sql-api-part2.html
+++ b/content/2021/09/07/connector-table-sql-api-part2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/10/26/sort-shuffle-part1.html
+++ b/content/2021/10/26/sort-shuffle-part1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/10/26/sort-shuffle-part2.html
+++ b/content/2021/10/26/sort-shuffle-part2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/11/03/flink-backward.html
+++ b/content/2021/11/03/flink-backward.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2021/12/10/log4j-cve.html
+++ b/content/2021/12/10/log4j-cve.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2022/01/04/scheduler-performance-part-one.html
+++ b/content/2022/01/04/scheduler-performance-part-one.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2022/01/04/scheduler-performance-part-two.html
+++ b/content/2022/01/04/scheduler-performance-part-two.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/2022/01/20/pravega-connector-101.html
+++ b/content/2022/01/20/pravega-connector-101.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page16/index.html
+++ b/content/blog/page16/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page17/index.html
+++ b/content/blog/page17/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page18/index.html
+++ b/content/blog/page18/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/community.html
+++ b/content/community.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/index.html
+++ b/content/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/material.html
+++ b/content/material.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2020/12/18/release-1.11.3.html
+++ b/content/news/2020/12/18/release-1.11.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/01/02/release-statefun-2.2.2.html
+++ b/content/news/2021/01/02/release-statefun-2.2.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
+++ b/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/01/19/release-1.12.1.html
+++ b/content/news/2021/01/19/release-1.12.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/01/29/release-1.10.3.html
+++ b/content/news/2021/01/29/release-1.10.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/03/03/release-1.12.2.html
+++ b/content/news/2021/03/03/release-1.12.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/04/15/release-statefun-3.0.0.html
+++ b/content/news/2021/04/15/release-statefun-3.0.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/05/03/release-1.13.0.html
+++ b/content/news/2021/05/03/release-1.13.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/05/21/release-1.12.4.html
+++ b/content/news/2021/05/21/release-1.12.4.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/05/28/release-1.13.1.html
+++ b/content/news/2021/05/28/release-1.13.1.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/08/06/release-1.12.5.html
+++ b/content/news/2021/08/06/release-1.12.5.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/08/06/release-1.13.2.html
+++ b/content/news/2021/08/06/release-1.13.2.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/08/09/release-1.11.4.html
+++ b/content/news/2021/08/09/release-1.11.4.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/08/31/release-1.14.0-rc0.html
+++ b/content/news/2021/08/31/release-1.14.0-rc0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/08/31/release-statefun-3.1.0.html
+++ b/content/news/2021/08/31/release-statefun-3.1.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/09/29/release-1.14.0.html
+++ b/content/news/2021/09/29/release-1.14.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/10/19/release-1.13.3.html
+++ b/content/news/2021/10/19/release-1.13.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/12/16/log4j-patch-releases.html
+++ b/content/news/2021/12/16/log4j-patch-releases.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2021/12/22/log4j-statefun-release.html
+++ b/content/news/2021/12/22/log4j-statefun-release.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2022/01/07/release-ml-2.0.0.html
+++ b/content/news/2022/01/07/release-ml-2.0.0.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/news/2022/01/17/release-1.14.3.html
+++ b/content/news/2022/01/17/release-1.14.3.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/privacy-policy.html
+++ b/content/privacy-policy.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
@@ -213,31 +215,40 @@
   <div class="col-sm-12">
     <h1>Privacy Policy</h1>
 
-	<p>Information about your use of this website is collected using server access
-logs and a tracking cookie. The collected information consists of the
-following:</p>
+	<p>Information about your use of this website is collected using server access logs.
+We do this to understand what parts of the website are important to our users, 
+what features are most frequently read up on, where users get lost in the documentation, etc. 
+This data allows us to better understand how users use the system, the website, and the docs 
+and where to focus improvements next.</p>
+
+<p>The collected information consists of the following:</p>
 
 <ol>
   <li>The IP address from which you access the website;</li>
   <li>The type of browser and operating system you use to access our site;</li>
   <li>The date and time you access our site;</li>
-  <li>The pages you visit; and</li>
-  <li>The addresses of pages from where you followed a link to our site.</li>
+  <li>The pages you visit;</li>
+  <li>If you click on any of the file download links on our website;</li>
+  <li>The addresses of pages from where you followed a link to our site;</li>
+  <li>The addresses of pages to where you go to from our site; and</li>
+  <li>The search terms you use on the website.</li>
 </ol>
 
-<p>Part of this information is gathered using a tracking cookie set by the
-<a href="http://www.google.com/analytics/">Google Analytics</a> service and handled by
-Google as described in their <a href="http://www.google.com/privacy.html">privacy policy</a>.
-See your browser documentation for instructions on how to disable the cookie
-if you prefer not to share this data with Google.</p>
+<p>This information is gathered and stored using the open source software <a href="https://matomo.org/">Matomo</a>.
+We don’t use any cookies to collect this information. An IP address is anonymized by removing 
+the last two octets from the IP address. That means that if you’re IP is 192.168.100.50, we store it as
+192.168.0.0.</p>
 
-<p>We use the gathered information to help us make our site more useful to
-visitors and to better understand how and when our site is used. We do not
-track or collect personally identifiable information or associate gathered
+<p>We do not track or collect personally identifiable information or associate gathered
 data with any personally identifying information from other sources.</p>
 
-<p>By using this website, you consent to the collection of this data in the
-manner and for the purpose described above.</p>
+<p>Matomo is self-hosted on a virtual machine, provided by the Apache Software Foundation. 
+It can only be accessed by Flink PMC members and members of the Apache Privacy committee. 
+The data can be viewed by anyone by visiting <a href="https://matomo.privacy.apache.org/">https://matomo.privacy.apache.org/</a>.</p>
+
+<p>Matomo respects any Do Not Track setting in your browser. You can also opt-out from all Matomo tracking below.</p>
+
+<iframe style="border: 0; height: 200px; width: 600px;" src="https://matomo.privacy.apache.org/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en&amp;backgroundColor=&amp;fontColor=&amp;fontSize=14px&amp;fontFamily=%22Helvetica%20Neue%22%2CHelvetica%2CArial%2Csans-serif"></iframe>
 
 
   </div>

--- a/content/project.html
+++ b/content/project.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/security.html
+++ b/content/security.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/slides.html
+++ b/content/slides.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/training.html
+++ b/content/training.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/privacy-policy.html
+++ b/content/zh/privacy-policy.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>Apache Flink: Apache Flink 代码风格和质量指南 — 序言</title>
+    <title>Apache Flink: Privacy Policy</title>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
@@ -112,7 +112,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">教程<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://nightlies.apache.org/flink/flink-docs-release-1.14/zh//docs/try-flink/local_installation/" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://nightlies.apache.org/flink/flink-statefun-docs-release-3.2/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://nightlies.apache.org/flink/flink-statefun-docs-release-3.1/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="/zh/training.html">Training Course</a></li>
               </ul>
             </li>
@@ -123,7 +123,7 @@
               <ul class="dropdown-menu">
                 <li><a href="https://nightlies.apache.org/flink/flink-docs-release-1.14" target="_blank">Flink 1.14 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://nightlies.apache.org/flink/flink-docs-master" target="_blank">Flink Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
-                <li><a href="https://nightlies.apache.org/flink/flink-statefun-docs-release-3.2" target="_blank">Flink Stateful Functions 3.2 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="https://nightlies.apache.org/flink/flink-statefun-docs-release-3.1" target="_blank">Flink Stateful Functions 3.1 (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="https://nightlies.apache.org/flink/flink-statefun-docs-master" target="_blank">Flink Stateful Functions Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
@@ -152,27 +152,6 @@
             <!-- Contribute -->
             <li><a href="/zh/contributing/how-to-contribute.html">如何参与贡献</a></li>
             
-            <ul class="nav navbar-nav navbar-subnav">
-              <li >
-                  <a href="/zh/contributing/contribute-code.html">贡献代码</a>
-              </li>
-              <li >
-                  <a href="/zh/contributing/reviewing-prs.html">审核 Pull Request</a>
-              </li>
-              <li  class="active">
-                  <a href="/zh/contributing/code-style-and-quality-preamble.html">代码样式与质量指南</a>
-              </li>
-              <li >
-                  <a href="/zh/contributing/contribute-documentation.html">贡献文档</a>
-              </li>
-              <li >
-                  <a href="/zh/contributing/docs-style.html">Documentation Style Guide</a>
-              </li>
-              <li >
-                  <a href="/zh/contributing/improve-website.html">贡献网站</a>
-              </li>
-            </ul>
-            
 
             <!-- GitHub -->
             <li>
@@ -184,7 +163,7 @@
             <!-- Language Switcher -->
             <li>
               
-                <a href="/contributing/code-style-and-quality-preamble.html">English</a>
+                <a href="/privacy-policy.html">English</a>
               
             </li>
 
@@ -232,63 +211,42 @@
       <div class="col-sm-9">
       <div class="row-fluid">
   <div class="col-sm-12">
-    <h1>Apache Flink 代码风格和质量指南 — 序言</h1>
+    <h1>Privacy Policy</h1>
 
-	
-<ul class="list-group" style="padding-top: 30px; font-weight: bold;">
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-preamble.html">
-			序言
-		</a>
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-pull-requests.html">
-			Pull Requests &amp; Changes
-		</a>
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-common.html">
-			常用编码指南
-		</a> 
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-java.html">
-			Java 语言指南
-		</a> 
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-scala.html">
-			Scala 语言指南
-		</a> 
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-components.html">
-			组件指南
-		</a> 
-	</li>
-	<li class="list-group-item">
-		<a href="/zh/contributing/code-style-and-quality-formatting.html">
-			格式指南
-		</a> 
-	</li>
-</ul>
+	<p>Information about your use of this website is collected using server access logs.
+We do this to understand what parts of the website are important to our users,
+what features are most frequently read up on, where users get lost in the documentation, etc.
+This data allows us to better understand how users use the system, the website, and the docs
+and where to focus improvements next.</p>
 
-<hr />
+<p>The collected information consists of the following:</p>
 
-<p>这是对我们想要维护的代码和质量标准的一种尝试。</p>
+<ol>
+  <li>The IP address from which you access the website;</li>
+  <li>The type of browser and operating system you use to access our site;</li>
+  <li>The date and time you access our site;</li>
+  <li>The pages you visit;</li>
+  <li>If you click on any of the file download links on our website;</li>
+  <li>The addresses of pages from where you followed a link to our site;</li>
+  <li>The addresses of pages to where you go to from our site; and</li>
+  <li>The search terms you use on the website.</li>
+</ol>
 
-<p>一次代码贡献(或者任何代码片段)可以从很多角度进行评价：一组评判标准是代码是否正确和高效。这需要正确且良好的解决<em>逻辑或算法</em>问题。</p>
+<p>This information is gathered and stored using the open source software <a href="https://matomo.org/">Matomo</a>.
+We don’t use any cookies to collect this information. An IP address is anonymized by removing
+the last two octets from the IP address. That means that if you’re IP is 192.168.100.50, we store it as
+192.168.0.0.</p>
 
-<p>另一组评判标准是代码是否使用了简洁的设计和架构，是否通过概念分离实现了良好的架构，是否足够简单易懂并且明确假设。该评判标准需要良好的解决软件工程问题。一个好的解决方案需要代码是容易被测试的，可以被除了原作者之外的其他人维护的（因为打破之后再维护是非常困难的），同时还需要能够高效的迭代演进的。</p>
+<p>We do not track or collect personally identifiable information or associate gathered
+data with any personally identifying information from other sources.</p>
 
-<p>不过第一组标准有相当客观的达成条件，相比之下要达到第二组评判标准更加困难，但是对于 Apache Flink 这样的开源项目来说却非常重要。为了能够吸引更多贡献者，为了的开源贡献能够更容易被开发者理解，同时也为了众多开发者同时开发时代码的健壮性，良好工程化的代码是至关重要的。对于良好的工程代码来说，更加容易保证代码的正确性和高效不会随着时间的推移受到影响</p>
+<p>Matomo is self-hosted on a virtual machine, provided by the Apache Software Foundation.
+It can only be accessed by Flink PMC members and members of the Apache Privacy committee.
+The data can be viewed by anyone by visiting <a href="https://matomo.privacy.apache.org/">https://matomo.privacy.apache.org/</a>.</p>
 
-<p>当然，本指南并不是一份如何写出良好的工程代码的全方位指导。有相当多的书籍尝试说明如何实现良好的代码。本指南只是作为最佳实践的检查清单，包括我们在开发 Flink 过程中遇到的模式，反模式和常见错误。</p>
+<p>Matomo respects any Do Not Track setting in your browser. You can also opt-out from all Matomo tracking below.</p>
 
-<p>高质量的开源代码很大一部分是关于帮助 reviewer 理解和双重检查执行结果。所以，本指南的一个重要目的是关于如何为为 review  构建一个良好的 pull request</p>
-
-<hr />
-
+<iframe style="border: 0; height: 200px; width: 600px;" src="https://matomo.privacy.apache.org/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en&amp;backgroundColor=&amp;fontColor=&amp;fontSize=14px&amp;fontFamily=%22Helvetica%20Neue%22%2CHelvetica%2CArial%2Csans-serif"></iframe>
 
 
   </div>

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/security.html
+++ b/content/zh/security.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -33,6 +33,8 @@
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
       /* We explicitly disable cookie tracking to avoid privacy issues */
       _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink as the same visit */
+      _paq.push(["setDomains", ["*.flink.apache.org","*.nightlies.apache.org/flink"]]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {

--- a/privacy-policy.zh.md
+++ b/privacy-policy.zh.md
@@ -3,9 +3,9 @@ title: "Privacy Policy"
 ---
 
 Information about your use of this website is collected using server access logs.
-We do this to understand what parts of the website are important to our users, 
-what features are most frequently read up on, where users get lost in the documentation, etc. 
-This data allows us to better understand how users use the system, the website, and the docs 
+We do this to understand what parts of the website are important to our users,
+what features are most frequently read up on, where users get lost in the documentation, etc.
+This data allows us to better understand how users use the system, the website, and the docs
 and where to focus improvements next.
 
 The collected information consists of the following:
@@ -20,15 +20,15 @@ The collected information consists of the following:
 8. The search terms you use on the website.
 
 This information is gathered and stored using the open source software [Matomo](https://matomo.org/).
-We don't use any cookies to collect this information. An IP address is anonymized by removing 
+We don't use any cookies to collect this information. An IP address is anonymized by removing
 the last two octets from the IP address. That means that if you're IP is 192.168.100.50, we store it as
-192.168.0.0. 
+192.168.0.0.
 
 We do not track or collect personally identifiable information or associate gathered
 data with any personally identifying information from other sources.
 
-Matomo is self-hosted on a virtual machine, provided by the Apache Software Foundation. 
-It can only be accessed by Flink PMC members and members of the Apache Privacy committee. 
+Matomo is self-hosted on a virtual machine, provided by the Apache Software Foundation.
+It can only be accessed by Flink PMC members and members of the Apache Privacy committee.
 The data can be viewed by anyone by visiting [https://matomo.privacy.apache.org/](https://matomo.privacy.apache.org/).
 
 Matomo respects any Do Not Track setting in your browser. You can also opt-out from all Matomo tracking below.


### PR DESCRIPTION
This PR addresses two things:

* e2377218c6ed9a8be3ae6e257776c8f08457ea96 makes sure that visits to flink.apache.org and nightlies.apache.org/flink are recognized from one to another
* 01f687376764106696efce2ea056ba54f68e7ae4 updates the privacy policy, removes all references to Google Analytics and includes and opt-out. Since there was no Chinese translation, the English version is now also available. https://issues.apache.org/jira/browse/FLINK-25882 has been created for a Chinese translation, after this PR is approved and merged. 