### PR TITLE
Make Flink-specific security page more prominent

### DIFF
--- a/docs/content.zh/what-is-flink/security.md
+++ b/docs/content.zh/what-is-flink/security.md
@@ -102,6 +102,6 @@ Historically, we've received numerous remote code execution vulnerability report
 
 ### I found a vulnerability in Flink, how do I report it?
 
-Thanks a lot for looking into the security of Apache Flink! We appreciate reports improving the security of Flink. We accept vulnerability reports through the [Apache Security Team](http://www.apache.org/security/), via their private email address [security@apache.org](mailto:security@apache.org).
+Thanks a lot for looking into the security of Apache Flink! We appreciate reports improving the security of Flink. We accept vulnerability reports through the [Apache Security Team](https://www.apache.org/security/), via their private email address [security@apache.org](mailto:security@apache.org).
 
 If you want to discuss a potential security issue privately with the Flink PMC, you can reach us also via [private@flink.apache.org](mailto:private@flink.apache.org).

--- a/docs/content/what-is-flink/security.md
+++ b/docs/content/what-is-flink/security.md
@@ -102,6 +102,6 @@ Historically, we've received numerous remote code execution vulnerability report
 
 ### I found a vulnerability in Flink, how do I report it?
 
-Thanks a lot for looking into the security of Apache Flink! We appreciate reports improving the security of Flink. We accept vulnerability reports through the [Apache Security Team](http://www.apache.org/security/), via their private email address [security@apache.org](mailto:security@apache.org).
+Thanks a lot for looking into the security of Apache Flink! We appreciate reports improving the security of Flink. We accept vulnerability reports through the [Apache Security Team](https://www.apache.org/security/), via their private email address [security@apache.org](mailto:security@apache.org).
 
 If you want to discuss a potential security issue privately with the Flink PMC, you can reach us also via [private@flink.apache.org](mailto:private@flink.apache.org).

--- a/docs/layouts/partials/docs/footer.html
+++ b/docs/layouts/partials/docs/footer.html
@@ -59,7 +59,7 @@ under the License.
       <div class="panel">
         <ul>
           <li>
-            <a href="https://www.apache.org/security/">{{ i18n "footer.security" }}</a>
+            <a href="{{ $.Site.LanguagePrefix }}/what-is-flink/security">{{ i18n "footer.security" }}</a-->
           </li>
           <li>
             <a href="https://www.apache.org/foundation/sponsorship.html">{{ i18n "footer.donate" }}</a>


### PR DESCRIPTION
As this will be relevant to Flink users.

This page then links to the generic information at https://www.apache.org/security