### PR TITLE
Add Elasticsearch connector 3.0.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,6 +105,18 @@ flink_releases:
       sha512_url: "https://downloads.apache.org/flink/flink-1.15.2/flink-1.15.2-src.tgz.sha512"
     release_notes_url: "https://nightlies.apache.org/flink/flink-docs-release-1.15/release-notes/flink-1.15"
 
+connector_releases:
+  - version: "3.0.0"
+    source_release:
+        name: "Apache Flink Elasticsearch Connector 3.0.0"
+        id: "300-elasticsearch-connector-download-source"
+        flink_versions:
+          - "1.16"
+        url: "https://www.apache.org/dyn/closer.lua/flink/flink-connector-elasticsearch-3.0.0/flink-connector-elasticsearch-3.0.0-src.tgz"
+        asc_url: "https://downloads.apache.org/flink/flink-connector-elasticsearch-3.0.0/flink-connector-elasticsearch-3.0.0-src.tgz.asc"
+        sha512_url: "https://downloads.apache.org/flink/flink-connector-elasticsearch-3.0.0/flink-connector-elasticsearch-3.0.0-src.tgz.sha512"
+
+
 flink_statefun_releases:
   -
       version_short: "3.2"
@@ -610,6 +622,12 @@ release_archive:
         version_short: 2.0
         version_long: 2.0.0
         release_date: 2020-04-02
+
+    connectors:
+      - name: "Flink Elasticsearch Connector"
+        connector: "elasticsearch"
+        version: 3.0.0
+        release_date: 2022-11-05
 
     flink_shaded:
       -

--- a/_config.yml
+++ b/_config.yml
@@ -627,7 +627,7 @@ release_archive:
       - name: "Flink Elasticsearch Connector"
         connector: "elasticsearch"
         version: 3.0.0
-        release_date: 2022-11-05
+        release_date: 2022-11-09
 
     flink_shaded:
       -

--- a/downloads.md
+++ b/downloads.md
@@ -107,6 +107,28 @@ Please have a look at the [Release Notes for Flink {{ flink_release.version_shor
 
 {% endfor %}
 
+## Flink connectors
+
+These connectors that are released separately from the main Flink releases.
+
+{% for release in site.connector_releases %}
+
+### {{ release.source_release.name }}
+
+<p>
+<a href="{{ release.source_release.url }}" id="{{ release.source_release.id }}">{{ release.source_release.name }} Source Release</a>
+(<a href="{{ release.source_release.asc_url }}">asc</a>, <a href="{{ release.source_release.sha512_url }}">sha512</a>)
+</p>
+ 
+This connector is compatible with these Apache Flink versions:
+{% for flink_version in release.source_release.flink_versions %}
+* {{ flink_version }}.x
+{% endfor %}
+
+{% endfor %}
+
+---
+
 Apache Flink® Stateful Functions {{ site.FLINK_STATEFUN_VERSION_STABLE }} is the latest stable release for the [Stateful Functions](https://flink.apache.org/stateful-functions.html) component.
 
 {% for flink_statefun_release in site.flink_statefun_releases %}
@@ -315,6 +337,19 @@ Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
 (<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>)
 {% endif %}
+</li>
+{% endfor %}
+</ul>
+
+### Flink Connectors
+
+These connectors that are released separately from the main Flink releases.
+
+<ul>
+{% for release in site.release_archive.connectors %}
+<li>
+{{ release.name }} {{ release.version }} - {{ release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-connector-${{connector}}-{{ release.version }}/flink-connector-${{connector}}-{{ release.version }}-src.tgz">Source</a>)
 </li>
 {% endfor %}
 </ul>

--- a/downloads.zh.md
+++ b/downloads.zh.md
@@ -126,6 +126,28 @@ flink-docs-release-{{ flink_release.version_short }}/release-notes/flink-{{ flin
 
 {% endfor %}
 
+## Flink connectors
+
+These connectors that are released separately from the main Flink releases.
+
+{% for release in site.connector_releases %}
+
+### {{ release.source_release.name }}
+
+<p>
+<a href="{{ release.source_release.url }}" id="{{ release.source_release.id }}">{{ release.source_release.name }} Source Release</a>
+(<a href="{{ release.source_release.asc_url }}">asc</a>, <a href="{{ release.source_release.sha512_url }}">sha512</a>)
+</p>
+
+This connector is compatible with these Apache Flink versions:
+{% for flink_version in release.source_release.flink_versions %}
+* {{ flink_version }}.x
+  {% endfor %}
+
+{% endfor %}
+
+---
+
 Apache Flink® Stateful Functions {{ site.FLINK_STATEFUN_VERSION_STABLE }} 是 [Stateful Functions](https://flink.apache.org/stateful-functions.html) 组件的最新稳定版本.
 
 {% for flink_statefun_release in site.flink_statefun_releases %}
@@ -297,6 +319,19 @@ Flink {{ flink_release.version_long }} - {{ flink_release.release_date }}
 (<a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}/flink-{{ flink_release.version_long }}-src.tgz">Source</a>,
 <a href="https://archive.apache.org/dist/flink/flink-{{ flink_release.version_long }}">Binaries</a>)
 {% endif %}
+</li>
+{% endfor %}
+</ul>
+
+### Flink Connectors
+
+These connectors that are released separately from the main Flink releases.
+
+<ul>
+{% for release in site.release_archive.connectors %}
+<li>
+{{ release.name }} {{ release.version }} - {{ release.release_date }}
+(<a href="https://archive.apache.org/dist/flink/flink-connector-${{connector}}-{{ release.version }}/flink-connector-${{connector}}-{{ release.version }}-src.tgz">Source</a>)
 </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
Also extends the download page to list connector releases.