### PR TITLE
Refactor grammar on flink-architecture markdown

### DIFF
--- a/docs/content/what-is-flink/flink-architecture.md
+++ b/docs/content/what-is-flink/flink-architecture.md
@@ -30,7 +30,7 @@ Convince yourself by exploring the [use cases]({{< relref "use-cases" >}}) that 
 
 Apache Flink is a distributed system and requires compute resources in order to execute applications. Flink integrates with all common cluster resource managers such as [Hadoop YARN](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html), [Apache Mesos](https://mesos.apache.org), and [Kubernetes](https://kubernetes.io/) but can also be setup to run as a stand-alone cluster.
 
-Flink is designed to work well each of the previously listed resource managers. This is achieved by resource-manager-specific deployment modes that allow Flink to interact with each resource manager in its idiomatic way.
+Flink is designed to work well with each of the previously listed resource managers. This is achieved by resource-manager-specific deployment modes that allow Flink to interact with each resource manager in its idiomatic way.
 
 When deploying a Flink application, Flink automatically identifies the required resources based on the application's configured parallelism and requests them from the resource manager. In case of a failure, Flink replaces the failed container by requesting new resources. All communication to submit or control an application happens via REST calls. This eases the integration of Flink in many environments.
 


### PR DESCRIPTION
Updated grammar on the markdown to improve clarity and accuracy. Added the preposition "with" after "work well" and changed "each of" to "with each of" for consistency.