### PR TITLE
Allow content to expire

### DIFF
--- a/_include/.htaccess
+++ b/_include/.htaccess
@@ -1,4 +1,11 @@
-# redirect rules to prevent old links from breaking
+# Allow removed content to expire
+<IfModule mod_expires.c>
+  ExpiresActive on
+  ExpiresByType text/html "access plus 1 hours"
+  ExpiresDefault          "access plus 1 days"
+</IfModule>
+
+# Redirect rules to prevent old links from breaking
 RewriteEngine On
 
 RewriteCond %{HTTPS} off

--- a/content/.htaccess
+++ b/content/.htaccess
@@ -1,4 +1,11 @@
-# redirect rules to prevent old links from breaking
+# Allow removed content to expire
+<IfModule mod_expires.c>
+  ExpiresActive on
+  ExpiresByType text/html "access plus 1 hours"
+  ExpiresDefault          "access plus 1 days"
+</IfModule>
+
+# Redirect rules to prevent old links from breaking
 RewriteEngine On
 
 RewriteCond %{HTTPS} off


### PR DESCRIPTION
The purpose of this PR is to allow expired content on the nightly build Flink website to expire.

Currently, flink-web does not explicitly specify `ExpiresActive` in `.htaccess`, and therefore content expiration is disabled by default. CDN or users' web browser might still serve outdated content even after the content has been removed.

For example, this Flink ML [web link](https://nightlies.apache.org/flink/flink-ml-docs-master/docs/try-flink-ml/quick-start/) still serves a page that has been deleted from the Flink ML repo even though the URL says "flink-ml-docs-master".

This PR fixes this problem by making the following changes:
- Enable expiration by setting `ExpiresActive on`
- Set `text/html` typed content to expire/refresh once every hour.
- Set all other content (e.g. `image/jpg`) to expire/refresh once every day.

See [1] for a discussion of similar issues and the suggestion by Apache infra team. See [2] for documentation of the HTTP directives added in this PR. See [3] for a detailed explanation of the `modification` directive.

[1] https://issues.apache.org/jira/browse/INFRA-18519
[2] https://github.com/apache/echarts-website/blob/asf-site/.htaccess
[3] https://stackoverflow.com/questions/562802/cache-expire-control-with-last-modification