### PR TITLE
[FLINK-28930] Add 'What is Flink Table Store?' link to flink website

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -3,6 +3,7 @@ en:
     what_is_statefun: What is Stateful Functions?
     what_is_flink_ml: What is Flink ML?
     what_is_flink_kubernetes_operator: What is the Flink Kubernetes Operator?
+    what_is_flink_table_store: What is Flink Table Store?
     flink_architecture: Architecture
     flink_applications: Applications
     flink_operations: Operations
@@ -33,6 +34,7 @@ zh:
     what_is_statefun: What is Stateful Functions?
     what_is_flink_ml: Flink ML是什么?
     what_is_flink_kubernetes_operator: Flink Kubernetes Operator 是什么?
+    what_is_flink_table_store: Flink Table Store 是什么?
     flink_architecture: 架构
     flink_applications: 应用
     flink_operations: 运维

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -60,6 +60,10 @@
 
             <li><a href="https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/">{{ site.data.i18n[page.language].what_is_flink_kubernetes_operator }}</a></li>
 
+            <!-- Flink Table Store? -->
+
+            <li><a href="https://nightlies.apache.org/flink/flink-table-store-docs-stable/">{{ site.data.i18n[page.language].what_is_flink_table_store }}</a></li>
+
             <!-- Use cases -->
             <li{% if page.url contains '/usecases.html' %} class="active"{% endif %}><a href="{{ baseurl_i18n }}/usecases.html">{{ site.data.i18n[page.language].use_case }}</a></li>
 


### PR DESCRIPTION
Similar to statefun and ml projects we should also add a "What is Flink Table Store?" link to the menu pointing to the doc site.

**The brief change log**

- Add 'What is Flink Table Store?' link to flink website.