### PR TITLE
[hotfix][docs] Delete the redundant content of "downloads.zh.md" file.

### DIFF
--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -220,9 +220,6 @@ Apache Flink® ML {{ site.FLINK_ML_VERSION_STABLE }} 是机器学习库的最新
 </dependency>
 ```
 
-The `statefun-sdk` dependency is the only one you will need to start developing applications.
-The `statefun-flink-harness` dependency includes a local execution environment that allows you to locally test your application in an IDE.
-
 本地开发程序仅需要依赖 `statefun-sdk`。`statefun-flink-harness` 提供了在 IDE 中测试用户开发的程序的本地执行环境。
 
 


### PR DESCRIPTION
# English document
![image](https://user-images.githubusercontent.com/95120044/164263321-71542b69-d948-4a0c-965e-9fe162b79d95.png)
# Chinese document 
![image](https://user-images.githubusercontent.com/95120044/164265305-f048abe1-685f-41b9-b231-016c39920a50.png)


- **From the above picture of Chinese and English documents, it can be seen that there is a part of English content in Chinese documents.**