### PR TITLE
Always pull latest Hugo image on docker build

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -20,6 +20,8 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "${SCRIPT_DIR}/_utils.sh"
 
+docker pull jakejarvis/hugo-extended:latest
+
 action=$1
 if [[ $action = "build" ]]
 then


### PR DESCRIPTION
Currently the `./docker-build.sh` script uses the `latest` tag for Hugo docker image. This will use whichever image is installed locally and can cause unexpected changes to the generated site. This change will ensure we are always using the latest image.