### PR TITLE
Restore verification for Google Search Console

### DIFF
--- a/content/googleae6c28c3c24290e6.html
+++ b/content/googleae6c28c3c24290e6.html
@@ -1,0 +1,1 @@
+google-site-verification: googleae6c28c3c24290e6.html

--- a/googleae6c28c3c24290e6.html
+++ b/googleae6c28c3c24290e6.html
@@ -1,0 +1,1 @@
+google-site-verification: googleae6c28c3c24290e6.html


### PR DESCRIPTION
Verification was previously done via Google Analytics, but since we have removed that the verification was also removed. This PR restores that verification by including a simple HTML file which Google periodically checks. 