### PR TITLE
[FLINK-32145] Fix incorrect docker image links of specific versions

### DIFF
--- a/docs/content/posts/2022-03-11-release-1.14.4.md
+++ b/docs/content/posts/2022-03-11-release-1.14.4.md
@@ -47,7 +47,7 @@ You can find the binaries on the updated [Downloads page](/downloads.html).
 
 ## Docker Images
 
-* [library/flink](https://hub.docker.com/_/flink?tab=tags&page=1&name=1.14.4) (official images)
+* [library/flink](https://hub.docker.com/_/flink/tags?page=1&name=1.14.4) (official images)
 * [apache/flink](https://hub.docker.com/r/apache/flink/tags?page=1&name=1.14.4) (ASF repository)
 
 ## PyPi

--- a/docs/content/posts/2022-06-22-release-1.14.5.md
+++ b/docs/content/posts/2022-06-22-release-1.14.5.md
@@ -46,7 +46,7 @@ You can find the binaries on the updated [Downloads page](/downloads.html).
 
 ## Docker Images
 
-* [library/flink](https://hub.docker.com/_/flink?tab=tags&page=1&name=1.14.5) (official images)
+* [library/flink](https://hub.docker.com/_/flink/tags?page=1&name=1.14.5) (official images)
 * [apache/flink](https://hub.docker.com/r/apache/flink/tags?page=1&name=1.14.5) (ASF repository)
 
 ## PyPi

--- a/docs/content/posts/2022-07-06-release-1.15.1.md
+++ b/docs/content/posts/2022-07-06-release-1.15.1.md
@@ -47,7 +47,7 @@ You can find the binaries on the updated [Downloads page](/downloads.html).
 
 ## Docker Images
 
-* [library/flink](https://hub.docker.com/_/flink?tab=tags&page=1&name=1.15.1) (official images)
+* [library/flink](https://hub.docker.com/_/flink/tags?page=1&name=1.15.1) (official images)
 * [apache/flink](https://hub.docker.com/r/apache/flink/tags?page=1&name=1.15.1) (ASF repository)
 
 ## PyPi

--- a/docs/content/posts/2022-08-24-release-1.15.2.md
+++ b/docs/content/posts/2022-08-24-release-1.15.2.md
@@ -46,7 +46,7 @@ You can find the binaries on the updated [Downloads page](/downloads.html).
 
 ## Docker Images
 
-* [library/flink](https://hub.docker.com/_/flink?tab=tags&page=1&name=1.15.2) (official images)
+* [library/flink](https://hub.docker.com/_/flink/tags?page=1&name=1.15.2) (official images)
 * [apache/flink](https://hub.docker.com/r/apache/flink/tags?page=1&name=1.15.2) (ASF repository)
 
 ## PyPi


### PR DESCRIPTION
Previous links would point an incorrect locations.