### PR TITLE
[FLINK-27049] Add 'What is Flink Kubernetes Operator?' link to flink website

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -2,6 +2,7 @@ en:
     what_is_flink: What is Apache Flink?
     what_is_statefun: What is Stateful Functions?
     what_is_flink_ml: What is Flink ML?
+    what_is_flink_kubernetes_operator: What is Flink Kubernetes Operator?
     flink_architecture: Architecture
     flink_applications: Applications
     flink_operations: Operations
@@ -31,6 +32,7 @@ zh:
     what_is_flink: Apache Flink 是什么?
     what_is_statefun: What is Stateful Functions?
     what_is_flink_ml: Flink ML是什么?
+    what_is_flink_kubernetes_operator: Flink Kubernetes Operator 是什么?
     flink_architecture: 架构
     flink_applications: 应用
     flink_operations: 运维

--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -2,7 +2,7 @@ en:
     what_is_flink: What is Apache Flink?
     what_is_statefun: What is Stateful Functions?
     what_is_flink_ml: What is Flink ML?
-    what_is_flink_kubernetes_operator: What is Flink Kubernetes Operator?
+    what_is_flink_kubernetes_operator: What is the Flink Kubernetes Operator?
     flink_architecture: Architecture
     flink_applications: Applications
     flink_operations: Operations

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -58,7 +58,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">{{ site.data.i18n[page.language].what_is_flink_kubernetes_operator }}</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">{{ site.data.i18n[page.language].what_is_flink_kubernetes_operator }}</a></li>
 
             <!-- Use cases -->
             <li{% if page.url contains '/usecases.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/usecases.html">{{ site.data.i18n[page.language].use_case }}</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -56,6 +56,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">{{ site.data.i18n[page.language].what_is_flink_ml }}</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">{{ site.data.i18n[page.language].what_is_flink_kubernetes_operator }}</a></li>
+
             <!-- Use cases -->
             <li{% if page.url contains '/usecases.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/usecases.html">{{ site.data.i18n[page.language].use_case }}</a></li>
 

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/05/03/pulsar-flink.html
+++ b/content/2019/05/03/pulsar-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/05/14/temporal-tables.html
+++ b/content/2019/05/14/temporal-tables.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/05/19/state-ttl.html
+++ b/content/2019/05/19/state-ttl.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/06/05/flink-network-stack.html
+++ b/content/2019/06/05/flink-network-stack.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/06/26/broadcast-state.html
+++ b/content/2019/06/26/broadcast-state.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2019/07/23/flink-network-stack-2.html
+++ b/content/2019/07/23/flink-network-stack-2.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/04/09/pyflink-udf-support-flink.html
+++ b/content/2020/04/09/pyflink-udf-support-flink.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/07/23/catalogs.html
+++ b/content/2020/07/23/catalogs.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
+++ b/content/2020/07/28/flink-sql-demo-building-e2e-streaming-application.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/08/04/pyflink-pandas-udf-support-flink.html
+++ b/content/2020/08/04/pyflink-pandas-udf-support-flink.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/08/19/statefun.html
+++ b/content/2020/08/19/statefun.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/09/01/flink-1.11-memory-management-improvements.html
+++ b/content/2020/09/01/flink-1.11-memory-management-improvements.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2020/12/15/pipelined-region-sheduling.html
+++ b/content/2020/12/15/pipelined-region-sheduling.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/01/07/pulsar-flink-connector-270.html
+++ b/content/2021/01/07/pulsar-flink-connector-270.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/01/07/pulsar-flink-connector-270.html
+++ b/content/2021/01/07/pulsar-flink-connector-270.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/01/18/rocksdb.html
+++ b/content/2021/01/18/rocksdb.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/01/18/rocksdb.html
+++ b/content/2021/01/18/rocksdb.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/02/10/native-k8s-with-ha.html
+++ b/content/2021/02/10/native-k8s-with-ha.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/02/10/native-k8s-with-ha.html
+++ b/content/2021/02/10/native-k8s-with-ha.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/03/11/batch-execution-mode.html
+++ b/content/2021/03/11/batch-execution-mode.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/03/11/batch-execution-mode.html
+++ b/content/2021/03/11/batch-execution-mode.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/05/06/reactive-mode.html
+++ b/content/2021/05/06/reactive-mode.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/05/06/reactive-mode.html
+++ b/content/2021/05/06/reactive-mode.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/07/07/backpressure.html
+++ b/content/2021/07/07/backpressure.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/07/07/backpressure.html
+++ b/content/2021/07/07/backpressure.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/09/07/connector-table-sql-api-part1.html
+++ b/content/2021/09/07/connector-table-sql-api-part1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/09/07/connector-table-sql-api-part1.html
+++ b/content/2021/09/07/connector-table-sql-api-part1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/09/07/connector-table-sql-api-part2.html
+++ b/content/2021/09/07/connector-table-sql-api-part2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/09/07/connector-table-sql-api-part2.html
+++ b/content/2021/09/07/connector-table-sql-api-part2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/10/26/sort-shuffle-part1.html
+++ b/content/2021/10/26/sort-shuffle-part1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/10/26/sort-shuffle-part1.html
+++ b/content/2021/10/26/sort-shuffle-part1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/10/26/sort-shuffle-part2.html
+++ b/content/2021/10/26/sort-shuffle-part2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/10/26/sort-shuffle-part2.html
+++ b/content/2021/10/26/sort-shuffle-part2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/11/03/flink-backward.html
+++ b/content/2021/11/03/flink-backward.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/11/03/flink-backward.html
+++ b/content/2021/11/03/flink-backward.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2021/12/10/log4j-cve.html
+++ b/content/2021/12/10/log4j-cve.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2021/12/10/log4j-cve.html
+++ b/content/2021/12/10/log4j-cve.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/01/04/scheduler-performance-part-one.html
+++ b/content/2022/01/04/scheduler-performance-part-one.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/01/04/scheduler-performance-part-one.html
+++ b/content/2022/01/04/scheduler-performance-part-one.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/01/04/scheduler-performance-part-two.html
+++ b/content/2022/01/04/scheduler-performance-part-two.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/01/04/scheduler-performance-part-two.html
+++ b/content/2022/01/04/scheduler-performance-part-two.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/01/20/pravega-connector-101.html
+++ b/content/2022/01/20/pravega-connector-101.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/01/20/pravega-connector-101.html
+++ b/content/2022/01/20/pravega-connector-101.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/02/22/scala-free.html
+++ b/content/2022/02/22/scala-free.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/02/22/scala-free.html
+++ b/content/2022/02/22/scala-free.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/06/async-sink-base.html
+++ b/content/2022/05/06/async-sink-base.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/06/async-sink-base.html
+++ b/content/2022/05/06/async-sink-base.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/06/pyflink-1.15-thread-mode.html
+++ b/content/2022/05/06/pyflink-1.15-thread-mode.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/06/pyflink-1.15-thread-mode.html
+++ b/content/2022/05/06/pyflink-1.15-thread-mode.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/06/restore-modes.html
+++ b/content/2022/05/06/restore-modes.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/06/restore-modes.html
+++ b/content/2022/05/06/restore-modes.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/18/latency-part1.html
+++ b/content/2022/05/18/latency-part1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/18/latency-part1.html
+++ b/content/2022/05/18/latency-part1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/23/latency-part2.html
+++ b/content/2022/05/23/latency-part2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/23/latency-part2.html
+++ b/content/2022/05/23/latency-part2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/05/30/changelog-state-backend.html
+++ b/content/2022/05/30/changelog-state-backend.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/05/30/changelog-state-backend.html
+++ b/content/2022/05/30/changelog-state-backend.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/2022/06/17/adaptive-batch-scheduler.html
+++ b/content/2022/06/17/adaptive-batch-scheduler.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/2022/06/17/adaptive-batch-scheduler.html
+++ b/content/2022/06/17/adaptive-batch-scheduler.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page10/index.html
+++ b/content/blog/page10/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page11/index.html
+++ b/content/blog/page11/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page12/index.html
+++ b/content/blog/page12/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page13/index.html
+++ b/content/blog/page13/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page14/index.html
+++ b/content/blog/page14/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page15/index.html
+++ b/content/blog/page15/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page16/index.html
+++ b/content/blog/page16/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page16/index.html
+++ b/content/blog/page16/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page17/index.html
+++ b/content/blog/page17/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page17/index.html
+++ b/content/blog/page17/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page18/index.html
+++ b/content/blog/page18/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page18/index.html
+++ b/content/blog/page18/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page19/index.html
+++ b/content/blog/page19/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page19/index.html
+++ b/content/blog/page19/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page2/index.html
+++ b/content/blog/page2/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page3/index.html
+++ b/content/blog/page3/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page4/index.html
+++ b/content/blog/page4/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page5/index.html
+++ b/content/blog/page5/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page6/index.html
+++ b/content/blog/page6/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page7/index.html
+++ b/content/blog/page7/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page8/index.html
+++ b/content/blog/page8/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/page9/index.html
+++ b/content/blog/page9/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/release_1.0.0-changelog_known_issues.html
+++ b/content/blog/release_1.0.0-changelog_known_issues.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/release_1.1.0-changelog.html
+++ b/content/blog/release_1.1.0-changelog.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/release_1.2.0-changelog.html
+++ b/content/blog/release_1.2.0-changelog.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/blog/release_1.3.0-changelog.html
+++ b/content/blog/release_1.3.0-changelog.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/community.html
+++ b/content/community.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/community.html
+++ b/content/community.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-components.html
+++ b/content/contributing/code-style-and-quality-components.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-formatting.html
+++ b/content/contributing/code-style-and-quality-formatting.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-java.html
+++ b/content/contributing/code-style-and-quality-java.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-preamble.html
+++ b/content/contributing/code-style-and-quality-preamble.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-pull-requests.html
+++ b/content/contributing/code-style-and-quality-pull-requests.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/code-style-and-quality-scala.html
+++ b/content/contributing/code-style-and-quality-scala.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/contribute-code.html
+++ b/content/contributing/contribute-code.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/contribute-documentation.html
+++ b/content/contributing/contribute-documentation.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/docs-style.html
+++ b/content/contributing/docs-style.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/how-to-contribute.html
+++ b/content/contributing/how-to-contribute.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/improve-website.html
+++ b/content/contributing/improve-website.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/contributing/reviewing-prs.html
+++ b/content/contributing/reviewing-prs.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/documentation.html
+++ b/content/documentation.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/ecosystem.html
+++ b/content/ecosystem.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
+++ b/content/ecosystem/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
+++ b/content/ecosystem/2020/06/23/flink-on-zeppelin-part2.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/feature/2019/09/13/state-processor-api.html
+++ b/content/feature/2019/09/13/state-processor-api.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/features/2017/07/04/flink-rescalable-state.html
+++ b/content/features/2017/07/04/flink-rescalable-state.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/features/2018/01/30/incremental-checkpointing.html
+++ b/content/features/2018/01/30/incremental-checkpointing.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
+++ b/content/features/2018/03/01/end-to-end-exactly-once-apache-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/features/2019/03/11/prometheus-monitoring.html
+++ b/content/features/2019/03/11/prometheus-monitoring.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/features/2020/03/27/flink-for-data-warehouse.html
+++ b/content/features/2020/03/27/flink-for-data-warehouse.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/flink-applications.html
+++ b/content/flink-applications.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/flink-architecture.html
+++ b/content/flink-architecture.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/flink-operations.html
+++ b/content/flink-operations.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/gettinghelp.html
+++ b/content/gettinghelp.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/index.html
+++ b/content/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/index.html
+++ b/content/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/material.html
+++ b/content/material.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/material.html
+++ b/content/material.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2014/08/26/release-0.6.html
+++ b/content/news/2014/08/26/release-0.6.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2014/09/26/release-0.6.1.html
+++ b/content/news/2014/09/26/release-0.6.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2014/10/03/upcoming_events.html
+++ b/content/news/2014/10/03/upcoming_events.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2014/11/04/release-0.7.0.html
+++ b/content/news/2014/11/04/release-0.7.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2014/11/18/hadoop-compatibility.html
+++ b/content/news/2014/11/18/hadoop-compatibility.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/01/06/december-in-flink.html
+++ b/content/news/2015/01/06/december-in-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/01/21/release-0.8.html
+++ b/content/news/2015/01/21/release-0.8.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/02/04/january-in-flink.html
+++ b/content/news/2015/02/04/january-in-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/02/09/streaming-example.html
+++ b/content/news/2015/02/09/streaming-example.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/03/02/february-2015-in-flink.html
+++ b/content/news/2015/03/02/february-2015-in-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
+++ b/content/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/04/07/march-in-flink.html
+++ b/content/news/2015/04/07/march-in-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/04/13/release-0.9.0-milestone1.html
+++ b/content/news/2015/04/13/release-0.9.0-milestone1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
+++ b/content/news/2015/05/11/Juggling-with-Bits-and-Bytes.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/05/14/Community-update-April.html
+++ b/content/news/2015/05/14/Community-update-April.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
+++ b/content/news/2015/06/24/announcing-apache-flink-0.9.0-release.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/08/24/introducing-flink-gelly.html
+++ b/content/news/2015/08/24/introducing-flink-gelly.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/09/01/release-0.9.1.html
+++ b/content/news/2015/09/01/release-0.9.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/09/03/flink-forward.html
+++ b/content/news/2015/09/03/flink-forward.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/09/16/off-heap-memory.html
+++ b/content/news/2015/09/16/off-heap-memory.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/11/16/release-0.10.0.html
+++ b/content/news/2015/11/16/release-0.10.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/11/27/release-0.10.1.html
+++ b/content/news/2015/11/27/release-0.10.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/12/04/Introducing-windows.html
+++ b/content/news/2015/12/04/Introducing-windows.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/12/11/storm-compatibility.html
+++ b/content/news/2015/12/11/storm-compatibility.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2015/12/18/a-year-in-review.html
+++ b/content/news/2015/12/18/a-year-in-review.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/02/11/release-0.10.2.html
+++ b/content/news/2016/02/11/release-0.10.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/03/08/release-1.0.0.html
+++ b/content/news/2016/03/08/release-1.0.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/04/06/cep-monitoring.html
+++ b/content/news/2016/04/06/cep-monitoring.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/04/06/release-1.0.1.html
+++ b/content/news/2016/04/06/release-1.0.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/04/14/flink-forward-announce.html
+++ b/content/news/2016/04/14/flink-forward-announce.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/04/22/release-1.0.2.html
+++ b/content/news/2016/04/22/release-1.0.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/05/11/release-1.0.3.html
+++ b/content/news/2016/05/11/release-1.0.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/05/24/stream-sql.html
+++ b/content/news/2016/05/24/stream-sql.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/08/08/release-1.1.0.html
+++ b/content/news/2016/08/08/release-1.1.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/08/11/release-1.1.1.html
+++ b/content/news/2016/08/11/release-1.1.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/08/24/ff16-keynotes-panels.html
+++ b/content/news/2016/08/24/ff16-keynotes-panels.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/09/05/release-1.1.2.html
+++ b/content/news/2016/09/05/release-1.1.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/10/12/release-1.1.3.html
+++ b/content/news/2016/10/12/release-1.1.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/12/19/2016-year-in-review.html
+++ b/content/news/2016/12/19/2016-year-in-review.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2016/12/21/release-1.1.4.html
+++ b/content/news/2016/12/21/release-1.1.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/02/06/release-1.2.0.html
+++ b/content/news/2017/02/06/release-1.2.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/03/23/release-1.1.5.html
+++ b/content/news/2017/03/23/release-1.1.5.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/03/29/table-sql-api-update.html
+++ b/content/news/2017/03/29/table-sql-api-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/04/04/dynamic-tables.html
+++ b/content/news/2017/04/04/dynamic-tables.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/04/26/release-1.2.1.html
+++ b/content/news/2017/04/26/release-1.2.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/05/16/official-docker-image.html
+++ b/content/news/2017/05/16/official-docker-image.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/06/01/release-1.3.0.html
+++ b/content/news/2017/06/01/release-1.3.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/06/23/release-1.3.1.html
+++ b/content/news/2017/06/23/release-1.3.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/08/05/release-1.3.2.html
+++ b/content/news/2017/08/05/release-1.3.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
+++ b/content/news/2017/11/22/release-1.4-and-1.5-timeline.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/12/12/release-1.4.0.html
+++ b/content/news/2017/12/12/release-1.4.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2017/12/21/2017-year-in-review.html
+++ b/content/news/2017/12/21/2017-year-in-review.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/02/15/release-1.4.1.html
+++ b/content/news/2018/02/15/release-1.4.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/03/08/release-1.4.2.html
+++ b/content/news/2018/03/08/release-1.4.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/03/15/release-1.3.3.html
+++ b/content/news/2018/03/15/release-1.3.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/05/25/release-1.5.0.html
+++ b/content/news/2018/05/25/release-1.5.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/07/12/release-1.5.1.html
+++ b/content/news/2018/07/12/release-1.5.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/07/31/release-1.5.2.html
+++ b/content/news/2018/07/31/release-1.5.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/08/09/release-1.6.0.html
+++ b/content/news/2018/08/09/release-1.6.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/08/21/release-1.5.3.html
+++ b/content/news/2018/08/21/release-1.5.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/09/20/release-1.5.4.html
+++ b/content/news/2018/09/20/release-1.5.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/09/20/release-1.6.1.html
+++ b/content/news/2018/09/20/release-1.6.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/10/29/release-1.5.5.html
+++ b/content/news/2018/10/29/release-1.5.5.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/10/29/release-1.6.2.html
+++ b/content/news/2018/10/29/release-1.6.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/11/30/release-1.7.0.html
+++ b/content/news/2018/11/30/release-1.7.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/12/21/release-1.7.1.html
+++ b/content/news/2018/12/21/release-1.7.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/12/22/release-1.6.3.html
+++ b/content/news/2018/12/22/release-1.6.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2018/12/26/release-1.5.6.html
+++ b/content/news/2018/12/26/release-1.5.6.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/02/13/unified-batch-streaming-blink.html
+++ b/content/news/2019/02/13/unified-batch-streaming-blink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/02/15/release-1.7.2.html
+++ b/content/news/2019/02/15/release-1.7.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/02/25/monitoring-best-practices.html
+++ b/content/news/2019/02/25/monitoring-best-practices.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/02/25/release-1.6.4.html
+++ b/content/news/2019/02/25/release-1.6.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/03/06/ffsf-preview.html
+++ b/content/news/2019/03/06/ffsf-preview.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/04/09/release-1.8.0.html
+++ b/content/news/2019/04/09/release-1.8.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/04/17/sod.html
+++ b/content/news/2019/04/17/sod.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/07/02/release-1.8.1.html
+++ b/content/news/2019/07/02/release-1.8.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/08/22/release-1.9.0.html
+++ b/content/news/2019/08/22/release-1.9.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/09/10/community-update.html
+++ b/content/news/2019/09/10/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/09/11/release-1.8.2.html
+++ b/content/news/2019/09/11/release-1.8.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/10/18/release-1.9.1.html
+++ b/content/news/2019/10/18/release-1.9.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
+++ b/content/news/2019/11/25/query-pulsar-streams-using-apache-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/12/09/flink-kubernetes-kudo.html
+++ b/content/news/2019/12/09/flink-kubernetes-kudo.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2019/12/11/release-1.8.3.html
+++ b/content/news/2019/12/11/release-1.8.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/01/15/demo-fraud-detection.html
+++ b/content/news/2020/01/15/demo-fraud-detection.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
+++ b/content/news/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/01/30/release-1.9.2.html
+++ b/content/news/2020/01/30/release-1.9.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
+++ b/content/news/2020/02/07/a-guide-for-unit-testing-in-apache-flink.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/02/11/release-1.10.0.html
+++ b/content/news/2020/02/11/release-1.10.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/02/20/ddl.html
+++ b/content/news/2020/02/20/ddl.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/03/24/demo-fraud-detection-2.html
+++ b/content/news/2020/03/24/demo-fraud-detection-2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/04/01/community-update.html
+++ b/content/news/2020/04/01/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/04/07/release-statefun-2.0.0.html
+++ b/content/news/2020/04/07/release-statefun-2.0.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
+++ b/content/news/2020/04/15/flink-serialization-tuning-vol-1.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
+++ b/content/news/2020/04/21/memory-management-improvements-flink-1.10.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/04/24/release-1.9.3.html
+++ b/content/news/2020/04/24/release-1.9.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/05/04/season-of-docs.html
+++ b/content/news/2020/05/04/season-of-docs.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/05/07/community-update.html
+++ b/content/news/2020/05/07/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/05/12/release-1.10.1.html
+++ b/content/news/2020/05/12/release-1.10.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/06/09/release-statefun-2.1.0.html
+++ b/content/news/2020/06/09/release-statefun-2.1.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/06/11/community-update.html
+++ b/content/news/2020/06/11/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/06/15/flink-on-zeppelin-part1.html
+++ b/content/news/2020/06/15/flink-on-zeppelin-part1.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/07/06/release-1.11.0.html
+++ b/content/news/2020/07/06/release-1.11.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/07/14/application-mode.html
+++ b/content/news/2020/07/14/application-mode.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/07/21/release-1.11.1.html
+++ b/content/news/2020/07/21/release-1.11.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/07/27/community-update.html
+++ b/content/news/2020/07/27/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/07/30/demo-fraud-detection-3.html
+++ b/content/news/2020/07/30/demo-fraud-detection-3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/08/06/external-resource.html
+++ b/content/news/2020/08/06/external-resource.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/08/20/flink-docker.html
+++ b/content/news/2020/08/20/flink-docker.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/08/25/release-1.10.2.html
+++ b/content/news/2020/08/25/release-1.10.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/09/04/community-update.html
+++ b/content/news/2020/09/04/community-update.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/09/17/release-1.11.2.html
+++ b/content/news/2020/09/17/release-1.11.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/09/28/release-statefun-2.2.0.html
+++ b/content/news/2020/09/28/release-statefun-2.2.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/10/13/stateful-serverless-internals.html
+++ b/content/news/2020/10/13/stateful-serverless-internals.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/11/11/release-statefun-2.2.1.html
+++ b/content/news/2020/11/11/release-statefun-2.2.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/12/10/release-1.12.0.html
+++ b/content/news/2020/12/10/release-1.12.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2020/12/18/release-1.11.3.html
+++ b/content/news/2020/12/18/release-1.11.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2020/12/18/release-1.11.3.html
+++ b/content/news/2020/12/18/release-1.11.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/01/02/release-statefun-2.2.2.html
+++ b/content/news/2021/01/02/release-statefun-2.2.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/01/02/release-statefun-2.2.2.html
+++ b/content/news/2021/01/02/release-statefun-2.2.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
+++ b/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
+++ b/content/news/2021/01/11/batch-fine-grained-fault-tolerance.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/01/19/release-1.12.1.html
+++ b/content/news/2021/01/19/release-1.12.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/01/19/release-1.12.1.html
+++ b/content/news/2021/01/19/release-1.12.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/01/29/release-1.10.3.html
+++ b/content/news/2021/01/29/release-1.10.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/01/29/release-1.10.3.html
+++ b/content/news/2021/01/29/release-1.10.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/03/03/release-1.12.2.html
+++ b/content/news/2021/03/03/release-1.12.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/03/03/release-1.12.2.html
+++ b/content/news/2021/03/03/release-1.12.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/04/15/release-statefun-3.0.0.html
+++ b/content/news/2021/04/15/release-statefun-3.0.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/04/15/release-statefun-3.0.0.html
+++ b/content/news/2021/04/15/release-statefun-3.0.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/04/29/release-1.12.3.html
+++ b/content/news/2021/04/29/release-1.12.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/05/03/release-1.13.0.html
+++ b/content/news/2021/05/03/release-1.13.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/05/03/release-1.13.0.html
+++ b/content/news/2021/05/03/release-1.13.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/05/21/release-1.12.4.html
+++ b/content/news/2021/05/21/release-1.12.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/05/21/release-1.12.4.html
+++ b/content/news/2021/05/21/release-1.12.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/05/28/release-1.13.1.html
+++ b/content/news/2021/05/28/release-1.13.1.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/05/28/release-1.13.1.html
+++ b/content/news/2021/05/28/release-1.13.1.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/08/06/release-1.12.5.html
+++ b/content/news/2021/08/06/release-1.12.5.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/08/06/release-1.12.5.html
+++ b/content/news/2021/08/06/release-1.12.5.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/08/06/release-1.13.2.html
+++ b/content/news/2021/08/06/release-1.13.2.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/08/06/release-1.13.2.html
+++ b/content/news/2021/08/06/release-1.13.2.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/08/09/release-1.11.4.html
+++ b/content/news/2021/08/09/release-1.11.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/08/09/release-1.11.4.html
+++ b/content/news/2021/08/09/release-1.11.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/08/31/release-1.14.0-rc0.html
+++ b/content/news/2021/08/31/release-1.14.0-rc0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/08/31/release-1.14.0-rc0.html
+++ b/content/news/2021/08/31/release-1.14.0-rc0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/08/31/release-statefun-3.1.0.html
+++ b/content/news/2021/08/31/release-statefun-3.1.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/08/31/release-statefun-3.1.0.html
+++ b/content/news/2021/08/31/release-statefun-3.1.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/09/29/release-1.14.0.html
+++ b/content/news/2021/09/29/release-1.14.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/09/29/release-1.14.0.html
+++ b/content/news/2021/09/29/release-1.14.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/10/19/release-1.13.3.html
+++ b/content/news/2021/10/19/release-1.13.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/10/19/release-1.13.3.html
+++ b/content/news/2021/10/19/release-1.13.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/12/16/log4j-patch-releases.html
+++ b/content/news/2021/12/16/log4j-patch-releases.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/12/16/log4j-patch-releases.html
+++ b/content/news/2021/12/16/log4j-patch-releases.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2021/12/22/log4j-statefun-release.html
+++ b/content/news/2021/12/22/log4j-statefun-release.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2021/12/22/log4j-statefun-release.html
+++ b/content/news/2021/12/22/log4j-statefun-release.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/01/07/release-ml-2.0.0.html
+++ b/content/news/2022/01/07/release-ml-2.0.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/01/07/release-ml-2.0.0.html
+++ b/content/news/2022/01/07/release-ml-2.0.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/01/17/release-1.14.3.html
+++ b/content/news/2022/01/17/release-1.14.3.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/01/17/release-1.14.3.html
+++ b/content/news/2022/01/17/release-1.14.3.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/01/31/release-statefun-3.2.0.html
+++ b/content/news/2022/01/31/release-statefun-3.2.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/01/31/release-statefun-3.2.0.html
+++ b/content/news/2022/01/31/release-statefun-3.2.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/02/18/release-1.13.6.html
+++ b/content/news/2022/02/18/release-1.13.6.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/02/18/release-1.13.6.html
+++ b/content/news/2022/02/18/release-1.13.6.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/03/11/release-1.14.4.html
+++ b/content/news/2022/03/11/release-1.14.4.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/03/11/release-1.14.4.html
+++ b/content/news/2022/03/11/release-1.14.4.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/04/03/release-kubernetes-operator-0.1.0.html
+++ b/content/news/2022/04/03/release-kubernetes-operator-0.1.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/04/03/release-kubernetes-operator-0.1.0.html
+++ b/content/news/2022/04/03/release-kubernetes-operator-0.1.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/05/05/1.15-announcement.html
+++ b/content/news/2022/05/05/1.15-announcement.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/05/05/1.15-announcement.html
+++ b/content/news/2022/05/05/1.15-announcement.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/05/11/release-table-store-0.1.0.html
+++ b/content/news/2022/05/11/release-table-store-0.1.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/05/11/release-table-store-0.1.0.html
+++ b/content/news/2022/05/11/release-table-store-0.1.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/06/05/release-kubernetes-operator-1.0.0.html
+++ b/content/news/2022/06/05/release-kubernetes-operator-1.0.0.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/06/05/release-kubernetes-operator-1.0.0.html
+++ b/content/news/2022/06/05/release-kubernetes-operator-1.0.0.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/news/2022/06/22/release-1.14.5.html
+++ b/content/news/2022/06/22/release-1.14.5.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/news/2022/06/22/release-1.14.5.html
+++ b/content/news/2022/06/22/release-1.14.5.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/poweredby.html
+++ b/content/poweredby.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/project.html
+++ b/content/project.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/project.html
+++ b/content/project.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/roadmap.html
+++ b/content/roadmap.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/security.html
+++ b/content/security.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/security.html
+++ b/content/security.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/slides.html
+++ b/content/slides.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/slides.html
+++ b/content/slides.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/stateful-functions.html
+++ b/content/stateful-functions.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/training.html
+++ b/content/training.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>

--- a/content/training.html
+++ b/content/training.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">What is the Flink Kubernetes Operator?</a></li>
 
             <!-- Use cases -->
             <li class="active"><a href="/usecases.html">Use Cases</a></li>

--- a/content/usecases.html
+++ b/content/usecases.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">What is Flink ML?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">What is Flink Kubernetes Operator?</a></li>
+
             <!-- Use cases -->
             <li class="active"><a href="/usecases.html">Use Cases</a></li>
 

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/community.html
+++ b/content/zh/community.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-components.html
+++ b/content/zh/contributing/code-style-and-quality-components.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-formatting.html
+++ b/content/zh/contributing/code-style-and-quality-formatting.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-java.html
+++ b/content/zh/contributing/code-style-and-quality-java.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-preamble.html
+++ b/content/zh/contributing/code-style-and-quality-preamble.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-preamble.html
+++ b/content/zh/contributing/code-style-and-quality-preamble.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-pull-requests.html
+++ b/content/zh/contributing/code-style-and-quality-pull-requests.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/code-style-and-quality-scala.html
+++ b/content/zh/contributing/code-style-and-quality-scala.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/contribute-code.html
+++ b/content/zh/contributing/contribute-code.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/contribute-documentation.html
+++ b/content/zh/contributing/contribute-documentation.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/docs-style.html
+++ b/content/zh/contributing/docs-style.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/how-to-contribute.html
+++ b/content/zh/contributing/how-to-contribute.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/improve-website.html
+++ b/content/zh/contributing/improve-website.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/contributing/reviewing-prs.html
+++ b/content/zh/contributing/reviewing-prs.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/downloads.html
+++ b/content/zh/downloads.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/ecosystem.html
+++ b/content/zh/ecosystem.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/flink-applications.html
+++ b/content/zh/flink-applications.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/flink-architecture.html
+++ b/content/zh/flink-architecture.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -110,6 +110,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/flink-operations.html
+++ b/content/zh/flink-operations.html
@@ -112,7 +112,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/gettinghelp.html
+++ b/content/zh/gettinghelp.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/index.html
+++ b/content/zh/index.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/material.html
+++ b/content/zh/material.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/poweredby.html
+++ b/content/zh/poweredby.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/roadmap.html
+++ b/content/zh/roadmap.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/security.html
+++ b/content/zh/security.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/security.html
+++ b/content/zh/security.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/stateful-functions.html
+++ b/content/zh/stateful-functions.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>
 

--- a/content/zh/training.html
+++ b/content/zh/training.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -100,7 +100,7 @@
 
             <!-- Flink Kubernetes Operator? -->
 
-            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">Flink Kubernetes Operator 是什么?</a></li>
 
             <!-- Use cases -->
             <li class="active"><a href="/zh/usecases.html">应用场景</a></li>

--- a/content/zh/usecases.html
+++ b/content/zh/usecases.html
@@ -98,6 +98,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-ml-docs-stable/">Flink ML是什么?</a></li>
 
+            <!-- Flink Kubernetes Operator? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/">Flink Kubernetes Operator 是什么?</a></li>
+
             <!-- Use cases -->
             <li class="active"><a href="/zh/usecases.html">应用场景</a></li>
 


### PR DESCRIPTION
Similar to statefun and ml projects we should also add a "What is Flink Kubernetes Operator?" link to the menu pointing to the doc site. 

**The brief change log**

- Add 'What is Flink Kubernetes Operator?' link to flink website.