### PR TITLE
[FLINK-31945] Fix missing title in the table of contents of the blogs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -54,6 +54,8 @@ posts = "/:year/:month/:day/:title/"
 [markup]
 [markup.goldmark.renderer]
   unsafe = true
+[markup.tableOfContents]
+  startLevel = 0
 
 [languages]
 [languages.en]


### PR DESCRIPTION
This pull request fixes missing title in the table of contents of the blogs. 

For more details, please see FLINK-31945.