### PR TITLE
[hotfix][docs] Add aliases for moved pages

### DIFF
--- a/docs/content.zh/how-to-contribute/getting-help.md
+++ b/docs/content.zh/how-to-contribute/getting-help.md
@@ -2,6 +2,8 @@
 title: 获取帮助
 bookCollapseSection: false
 weight: 25
+aliases:
+- /getting-help.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/what-is-flink/community.md
+++ b/docs/content.zh/what-is-flink/community.md
@@ -2,6 +2,8 @@
 title: 社区 & 项目信息
 bookCollapseSection: false
 weight: 7
+aliases:
+- /community.html
 
 tables:
     mailing-lists:

--- a/docs/content.zh/what-is-flink/powered-by.md
+++ b/docs/content.zh/what-is-flink/powered-by.md
@@ -2,6 +2,8 @@
 title: Flink 用户
 bookToc: false
 weight: 5
+aliases:
+- /powered-by.html
 
 tables:
     powered-by:

--- a/docs/content.zh/what-is-flink/roadmap.md
+++ b/docs/content.zh/what-is-flink/roadmap.md
@@ -2,6 +2,8 @@
 title: 开发计划
 bookCollapseSection: false
 weight: 6
+aliases:
+- /roadmap.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/what-is-flink/security.md
+++ b/docs/content.zh/what-is-flink/security.md
@@ -2,6 +2,8 @@
 title: Security
 bookCollapseSection: false
 weight: 8
+aliases:
+- /security.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/what-is-flink/use-cases.md
+++ b/docs/content.zh/what-is-flink/use-cases.md
@@ -2,6 +2,8 @@
 title: 应用场景
 bookCollapseSection: false
 weight: 4
+aliases:
+- /use-cases.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/how-to-contribute/getting-help.md
+++ b/docs/content/how-to-contribute/getting-help.md
@@ -2,6 +2,8 @@
 title: Getting Help
 bookCollapseSection: false
 weight: 25
+aliases:
+- /getting-help.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/what-is-flink/community.md
+++ b/docs/content/what-is-flink/community.md
@@ -2,6 +2,8 @@
 title: Community & Project Info
 bookCollapseSection: false
 weight: 7
+aliases:
+- /community.html
 
 tables:
     mailing-lists:

--- a/docs/content/what-is-flink/powered-by.md
+++ b/docs/content/what-is-flink/powered-by.md
@@ -2,6 +2,8 @@
 title: Powered By
 bookToc: false
 weight: 5
+aliases:
+- /powered-by.html
 
 tables:
     powered-by:

--- a/docs/content/what-is-flink/roadmap.md
+++ b/docs/content/what-is-flink/roadmap.md
@@ -2,6 +2,8 @@
 title: Roadmap
 bookCollapseSection: false
 weight: 6
+aliases:
+- /roadmap.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/what-is-flink/security.md
+++ b/docs/content/what-is-flink/security.md
@@ -2,6 +2,8 @@
 title: Security
 bookCollapseSection: false
 weight: 8
+aliases:
+- /security.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/what-is-flink/use-cases.md
+++ b/docs/content/what-is-flink/use-cases.md
@@ -2,6 +2,9 @@
 title: Use Cases
 bookCollapseSection: false
 weight: 4
+aliases:
+- /use-cases.html
+
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
#676 introduced the new website, but moved some pages breaking inbound links for things like Powered By and Use Cases. 

This PR uses Hugo's `alias` feature to set up the necessary redirects. 
