### PR TITLE
[FLINK-20760][Project Website] Fix broken doc link

### DIFF
--- a/content/contributing/code-style-and-quality-common.html
+++ b/content/contributing/code-style-and-quality-common.html
@@ -482,7 +482,7 @@ That way, you get warnings from IntelliJ about all sections where you have to re
 <p><em>Note: This means that <code>@Nonnull</code> annotations are usually not necessary, but can be used in certain cases to override a previous annotation, or to point non-nullability out in a context where one would expect a nullable value.</em></p>
 
 <p><code>Optional</code> is a good solution as a return type for method that may or may not have a result, so nullable return types are good candidates to be replaced with <code>Optional</code>.
-See also <a href="code-style-and-quality-java.md#java-optional">usage of Java Optional</a>.</p>
+See also <a href="code-style-and-quality-java.html#java-optional">usage of Java Optional</a>.</p>
 
 <h3 id="avoid-code-duplication">Avoid Code Duplication</h3>
 

--- a/content/zh/contributing/code-style-and-quality-common.html
+++ b/content/zh/contributing/code-style-and-quality-common.html
@@ -473,7 +473,7 @@ That way, you get warnings from IntelliJ about all sections where you have to re
 <p><em>Note: This means that <code>@Nonnull</code> annotations are usually not necessary, but can be used in certain cases to override a previous annotation, or to point non-nullability out in a context where one would expect a nullable value.</em></p>
 
 <p><code>Optional</code> is a good solution as a return type for method that may or may not have a result, so nullable return types are good candidates to be replaced with <code>Optional</code>.
-See also <a href="code-style-and-quality-java.md#java-optional">usage of Java Optional</a>.</p>
+See also <a href="code-style-and-quality-java.html#java-optional">usage of Java Optional</a>.</p>
 
 <h3 id="avoid-code-duplication">Avoid Code Duplication</h3>
 

--- a/contributing/code-style-and-quality-common.md
+++ b/contributing/code-style-and-quality-common.md
@@ -163,7 +163,7 @@ That way, you get warnings from IntelliJ about all sections where you have to re
 _Note: This means that `@Nonnull` annotations are usually not necessary, but can be used in certain cases to override a previous annotation, or to point non-nullability out in a context where one would expect a nullable value._
 
 `Optional` is a good solution as a return type for method that may or may not have a result, so nullable return types are good candidates to be replaced with `Optional`.
-See also [usage of Java Optional](code-style-and-quality-java.md#java-optional).
+See also [usage of Java Optional](code-style-and-quality-java.html#java-optional).
 
 
 ### Avoid Code Duplication

--- a/contributing/code-style-and-quality-common.zh.md
+++ b/contributing/code-style-and-quality-common.zh.md
@@ -163,7 +163,7 @@ That way, you get warnings from IntelliJ about all sections where you have to re
 _Note: This means that `@Nonnull` annotations are usually not necessary, but can be used in certain cases to override a previous annotation, or to point non-nullability out in a context where one would expect a nullable value._
 
 `Optional` is a good solution as a return type for method that may or may not have a result, so nullable return types are good candidates to be replaced with `Optional`.
-See also [usage of Java Optional](code-style-and-quality-java.md#java-optional).
+See also [usage of Java Optional](code-style-and-quality-java.html#java-optional).
 
 
 ### Avoid Code Duplication


### PR DESCRIPTION
## What is the purpose of the change

Fix broken doc link in Apache Flink Code Style and Quality Guide.

The link in pic is broken. The [[usage of Java Optional](https://flink.apache.org/contributing/code-style-and-quality-java.md#java-optional)](https://flink.apache.org/contributing/code-style-and-quality-java.md#java-optional) should be linked to [[here](https://flink.apache.org/contributing/code-style-and-quality-java.html#java-optional)](https://flink.apache.org/contributing/code-style-and-quality-java.html#java-optional). ![img](https://issues.apache.org/jira/secure/attachment/13017608/13017608_image-2020-12-24-15-56-04-643.png)


## Brief change log

  - Fix broken doc link in following files:
    - *contributing/code-style-and-quality-common.md*
    - *contributing/code-style-and-quality-common.zh.md*
    - *content/contributing/code-style-and-quality-common.html*
    - *content/zh/contributing/code-style-and-quality-common.html*


## Verifying this change

This change is already covered by existing tests. I rebuilt the website locally using docker, the changes works

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no