### PR TITLE
[FLINK-26781] Link Flink Kubernetes operator doc site to Flink Website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,13 @@ FLINK_ML_STABLE_SHORT: "2.0"
 FLINK_ML_GITHUB_URL: https://github.com/apache/flink-ml
 FLINK_ML_GITHUB_REPO_NAME: flink-ml
 
+#TODO If kubernetes operator stable version complete,replace it to stable version
+FLINK_KUBERNETES_OPERATOR_VERSION_STABLE: 1.0
+FLINK_KUBERNETES_OPERATOR_STABLE_SHORT: "1.0"
+
+FLINK_KUBERNETES_OPERATOR_URL: https://github.com/apache/flink-kubernetes-operator
+FLINK_KUBERNETES_OPERATOR_GITHUB_REPO_NAME: flink-kubernetes-operator
+
 # Example for scala dependent component:
 #  -
 #    name: "Prometheus MetricReporter"
@@ -615,6 +622,10 @@ docs-statefun-snapshot: "https://nightlies.apache.org/flink/flink-statefun-docs-
 
 docs-ml-stable: "https://nightlies.apache.org/flink/flink-ml-docs-release-2.0"
 docs-ml-snapshot: "https://nightlies.apache.org/flink/flink-ml-docs-master"
+
+#TODO If kubernetes operator stable version complete,replace it to stable url
+docs-kubernetes-operator-stable: "https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main"
+docs-kubernetes-operator-snapshot: "https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main"
 
 # Used by the gh_link plugin
 jira: "https://issues.apache.org/jira/browse/FLINK"

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -76,6 +76,7 @@
                 <li><a href="{{ site.docs-stable }}/{% if page.language != 'en' %}{{ page.language }}/{% endif %}/docs/try-flink/local_installation/" target="_blank">With Flink <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-statefun-stable }}/getting-started/project-setup.html" target="_blank">With Flink Stateful Functions <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-ml-stable }}/try-flink-ml/quick-start.html" target="_blank">With Flink ML <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ site.docs-kubernetes-operator-stable }}/try-flink-kubernetes-operator/quick-start.html" target="_blank">With Flink Kubernetes Operator <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ baseurl_i18n }}/training.html">{{ site.data.i18n[page.language].training_course }}</a></li>
               </ul>
             </li>
@@ -90,6 +91,8 @@
                 <li><a href="{{ site.docs-statefun-snapshot }}" target="_blank">Flink Stateful Functions Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-ml-stable }}" target="_blank">Flink ML {{site.FLINK_ML_STABLE_SHORT}} (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
                 <li><a href="{{ site.docs-ml-snapshot }}" target="_blank">Flink ML Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ site.docs-kubernetes-operator-stable }}" target="_blank">Flink Kubernetes Operator {{site.FLINK_KUBERNETES_OPERATOR_STABLE_SHORT}} (Latest stable release) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
+                <li><a href="{{ site.docs-kubernetes-operator-snapshot }}" target="_blank">Flink Kubernetes Operator Master (Latest Snapshot) <small><span class="glyphicon glyphicon-new-window"></span></small></a></li>
               </ul>
             </li>
 


### PR DESCRIPTION
Link Flink Kubernetes operator doc site to Flink Website. There is no stable version yet as we are still working toward our first preview release in 1-2 weeks. We should only have snapshot docs now