### PR TITLE
[hotfix][docs] Change how-to-contribute empty link to overview page

### DIFF
--- a/docs/content/what-is-flink/community.md
+++ b/docs/content/what-is-flink/community.md
@@ -122,7 +122,7 @@ under the License.
 
 ## How do I get help from Apache Flink?
 
-There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. For user support and questions use the *user mailing list*. You can also join the community on [Slack](#slack). Some committers are also monitoring [Stack Overflow](#stack-overflow). Please remember to tag your questions with the *[apache-flink](http://stackoverflow.com/questions/tagged/apache-flink)* tag. Bugs and feature requests can either be discussed on the *dev mailing list* or on [Jira](#issue-tracker). Those interested in contributing to Flink should check out the [contribution guide]({{< relref "how-to-contribute" >}}).
+There are many ways to get help from the Apache Flink community. The [mailing lists](#mailing-lists) are the primary place where all Flink committers are present. For user support and questions use the *user mailing list*. You can also join the community on [Slack](#slack). Some committers are also monitoring [Stack Overflow](#stack-overflow). Please remember to tag your questions with the *[apache-flink](http://stackoverflow.com/questions/tagged/apache-flink)* tag. Bugs and feature requests can either be discussed on the *dev mailing list* or on [Jira](#issue-tracker). Those interested in contributing to Flink should check out the [contribution guide]({{< relref "how-to-contribute/overview" >}}).
 
 ## Mailing Lists
 


### PR DESCRIPTION
The how-to-contribute link on the [what is flink](https://flink.apache.org/what-is-flink/community/#how-do-i-get-help-from-apache-flink) page currently links to /how-to-contribute/
This is an empty page.
This commit changes the link to /how-to-contribute/overview/ which seems to be the intended helpful page.

I considered using an alias instead if possible, but the /what-is-flink URL also currently opens an empty page (no content), except that it's not linked to from anywhere so user experience is not impacted. So I assume this was a conscious design decision and just changed the link in question from
/how-to-contribute/
to
/how-to-contribute/overview/

I have built it locally with Hugo and tested that it works.
Thanks!