### PR TITLE
Delete duplicated word "from" from usecases.md and usecases.html

### DIFF
--- a/content/usecases.html
+++ b/content/usecases.html
@@ -320,7 +320,7 @@
 
 <h3 id="what-are-data-pipelines">What are data pipelines?</h3>
 
-<p>Extract-transform-load (ETL) is a common approach to convert and move data between storage systems. Often ETL jobs are periodically triggered to copy data from from transactional database systems to an analytical database or a data warehouse.</p>
+<p>Extract-transform-load (ETL) is a common approach to convert and move data between storage systems. Often ETL jobs are periodically triggered to copy data from transactional database systems to an analytical database or a data warehouse.</p>
 
 <p>Data pipelines serve a similar purpose as ETL jobs. They transform and enrich data and can move it from one storage system to another. However, they operate in a continuous streaming mode instead of being periodically triggered. Hence, they are able to read records from sources that continuously produce data and move it with low latency to their destination. For example a data pipeline might monitor a file system directory for new files and write their data into an event log. Another application might materialize an event stream to a database or incrementally build and refine a search index.</p>
 

--- a/usecases.md
+++ b/usecases.md
@@ -80,7 +80,7 @@ Flink provides very good support for continuous streaming as well as batch analy
 
 ### What are data pipelines?
 
-Extract-transform-load (ETL) is a common approach to convert and move data between storage systems. Often ETL jobs are periodically triggered to copy data from from transactional database systems to an analytical database or a data warehouse.
+Extract-transform-load (ETL) is a common approach to convert and move data between storage systems. Often ETL jobs are periodically triggered to copy data from transactional database systems to an analytical database or a data warehouse.
 
 Data pipelines serve a similar purpose as ETL jobs. They transform and enrich data and can move it from one storage system to another. However, they operate in a continuous streaming mode instead of being periodically triggered. Hence, they are able to read records from sources that continuously produce data and move it with low latency to their destination. For example a data pipeline might monitor a file system directory for new files and write their data into an event log. Another application might materialize an event stream to a database or incrementally build and refine a search index.
 


### PR DESCRIPTION
Old sentence:  "Often ETL jobs are periodically triggered to copy data from from transactional database systems to an analytical database or a data warehouse"

New sentence:  "Often ETL jobs are periodically triggered to copy data from transactional database systems to an analytical database or a data warehouse"