### PR TITLE
[FLINK-25823] Remove Mesos from flink Architecture documentation.

### DIFF
--- a/content/zh/what-is-flink/flink-architecture/index.html
+++ b/content/zh/what-is-flink/flink-architecture/index.html
@@ -14,7 +14,7 @@
 有界流 有定义流的开始，也有定义流的结束。有界流可以在摄取所有数据后再进行计算。有界流所有数据可以被排序，所以并不需要有序摄取。有界流处理通常被称为批处理
 Apache Flink 擅长处理无界和有界数据集 精确的时间控制和状态化使得 Flink 的运行时(runtime)能够运行任何处理无界流的应用。有界流则由一些专为固定大小数据集特殊设计的算法和数据结构进行内部处理，产生了出色的性能。
 通过探索 Flink 之上构建的 用例 来加深理解。
-部署应用到任意地方 # Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 Hadoop YARN、 Apache Mesos 和 Kubernetes，但同时也可以作为独立集群运行。
+部署应用到任意地方 # Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 Hadoop YARN 和 Kubernetes，但同时也可以作为独立集群运行。
 Flink 被设计为能够很好地工作在上述每个资源管理器中，这是通过资源管理器特定(resource-manager-specific)的部署模式实现的。Flink 可以采用与当前资源管理器相适应的方式进行交互。
 部署 Flink 应用程序时，Flink 会根据应用程序配置的并行性自动标识所需的资源，并从资源管理器请求这些资源。在发生故障的情况下，Flink 通过请求新资源来替换发生故障的容器。提交或控制应用程序的所有通信都是通过 REST 调用进行的，这可以简化 Flink 与各种环境中的集成。
 运行任意规模应用 # Flink 旨在任意规模上运行有状态流式应用。因此，应用程序被并行化为可能数千个任务，这些任务分布在集群中并发执行。所以应用程序能够充分利用无尽的 CPU、内存、磁盘和网络 IO。而且 Flink 很容易维护非常大的应用程序状态。其异步和增量的检查点算法对处理延迟产生最小的影响，同时保证精确一次状态的一致性。
@@ -29,7 +29,7 @@ Flink 用户报告了其生产环境中一些令人印象深刻的扩展性数�
 有界流 有定义流的开始，也有定义流的结束。有界流可以在摄取所有数据后再进行计算。有界流所有数据可以被排序，所以并不需要有序摄取。有界流处理通常被称为批处理
 Apache Flink 擅长处理无界和有界数据集 精确的时间控制和状态化使得 Flink 的运行时(runtime)能够运行任何处理无界流的应用。有界流则由一些专为固定大小数据集特殊设计的算法和数据结构进行内部处理，产生了出色的性能。
 通过探索 Flink 之上构建的 用例 来加深理解。
-部署应用到任意地方 # Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 Hadoop YARN、 Apache Mesos 和 Kubernetes，但同时也可以作为独立集群运行。
+部署应用到任意地方 # Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 Hadoop YARN 和 Kubernetes，但同时也可以作为独立集群运行。
 Flink 被设计为能够很好地工作在上述每个资源管理器中，这是通过资源管理器特定(resource-manager-specific)的部署模式实现的。Flink 可以采用与当前资源管理器相适应的方式进行交互。
 部署 Flink 应用程序时，Flink 会根据应用程序配置的并行性自动标识所需的资源，并从资源管理器请求这些资源。在发生故障的情况下，Flink 通过请求新资源来替换发生故障的容器。提交或控制应用程序的所有通信都是通过 REST 调用进行的，这可以简化 Flink 与各种环境中的集成。
 运行任意规模应用 # Flink 旨在任意规模上运行有状态流式应用。因此，应用程序被并行化为可能数千个任务，这些任务分布在集群中并发执行。所以应用程序能够充分利用无尽的 CPU、内存、磁盘和网络 IO。而且 Flink 很容易维护非常大的应用程序状态。其异步和增量的检查点算法对处理延迟产生最小的影响，同时保证精确一次状态的一致性。
@@ -981,7 +981,7 @@ https://github.com/alex-shpak/hugo-book
   部署应用到任意地方
   <a class="anchor" href="#%e9%83%a8%e7%bd%b2%e5%ba%94%e7%94%a8%e5%88%b0%e4%bb%bb%e6%84%8f%e5%9c%b0%e6%96%b9">#</a>
 </h2>
-<p>Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a>、 <a href="https://mesos.apache.org">Apache Mesos</a> 和 <a href="https://kubernetes.io/">Kubernetes</a>，但同时也可以作为独立集群运行。</p>
+<p>Apache Flink 是一个分布式系统，它需要计算资源来执行应用程序。Flink 集成了所有常见的集群资源管理器，例如 <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a> 和 <a href="https://kubernetes.io/">Kubernetes</a>，但同时也可以作为独立集群运行。</p>
 <p>Flink 被设计为能够很好地工作在上述每个资源管理器中，这是通过资源管理器特定(resource-manager-specific)的部署模式实现的。Flink 可以采用与当前资源管理器相适应的方式进行交互。</p>
 <p>部署 Flink 应用程序时，Flink 会根据应用程序配置的并行性自动标识所需的资源，并从资源管理器请求这些资源。在发生故障的情况下，Flink 通过请求新资源来替换发生故障的容器。提交或控制应用程序的所有通信都是通过 REST 调用进行的，这可以简化 Flink 与各种环境中的集成。</p>
 <!-- Add this section once library deployment mode is supported. -->

--- a/docs/content/what-is-flink/flink-architecture.md
+++ b/docs/content/what-is-flink/flink-architecture.md
@@ -28,7 +28,7 @@ Convince yourself by exploring the [use cases]({{< relref "use-cases" >}}) that 
 
 ## Deploy Applications Anywhere
 
-Apache Flink is a distributed system and requires compute resources in order to execute applications. Flink integrates with all common cluster resource managers such as [Hadoop YARN](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html), [Apache Mesos](https://mesos.apache.org), and [Kubernetes](https://kubernetes.io/) but can also be setup to run as a stand-alone cluster.
+Apache Flink is a distributed system and requires compute resources in order to execute applications. Flink integrates with all common cluster resource managers such as [Hadoop YARN](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html) and [Kubernetes](https://kubernetes.io/) but can also be setup to run as a stand-alone cluster.
 
 Flink is designed to work well each of the previously listed resource managers. This is achieved by resource-manager-specific deployment modes that allow Flink to interact with each resource manager in its idiomatic way.
 


### PR DESCRIPTION
Mesos support in Flink is removed as part of [FLINK-23118](https://issues.apache.org/jira/browse/FLINK-23118). 
But currently in Flink Architecture page https://flink.apache.org/what-is-flink/flink-architecture/ still shows Mesos as one of the deployment option. 

## Testing 
1. Made changes in local system . 
2. Started the webservice using `./docker-build.sh`
3. Checked and verified manually 
<img width="1530" alt="Screenshot 2023-10-08 at 1 12 37 AM" src="https://github.com/apache/flink-web/assets/40290566/45177e06-c7f2-48a2-8f79-20fa210e5c48">
