### PR TITLE
Update the expired slack invitation link

### DIFF
--- a/docs/content.zh/community.md
+++ b/docs/content.zh/community.md
@@ -145,7 +145,7 @@ under the License.
 
 ## Slack
 
-你可以通过 [此链接](https://join.slack.com/t/apache-flink/shared_invite/zt-1qxczhnzb-Redy4vcPAiTkfcBw81Dm8Q)
+你可以通过 [此链接](https://join.slack.com/t/apache-flink/shared_invite/zt-1ta0su2np-lCCV6xD7XeKjwQuHMOTBIA)
 加入 Apache Flink 社区专属的 Slack 工作空间。 在成功加入后，不要忘记在 #introductions 频道介绍你自己。 Slack 规定每个邀请链接最多可邀请 100 人，如果遇到上述链接失效的情况，请联系 [Dev 邮件列表](#mailing-lists)。 
 所有已经加入社区 Slack 空间的成员同样可以邀请新成员加入。
 

--- a/docs/content.zh/getting-help.md
+++ b/docs/content.zh/getting-help.md
@@ -47,7 +47,7 @@ Apache Flink 社区每天都会回答许多用户的问题。你可以从历史�
 
 ### Slack
 
-你可以通过 [此链接](https://join.slack.com/t/apache-flink/shared_invite/zt-1qxczhnzb-Redy4vcPAiTkfcBw81Dm8Q) 加入 Apache Flink 社区专属的 Slack 工作空间。
+你可以通过 [此链接](https://join.slack.com/t/apache-flink/shared_invite/zt-1ta0su2np-lCCV6xD7XeKjwQuHMOTBIA) 加入 Apache Flink 社区专属的 Slack 工作空间。
 在成功加入后，不要忘记在 #introductions 频道介绍你自己。
 Slack 规定每个邀请链接最多可邀请 100 人，如果遇到上述链接失效的情况，请联系 [Dev 邮件列表]({{< relref "community" >}}#mailing-lists)。 
 所有已经加入社区 Slack 空间的成员同样可以邀请新成员加入。

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -146,7 +146,7 @@ If you send us an email with a code snippet, make sure that:
 
 ## Slack
 
-You can join the [Apache Flink community on Slack.](https://join.slack.com/t/apache-flink/shared_invite/zt-1qxczhnzb-Redy4vcPAiTkfcBw81Dm8Q)
+You can join the [Apache Flink community on Slack.](https://join.slack.com/t/apache-flink/shared_invite/zt-1ta0su2np-lCCV6xD7XeKjwQuHMOTBIA)
 After creating an account in Slack, don't forget to introduce yourself in #introductions.
 Due to Slack limitations the invite link expires after 100 invites. If it is expired, please reach out to the [Dev mailing list](#mailing-lists).
 Any existing Slack member can also invite anyone else to join.

--- a/docs/content/getting-help.md
+++ b/docs/content/getting-help.md
@@ -47,7 +47,7 @@ Please note that you won't receive a response to your mail if you are not subscr
 
 ### Slack
 
-You can join the [Apache Flink community on Slack.](https://join.slack.com/t/apache-flink/shared_invite/zt-1qxczhnzb-Redy4vcPAiTkfcBw81Dm8Q)
+You can join the [Apache Flink community on Slack.](https://join.slack.com/t/apache-flink/shared_invite/zt-1ta0su2np-lCCV6xD7XeKjwQuHMOTBIA)
 After creating an account in Slack, don't forget to introduce yourself in #introductions.
 Due to Slack limitations the invite link expires after 100 invites. If it is expired, please reach out to the [Dev mailing list]({{< relref "community" >}}#mailing-lists).
 Any existing Slack member can also invite anyone else to join.


### PR DESCRIPTION
Since the slack invitation link has been expired, update it.