### PR TITLE
[hotfix] fix typo in the 1.18.1 release announcement

### DIFF
--- a/content/2014/08/26/apache-flink-0.6-available/index.html
+++ b/content/2014/08/26/apache-flink-0.6-available/index.html
@@ -29,7 +29,7 @@ What is Flink? # Apache Flink is a general-purpose data processing engine for cl
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2014/09/26/apache-flink-0.6.1-available/index.html
+++ b/content/2014/09/26/apache-flink-0.6.1-available/index.html
@@ -31,7 +31,7 @@ Download the release today." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2014/10/03/upcoming-events/index.html
+++ b/content/2014/10/03/upcoming-events/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2014/11/04/apache-flink-0.7.0-available/index.html
+++ b/content/2014/11/04/apache-flink-0.7.0-available/index.html
@@ -33,7 +33,7 @@ Overview of major new features # Flink Streaming: The gem of the 0." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2014/11/18/hadoop-compatibility-in-flink/index.html
+++ b/content/2014/11/18/hadoop-compatibility-in-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/01/06/december-2014-in-the-flink-community/index.html
+++ b/content/2015/01/06/december-2014-in-the-flink-community/index.html
@@ -29,7 +29,7 @@ Flink graduation # The biggest news is that the Apache board approved Flink as a
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/01/21/apache-flink-0.8.0-available/index.html
+++ b/content/2015/01/21/apache-flink-0.8.0-available/index.html
@@ -33,7 +33,7 @@ Overview of major new features # Extended filesystem support: The former Distrib
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/02/04/january-2015-in-the-flink-community/index.html
+++ b/content/2015/02/04/january-2015-in-the-flink-community/index.html
@@ -33,7 +33,7 @@ Articles in the press # The Apache Software Foundation announced Flink as a Top-
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/02/09/introducing-flink-streaming/index.html
+++ b/content/2015/02/09/introducing-flink-streaming/index.html
@@ -29,7 +29,7 @@ In this post, we go through an example that uses the Flink Streaming API to comp
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/03/02/february-2015-in-the-flink-community/index.html
+++ b/content/2015/03/02/february-2015-in-the-flink-community/index.html
@@ -31,7 +31,7 @@ New committer # Max Michels has been voted a committer by the Flink PMC." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/03/13/peeking-into-apache-flinks-engine-room/index.html
+++ b/content/2015/03/13/peeking-into-apache-flinks-engine-room/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/04/07/march-2015-in-the-flink-community/index.html
+++ b/content/2015/04/07/march-2015-in-the-flink-community/index.html
@@ -31,7 +31,7 @@ Learn about the internals of Flink # The community has started an effort to bett
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/04/13/announcing-flink-0.9.0-milestone1-preview-release/index.html
+++ b/content/2015/04/13/announcing-flink-0.9.0-milestone1-preview-release/index.html
@@ -29,7 +29,7 @@ You can download the release here and check out the latest documentation here." 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/05/11/juggling-with-bits-and-bytes/index.html
+++ b/content/2015/05/11/juggling-with-bits-and-bytes/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/05/14/april-2015-in-the-flink-community/index.html
+++ b/content/2015/05/14/april-2015-in-the-flink-community/index.html
@@ -31,7 +31,7 @@ Flink 0." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/06/24/announcing-apache-flink-0.9.0/index.html
+++ b/content/2015/06/24/announcing-apache-flink-0.9.0/index.html
@@ -29,7 +29,7 @@ Download the release and check out the documentation. Feedback through the Flink
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/08/24/introducing-gelly-graph-processing-with-apache-flink/index.html
+++ b/content/2015/08/24/introducing-gelly-graph-processing-with-apache-flink/index.html
@@ -29,7 +29,7 @@ Gelly allows Flink users to perform end-to-end data analysis in a single system.
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/09/01/apache-flink-0.9.1-available/index.html
+++ b/content/2015/09/01/apache-flink-0.9.1-available/index.html
@@ -33,7 +33,7 @@ The following issues were fixed for this release:" />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/09/03/announcing-flink-forward-2015/index.html
+++ b/content/2015/09/03/announcing-flink-forward-2015/index.html
@@ -29,7 +29,7 @@ The conference program has been announced by the organizers and a program commit
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/09/16/off-heap-memory-in-apache-flink-and-the-curious-jit-compiler/index.html
+++ b/content/2015/09/16/off-heap-memory-in-apache-flink-and-the-curious-jit-compiler/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/11/16/announcing-apache-flink-0.10.0/index.html
+++ b/content/2015/11/16/announcing-apache-flink-0.10.0/index.html
@@ -29,7 +29,7 @@ For Flink 0.10.0, the focus of the community was to graduate the DataStream API 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/11/27/flink-0.10.1-released/index.html
+++ b/content/2015/11/27/flink-0.10.1-released/index.html
@@ -31,7 +31,7 @@ Issues fixed # [FLINK-2879] - Links in documentation are broken [FLINK-2938] - S
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/12/04/introducing-stream-windows-in-apache-flink/index.html
+++ b/content/2015/12/04/introducing-stream-windows-in-apache-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/12/11/storm-compatibility-in-apache-flink-how-to-run-existing-storm-topologies-on-flink/index.html
+++ b/content/2015/12/11/storm-compatibility-in-apache-flink-how-to-run-existing-storm-topologies-on-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2015/12/18/flink-2015-a-year-in-review-and-a-lookout-to-2016/index.html
+++ b/content/2015/12/18/flink-2015-a-year-in-review-and-a-lookout-to-2016/index.html
@@ -29,7 +29,7 @@ Overall, we have seen Flink grow in terms of functionality from an engine to one
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/02/11/flink-0.10.2-released/index.html
+++ b/content/2016/02/11/flink-0.10.2-released/index.html
@@ -31,7 +31,7 @@ Issues fixed # FLINK-3242: Adjust StateBackendITCase for 0.10 signatures of stat
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/03/08/announcing-apache-flink-1.0.0/index.html
+++ b/content/2016/03/08/announcing-apache-flink-1.0.0/index.html
@@ -29,7 +29,7 @@ Flink version 1.0.0 marks the beginning of the 1.X.X series of releases, which w
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/04/06/flink-1.0.1-released/index.html
+++ b/content/2016/04/06/flink-1.0.1-released/index.html
@@ -31,7 +31,7 @@ Fixed Issues # Bug [FLINK-3179] - Combiner is not injected if Reduce or GroupRed
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/04/06/introducing-complex-event-processing-cep-with-apache-flink/index.html
+++ b/content/2016/04/06/introducing-complex-event-processing-cep-with-apache-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/04/14/flink-forward-2016-call-for-submissions-is-now-open/index.html
+++ b/content/2016/04/14/flink-forward-2016-call-for-submissions-is-now-open/index.html
@@ -29,7 +29,7 @@ The conference welcomes submissions on everything Flink-related, including exper
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/04/22/flink-1.0.2-released/index.html
+++ b/content/2016/04/22/flink-1.0.2-released/index.html
@@ -31,7 +31,7 @@ Fixed Issues # Bug # [FLINK-3657] [dataSet] Change access of DataSetUtils.countE
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/05/11/flink-1.0.3-released/index.html
+++ b/content/2016/05/11/flink-1.0.3-released/index.html
@@ -31,7 +31,7 @@ Fixed Issues # Bug # [FLINK-3790] [streaming] Use proper hadoop config in rollin
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/05/24/stream-processing-for-everyone-with-sql-and-apache-flink/index.html
+++ b/content/2016/05/24/stream-processing-for-everyone-with-sql-and-apache-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/08/04/announcing-apache-flink-1.1.0/index.html
+++ b/content/2016/08/04/announcing-apache-flink-1.1.0/index.html
@@ -29,7 +29,7 @@ This release is the first major release in the 1.X.X series of releases, which m
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/08/04/flink-1.1.1-released/index.html
+++ b/content/2016/08/04/flink-1.1.1-released/index.html
@@ -31,7 +31,7 @@ This was fixed with this release and we highly recommend all users to use this v
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/08/24/flink-forward-2016-announcing-schedule-keynotes-and-panel-discussion/index.html
+++ b/content/2016/08/24/flink-forward-2016-announcing-schedule-keynotes-and-panel-discussion/index.html
@@ -29,7 +29,7 @@ Ted Dunning has been announced as a keynote speaker at the event. Ted is the VP 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/09/05/apache-flink-1.1.2-released/index.html
+++ b/content/2016/09/05/apache-flink-1.1.2-released/index.html
@@ -33,7 +33,7 @@ Release Notes - Flink - Version 1.1.2 [FLINK-4236] - Flink Dashboard stops showi
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/10/12/apache-flink-1.1.3-released/index.html
+++ b/content/2016/10/12/apache-flink-1.1.3-released/index.html
@@ -33,7 +33,7 @@ Note for RocksDB Backend Users # It is highly recommended to use the &ldquo;full
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/12/19/apache-flink-in-2016-year-in-review/index.html
+++ b/content/2016/12/19/apache-flink-in-2016-year-in-review/index.html
@@ -29,7 +29,7 @@ In this post, we’ll look back on the project’s progress over the course of 2
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2016/12/21/apache-flink-1.1.4-released/index.html
+++ b/content/2016/12/21/apache-flink-1.1.4-released/index.html
@@ -33,7 +33,7 @@ Note for RocksDB Backend Users # We updated Flink&rsquo;s RocksDB dependency ver
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/02/06/announcing-apache-flink-1.2.0/index.html
+++ b/content/2017/02/06/announcing-apache-flink-1.2.0/index.html
@@ -31,7 +31,7 @@ We encourage everyone to download the release and check out the documentation." 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/03/23/apache-flink-1.1.5-released/index.html
+++ b/content/2017/03/23/apache-flink-1.1.5-released/index.html
@@ -31,7 +31,7 @@ This release includes critical fixes for HA recovery robustness, fault tolerance
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/03/29/from-streams-to-tables-and-back-again-an-update-on-flinks-table-sql-api/index.html
+++ b/content/2017/03/29/from-streams-to-tables-and-back-again-an-update-on-flinks-table-sql-api/index.html
@@ -29,7 +29,7 @@ Flink&rsquo;s DataStream abstraction is a powerful API which lets you flexibly d
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/03/30/continuous-queries-on-dynamic-tables/index.html
+++ b/content/2017/03/30/continuous-queries-on-dynamic-tables/index.html
@@ -29,7 +29,7 @@ Apache Flink is very well suited to power streaming analytics applications becau
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/04/26/apache-flink-1.2.1-released/index.html
+++ b/content/2017/04/26/apache-flink-1.2.1-released/index.html
@@ -35,7 +35,7 @@ FLINK-6353 Restoring using CheckpointedRestoring does not work from 1.2 to 1.2 F
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/05/16/introducing-docker-images-for-apache-flink/index.html
+++ b/content/2017/05/16/introducing-docker-images-for-apache-flink/index.html
@@ -29,7 +29,7 @@ A community-maintained way to run Apache Flink on Docker and other container run
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/06/01/apache-flink-1.3.0-release-announcement/index.html
+++ b/content/2017/06/01/apache-flink-1.3.0-release-announcement/index.html
@@ -31,7 +31,7 @@ Users can expect Flink releases now in a 4 month cycle." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/06/23/apache-flink-1.3.1-released/index.html
+++ b/content/2017/06/23/apache-flink-1.3.1-released/index.html
@@ -33,7 +33,7 @@ We highly recommend all users to upgrade to Flink 1.3.1.
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/07/04/a-deep-dive-into-rescalable-state-in-apache-flink/index.html
+++ b/content/2017/07/04/a-deep-dive-into-rescalable-state-in-apache-flink/index.html
@@ -29,7 +29,7 @@ In contrast, operators in stateless stream processing only consider their curren
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/08/05/apache-flink-1.3.2-released/index.html
+++ b/content/2017/08/05/apache-flink-1.3.2-released/index.html
@@ -33,7 +33,7 @@ Important Notice: A user reported a bug in the FlinkKafkaConsumer (FLINK-7143) t
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/11/21/looking-ahead-to-apache-flink-1.4.0-and-1.5.0/index.html
+++ b/content/2017/11/21/looking-ahead-to-apache-flink-1.4.0-and-1.5.0/index.html
@@ -29,7 +29,7 @@ Both releases include ambitious features that we believe will move Flink to an e
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/12/12/apache-flink-1.4.0-release-announcement/index.html
+++ b/content/2017/12/12/apache-flink-1.4.0-release-announcement/index.html
@@ -31,7 +31,7 @@ We encourage everyone to download the release and check out the documentation." 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2017/12/21/apache-flink-in-2017-year-in-review/index.html
+++ b/content/2017/12/21/apache-flink-in-2017-year-in-review/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/01/30/managing-large-state-in-apache-flink-an-intro-to-incremental-checkpointing/index.html
+++ b/content/2018/01/30/managing-large-state-in-apache-flink-an-intro-to-incremental-checkpointing/index.html
@@ -29,7 +29,7 @@ State is a fundamental, enabling concept in stream processing required for a maj
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/02/15/apache-flink-1.4.1-released/index.html
+++ b/content/2018/02/15/apache-flink-1.4.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/02/28/an-overview-of-end-to-end-exactly-once-processing-in-apache-flink-with-apache-kafka-too/index.html
+++ b/content/2018/02/28/an-overview-of-end-to-end-exactly-once-processing-in-apache-flink-with-apache-kafka-too/index.html
@@ -29,7 +29,7 @@ Apache Flink 1.4.0, released in December 2017, introduced a significant mileston
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/03/08/apache-flink-1.4.2-released/index.html
+++ b/content/2018/03/08/apache-flink-1.4.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/03/15/apache-flink-1.3.3-released/index.html
+++ b/content/2018/03/15/apache-flink-1.3.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/05/18/apache-flink-1.5.0-release-announcement/index.html
+++ b/content/2018/05/18/apache-flink-1.5.0-release-announcement/index.html
@@ -31,7 +31,7 @@ We encourage everyone to download the release and check out the documentation." 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/07/12/apache-flink-1.5.1-released/index.html
+++ b/content/2018/07/12/apache-flink-1.5.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/07/31/apache-flink-1.5.2-released/index.html
+++ b/content/2018/07/31/apache-flink-1.5.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/08/09/apache-flink-1.6.0-release-announcement/index.html
+++ b/content/2018/08/09/apache-flink-1.6.0-release-announcement/index.html
@@ -31,7 +31,7 @@ We encourage everyone to download the release and check out the documentation." 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/08/21/apache-flink-1.5.3-released/index.html
+++ b/content/2018/08/21/apache-flink-1.5.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/09/20/apache-flink-1.5.4-released/index.html
+++ b/content/2018/09/20/apache-flink-1.5.4-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/09/20/apache-flink-1.6.1-released/index.html
+++ b/content/2018/09/20/apache-flink-1.6.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/10/29/apache-flink-1.5.5-released/index.html
+++ b/content/2018/10/29/apache-flink-1.5.5-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/10/29/apache-flink-1.6.2-released/index.html
+++ b/content/2018/10/29/apache-flink-1.6.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/11/30/apache-flink-1.7.0-release-announcement/index.html
+++ b/content/2018/11/30/apache-flink-1.7.0-release-announcement/index.html
@@ -29,7 +29,7 @@ Flink 1.7.0 is API-compatible with previous 1.x.y releases for APIs annotated wi
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/12/21/apache-flink-1.7.1-released/index.html
+++ b/content/2018/12/21/apache-flink-1.7.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/12/22/apache-flink-1.6.3-released/index.html
+++ b/content/2018/12/22/apache-flink-1.6.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2018/12/26/apache-flink-1.5.6-released/index.html
+++ b/content/2018/12/26/apache-flink-1.5.6-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/02/13/batch-as-a-special-case-of-streaming-and-alibabas-contribution-of-blink/index.html
+++ b/content/2019/02/13/batch-as-a-special-case-of-streaming-and-alibabas-contribution-of-blink/index.html
@@ -29,7 +29,7 @@ A Unified Approach to Batch and Streaming # Since its early days, Apache Flink h
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/02/15/apache-flink-1.7.2-released/index.html
+++ b/content/2019/02/15/apache-flink-1.7.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/02/21/monitoring-apache-flink-applications-101/index.html
+++ b/content/2019/02/21/monitoring-apache-flink-applications-101/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/02/25/apache-flink-1.6.4-released/index.html
+++ b/content/2019/02/25/apache-flink-1.6.4-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/03/06/what-to-expect-from-flink-forward-san-francisco-2019/index.html
+++ b/content/2019/03/06/what-to-expect-from-flink-forward-san-francisco-2019/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/03/11/flink-and-prometheus-cloud-native-monitoring-of-streaming-applications/index.html
+++ b/content/2019/03/11/flink-and-prometheus-cloud-native-monitoring-of-streaming-applications/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/04/09/apache-flink-1.8.0-release-announcement/index.html
+++ b/content/2019/04/09/apache-flink-1.8.0-release-announcement/index.html
@@ -29,7 +29,7 @@ Flink 1.8.0 is API-compatible with previous 1.x.y releases for APIs annotated wi
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/04/17/apache-flinks-application-to-season-of-docs/index.html
+++ b/content/2019/04/17/apache-flinks-application-to-season-of-docs/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/05/03/when-flink-pulsar-come-together/index.html
+++ b/content/2019/05/03/when-flink-pulsar-come-together/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/05/14/flux-capacitor-huh-temporal-tables-and-joins-in-streaming-sql/index.html
+++ b/content/2019/05/14/flux-capacitor-huh-temporal-tables-and-joins-in-streaming-sql/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/05/17/state-ttl-in-flink-1.8.0-how-to-automatically-cleanup-application-state-in-apache-flink/index.html
+++ b/content/2019/05/17/state-ttl-in-flink-1.8.0-how-to-automatically-cleanup-application-state-in-apache-flink/index.html
@@ -29,7 +29,7 @@ In this post, we motivate the State TTL feature and discuss its use cases." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/06/05/a-deep-dive-into-flinks-network-stack/index.html
+++ b/content/2019/06/05/a-deep-dive-into-flinks-network-stack/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/06/26/a-practical-guide-to-broadcast-state-in-apache-flink/index.html
+++ b/content/2019/06/26/a-practical-guide-to-broadcast-state-in-apache-flink/index.html
@@ -29,7 +29,7 @@ What is Broadcast State? # The Broadcast State can be used to combine and jointl
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/07/02/apache-flink-1.8.1-released/index.html
+++ b/content/2019/07/02/apache-flink-1.8.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/07/23/flink-network-stack-vol.-2-monitoring-metrics-and-that-backpressure-thing/index.html
+++ b/content/2019/07/23/flink-network-stack-vol.-2-monitoring-metrics-and-that-backpressure-thing/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/08/22/apache-flink-1.9.0-release-announcement/index.html
+++ b/content/2019/08/22/apache-flink-1.9.0-release-announcement/index.html
@@ -29,7 +29,7 @@ The Apache Flink project&rsquo;s goal is to develop a stream processing system t
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/09/05/flink-community-update-september19/index.html
+++ b/content/2019/09/05/flink-community-update-september19/index.html
@@ -29,7 +29,7 @@ The first post in the series takes you on an little detour across the year, to f
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/09/11/apache-flink-1.8.2-released/index.html
+++ b/content/2019/09/11/apache-flink-1.8.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/09/13/the-state-processor-api-how-to-read-write-and-modify-the-state-of-flink-applications/index.html
+++ b/content/2019/09/13/the-state-processor-api-how-to-read-write-and-modify-the-state-of-flink-applications/index.html
@@ -29,7 +29,7 @@ In this post, we explain why this feature is a big step for Flink, what you can 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/10/18/apache-flink-1.9.1-released/index.html
+++ b/content/2019/10/18/apache-flink-1.9.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/11/06/running-apache-flink-on-kubernetes-with-kudo/index.html
+++ b/content/2019/11/06/running-apache-flink-on-kubernetes-with-kudo/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/11/25/how-to-query-pulsar-streams-using-apache-flink/index.html
+++ b/content/2019/11/25/how-to-query-pulsar-streams-using-apache-flink/index.html
@@ -29,7 +29,7 @@ A short intro to Apache Pulsar # Apache Pulsar is a flexible pub/sub messaging s
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2019/12/11/apache-flink-1.8.3-released/index.html
+++ b/content/2019/12/11/apache-flink-1.8.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/01/15/advanced-flink-application-patterns-vol.1-case-study-of-a-fraud-detection-system/index.html
+++ b/content/2020/01/15/advanced-flink-application-patterns-vol.1-case-study-of-a-fraud-detection-system/index.html
@@ -31,7 +31,7 @@ Dynamic updates of application logic allow Flink jobs to change at runtime, with
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink/index.html
+++ b/content/2020/01/29/state-unlocked-interacting-with-state-in-apache-flink/index.html
@@ -29,7 +29,7 @@ In order to provide a state-of-the-art experience to Flink developers, the Apach
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/01/30/apache-flink-1.9.2-released/index.html
+++ b/content/2020/01/30/apache-flink-1.9.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/02/03/a-guide-for-unit-testing-in-apache-flink/index.html
+++ b/content/2020/02/03/a-guide-for-unit-testing-in-apache-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/02/11/apache-flink-1.10.0-release-announcement/index.html
+++ b/content/2020/02/11/apache-flink-1.10.0-release-announcement/index.html
@@ -29,7 +29,7 @@ Flink 1.10 also marks the completion of the Blink integration, hardening streami
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/02/20/no-java-required-configuring-sources-and-sinks-in-sql/index.html
+++ b/content/2020/02/20/no-java-required-configuring-sources-and-sinks-in-sql/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink/index.html
+++ b/content/2020/02/22/apache-beam-how-beam-runs-on-top-of-flink/index.html
@@ -29,7 +29,7 @@ Apache Flink and Apache Beam are open-source frameworks for parallel, distribute
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/03/24/advanced-flink-application-patterns-vol.2-dynamic-updates-of-application-logic/index.html
+++ b/content/2020/03/24/advanced-flink-application-patterns-vol.2-dynamic-updates-of-application-logic/index.html
@@ -29,7 +29,7 @@ We intentionally omitted details of how the applied rules are initialized and wh
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/03/27/flink-as-unified-engine-for-modern-data-warehousing-production-ready-hive-integration/index.html
+++ b/content/2020/03/27/flink-as-unified-engine-for-modern-data-warehousing-production-ready-hive-integration/index.html
@@ -33,7 +33,7 @@ Firstly, today’s business is shifting to a more real-time fashion, and thus de
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/03/30/flink-community-update-april20/index.html
+++ b/content/2020/03/30/flink-community-update-april20/index.html
@@ -29,7 +29,7 @@ And since now it&rsquo;s more important than ever to keep up the spirits, we’d
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/04/07/stateful-functions-2.0-an-event-driven-database-on-apache-flink/index.html
+++ b/content/2020/04/07/stateful-functions-2.0-an-event-driven-database-on-apache-flink/index.html
@@ -29,7 +29,7 @@ Stateful Functions 2.0 makes it possible to combine StateFun’s powerful approa
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/04/09/pyflink-introducing-python-support-for-udfs-in-flinks-table-api/index.html
+++ b/content/2020/04/09/pyflink-introducing-python-support-for-udfs-in-flinks-table-api/index.html
@@ -29,7 +29,7 @@ In Flink 1.10, the community further extended the support for Python by adding P
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/04/15/flink-serialization-tuning-vol.-1-choosing-your-serializer-if-you-can/index.html
+++ b/content/2020/04/15/flink-serialization-tuning-vol.-1-choosing-your-serializer-if-you-can/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/04/21/memory-management-improvements-with-apache-flink-1.10/index.html
+++ b/content/2020/04/21/memory-management-improvements-with-apache-flink-1.10/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/04/24/apache-flink-1.9.3-released/index.html
+++ b/content/2020/04/24/apache-flink-1.9.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/05/04/applying-to-google-season-of-docs-2020/index.html
+++ b/content/2020/05/04/applying-to-google-season-of-docs-2020/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/05/06/flink-community-update-may20/index.html
+++ b/content/2020/05/06/flink-community-update-may20/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/05/12/apache-flink-1.10.1-released/index.html
+++ b/content/2020/05/12/apache-flink-1.10.1-released/index.html
@@ -33,7 +33,7 @@ Note FLINK-16684 changed the builders of the StreamingFileSink to make them comp
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/06/09/stateful-functions-2.1.0-release-announcement/index.html
+++ b/content/2020/06/09/stateful-functions-2.1.0-release-announcement/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/06/10/flink-community-update-june20/index.html
+++ b/content/2020/06/10/flink-community-update-june20/index.html
@@ -29,7 +29,7 @@ To top it off, a piece of good news: Flink Forward is back on October 19-22 as a
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/06/15/flink-on-zeppelin-notebooks-for-interactive-data-analysis-part-1/index.html
+++ b/content/2020/06/15/flink-on-zeppelin-notebooks-for-interactive-data-analysis-part-1/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/06/23/flink-on-zeppelin-notebooks-for-interactive-data-analysis-part-2/index.html
+++ b/content/2020/06/23/flink-on-zeppelin-notebooks-for-interactive-data-analysis-part-2/index.html
@@ -29,7 +29,7 @@ Streaming Data Visualization # With Zeppelin, you can build a real time streamin
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/06/apache-flink-1.11.0-release-announcement/index.html
+++ b/content/2020/07/06/apache-flink-1.11.0-release-announcement/index.html
@@ -29,7 +29,7 @@ The core engine is introducing unaligned checkpoints, a major change to Flink&rs
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/14/application-deployment-in-flink-current-state-and-the-new-application-mode/index.html
+++ b/content/2020/07/14/application-deployment-in-flink-current-state-and-the-new-application-mode/index.html
@@ -29,7 +29,7 @@ These platforms aim at simplifying application submission internally by lifting 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/21/apache-flink-1.11.1-released/index.html
+++ b/content/2020/07/21/apache-flink-1.11.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/23/sharing-is-caring-catalogs-in-flink-sql/index.html
+++ b/content/2020/07/23/sharing-is-caring-catalogs-in-flink-sql/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/28/flink-sql-demo-building-an-end-to-end-streaming-application/index.html
+++ b/content/2020/07/28/flink-sql-demo-building-an-end-to-end-streaming-application/index.html
@@ -29,7 +29,7 @@ In the following sections, we describe how to integrate Kafka, MySQL, Elasticsea
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/29/flink-community-update-july20/index.html
+++ b/content/2020/07/29/flink-community-update-july20/index.html
@@ -31,7 +31,7 @@ The Past Month in Flink # Flink Releases # Flink 1.11 # A couple of weeks ago, F
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/07/30/advanced-flink-application-patterns-vol.3-custom-window-processing/index.html
+++ b/content/2020/07/30/advanced-flink-application-patterns-vol.3-custom-window-processing/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/08/04/pyflink-the-integration-of-pandas-into-pyflink/index.html
+++ b/content/2020/08/04/pyflink-the-integration-of-pandas-into-pyflink/index.html
@@ -29,7 +29,7 @@ Pic source: VanderPlas 2017, slide 52." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/08/06/accelerating-your-workload-with-gpu-and-other-external-resources/index.html
+++ b/content/2020/08/06/accelerating-your-workload-with-gpu-and-other-external-resources/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/08/18/monitoring-and-controlling-networks-of-iot-devices-with-flink-stateful-functions/index.html
+++ b/content/2020/08/18/monitoring-and-controlling-networks-of-iot-devices-with-flink-stateful-functions/index.html
@@ -29,7 +29,7 @@ IoT networks are composed of many individual, but interconnected components, whi
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/08/20/the-state-of-flink-on-docker/index.html
+++ b/content/2020/08/20/the-state-of-flink-on-docker/index.html
@@ -33,7 +33,7 @@ Reduce confusion: Flink used to have 2 Dockerfiles and a 3rd file maintained out
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/08/25/apache-flink-1.10.2-released/index.html
+++ b/content/2020/08/25/apache-flink-1.10.2-released/index.html
@@ -33,7 +33,7 @@ Note After FLINK-18242, the deprecated `OptionsFactory` and `ConfigurableOptions
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/09/01/memory-management-improvements-for-flinks-jobmanager-in-apache-flink-1.11/index.html
+++ b/content/2020/09/01/memory-management-improvements-for-flinks-jobmanager-in-apache-flink-1.11/index.html
@@ -29,7 +29,7 @@ The previous blog post focused on the memory model of the TaskManagers and how i
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/09/04/flink-community-update-august20/index.html
+++ b/content/2020/09/04/flink-community-update-august20/index.html
@@ -29,7 +29,7 @@ The Past Month in Flink # Flink Releases # Getting Ready for Flink Stateful Func
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/09/17/apache-flink-1.11.2-released/index.html
+++ b/content/2020/09/17/apache-flink-1.11.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/09/28/stateful-functions-2.2.0-release-announcement/index.html
+++ b/content/2020/09/28/stateful-functions-2.2.0-release-announcement/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/10/13/stateful-functions-internals-behind-the-scenes-of-stateful-serverless/index.html
+++ b/content/2020/10/13/stateful-functions-internals-behind-the-scenes-of-stateful-serverless/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1-checkpoints-alignment-and-backpressure/index.html
+++ b/content/2020/10/15/from-aligned-to-unaligned-checkpoints-part-1-checkpoints-alignment-and-backpressure/index.html
@@ -29,7 +29,7 @@ Despite all these great properties, Flink&rsquo;s checkpointing method has an Ac
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/11/11/stateful-functions-2.2.1-release-announcement/index.html
+++ b/content/2020/11/11/stateful-functions-2.2.1-release-announcement/index.html
@@ -31,7 +31,7 @@ We strongly recommend all users to upgrade to 2." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/12/02/improvements-in-task-scheduling-for-batch-workloads-in-apache-flink-1.12/index.html
+++ b/content/2020/12/02/improvements-in-task-scheduling-for-batch-workloads-in-apache-flink-1.12/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/12/10/apache-flink-1.12.0-release-announcement/index.html
+++ b/content/2020/12/10/apache-flink-1.12.0-release-announcement/index.html
@@ -31,7 +31,7 @@ The community has added support for efficient batch execution in the DataStream 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2020/12/18/apache-flink-1.11.3-released/index.html
+++ b/content/2020/12/18/apache-flink-1.11.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/02/stateful-functions-2.2.2-release-announcement/index.html
+++ b/content/2021/01/02/stateful-functions-2.2.2-release-announcement/index.html
@@ -29,7 +29,7 @@ The most important change of this bugfix release is upgrading Apache Flink to ve
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/07/whats-new-in-the-pulsar-flink-connector-2.7.0/index.html
+++ b/content/2021/01/07/whats-new-in-the-pulsar-flink-connector-2.7.0/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/11/exploring-fine-grained-recovery-of-bounded-data-sets-on-flink/index.html
+++ b/content/2021/01/11/exploring-fine-grained-recovery-of-bounded-data-sets-on-flink/index.html
@@ -29,7 +29,7 @@ Processing efficiency is not the only parameter users of data processing systems
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/18/using-rocksdb-state-backend-in-apache-flink-when-and-how/index.html
+++ b/content/2021/01/18/using-rocksdb-state-backend-in-apache-flink-when-and-how/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/19/apache-flink-1.12.1-released/index.html
+++ b/content/2021/01/19/apache-flink-1.12.1-released/index.html
@@ -33,7 +33,7 @@ Attention: Using unaligned checkpoints in Flink 1.12.0 combined with two/multipl
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/01/29/apache-flink-1.10.3-released/index.html
+++ b/content/2021/01/29/apache-flink-1.10.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/02/10/how-to-natively-deploy-flink-on-kubernetes-with-high-availability-ha/index.html
+++ b/content/2021/02/10/how-to-natively-deploy-flink-on-kubernetes-with-high-availability-ha/index.html
@@ -29,7 +29,7 @@ From release to release, the Flink community has made significant progress in in
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/03/03/apache-flink-1.12.2-released/index.html
+++ b/content/2021/03/03/apache-flink-1.12.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/03/11/a-rundown-of-batch-execution-mode-in-the-datastream-api/index.html
+++ b/content/2021/03/11/a-rundown-of-batch-execution-mode-in-the-datastream-api/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/04/15/stateful-functions-3.0.0-remote-functions-front-and-center/index.html
+++ b/content/2021/04/15/stateful-functions-3.0.0-remote-functions-front-and-center/index.html
@@ -29,7 +29,7 @@ This new release brings remote functions to the front and center of StateFun, ma
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/04/29/apache-flink-1.12.3-released/index.html
+++ b/content/2021/04/29/apache-flink-1.12.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/05/03/apache-flink-1.13.0-release-announcement/index.html
+++ b/content/2021/05/03/apache-flink-1.13.0-release-announcement/index.html
@@ -29,7 +29,7 @@ The release brings us a big step forward in one of our major efforts: Making Str
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/05/06/scaling-flink-automatically-with-reactive-mode/index.html
+++ b/content/2021/05/06/scaling-flink-automatically-with-reactive-mode/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/05/21/apache-flink-1.12.4-released/index.html
+++ b/content/2021/05/21/apache-flink-1.12.4-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/05/28/apache-flink-1.13.1-released/index.html
+++ b/content/2021/05/28/apache-flink-1.13.1-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/07/07/how-to-identify-the-source-of-backpressure/index.html
+++ b/content/2021/07/07/how-to-identify-the-source-of-backpressure/index.html
@@ -29,7 +29,7 @@ The backpressure topic was tackled from different angles over the last couple of
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/08/06/apache-flink-1.12.5-released/index.html
+++ b/content/2021/08/06/apache-flink-1.12.5-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/08/06/apache-flink-1.13.2-released/index.html
+++ b/content/2021/08/06/apache-flink-1.13.2-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/08/09/apache-flink-1.11.4-released/index.html
+++ b/content/2021/08/09/apache-flink-1.11.4-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/08/31/help-us-stabilize-apache-flink-1.14.0-rc0/index.html
+++ b/content/2021/08/31/help-us-stabilize-apache-flink-1.14.0-rc0/index.html
@@ -31,7 +31,7 @@ A lot of features and fixes went into this release, including improvements to th
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/08/31/stateful-functions-3.1.0-release-announcement/index.html
+++ b/content/2021/08/31/stateful-functions-3.1.0-release-announcement/index.html
@@ -29,7 +29,7 @@ The binary distribution and source artifacts are now available on the updated Do
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/09/07/implementing-a-custom-source-connector-for-table-api-and-sql-part-one/index.html
+++ b/content/2021/09/07/implementing-a-custom-source-connector-for-table-api-and-sql-part-one/index.html
@@ -29,7 +29,7 @@ Introduction # Apache Flink is a data processing engine that aims to keep state 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/09/07/implementing-a-custom-source-connector-for-table-api-and-sql-part-two/index.html
+++ b/content/2021/09/07/implementing-a-custom-source-connector-for-table-api-and-sql-part-two/index.html
@@ -31,7 +31,7 @@ integrate a source connector which connects to a mailbox using the IMAP protocol
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/09/29/apache-flink-1.14.0-release-announcement/index.html
+++ b/content/2021/09/29/apache-flink-1.14.0-release-announcement/index.html
@@ -29,7 +29,7 @@ This release brings many new features and improvements in areas such as the SQL 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/10/19/apache-flink-1.13.3-released/index.html
+++ b/content/2021/10/19/apache-flink-1.13.3-released/index.html
@@ -35,7 +35,7 @@ Updated Maven dependencies:
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/10/26/sort-based-blocking-shuffle-implementation-in-flink-part-one/index.html
+++ b/content/2021/10/26/sort-based-blocking-shuffle-implementation-in-flink-part-one/index.html
@@ -29,7 +29,7 @@ How data gets passed around between operators # Data shuffling is an important s
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/10/26/sort-based-blocking-shuffle-implementation-in-flink-part-two/index.html
+++ b/content/2021/10/26/sort-based-blocking-shuffle-implementation-in-flink-part-two/index.html
@@ -29,7 +29,7 @@ Like sort-merge shuffle implemented by other distributed data processing framewo
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/11/03/flink-backward-the-apache-flink-retrospective/index.html
+++ b/content/2021/11/03/flink-backward-the-apache-flink-retrospective/index.html
@@ -29,7 +29,7 @@ A retrospective on the release cycle # From the team, we collected emotions that
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/12/10/advise-on-apache-log4j-zero-day-cve-2021-44228/index.html
+++ b/content/2021/12/10/advise-on-apache-log4j-zero-day-cve-2021-44228/index.html
@@ -31,7 +31,7 @@ env.java.opts: -Dlog4j2.formatMsgNoLookups=true If you are already setting env."
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/12/16/apache-flink-log4j-emergency-releases/index.html
+++ b/content/2021/12/16/apache-flink-log4j-emergency-releases/index.html
@@ -35,7 +35,7 @@ We are publishing this announcement earlier than usual to give users access to t
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2021/12/22/apache-flink-statefun-log4j-emergency-release/index.html
+++ b/content/2021/12/22/apache-flink-statefun-log4j-emergency-release/index.html
@@ -33,7 +33,7 @@ You can find the source and binaries on the updated Downloads page, and Docker i
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/04/how-we-improved-scheduler-performance-for-large-scale-jobs-part-one/index.html
+++ b/content/2022/01/04/how-we-improved-scheduler-performance-for-large-scale-jobs-part-one/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/04/how-we-improved-scheduler-performance-for-large-scale-jobs-part-two/index.html
+++ b/content/2022/01/04/how-we-improved-scheduler-performance-for-large-scale-jobs-part-two/index.html
@@ -29,7 +29,7 @@ Reducing complexity with groups # A distribution pattern describes how consumer 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/07/apache-flink-ml-2.0.0-release-announcement/index.html
+++ b/content/2022/01/07/apache-flink-ml-2.0.0-release-announcement/index.html
@@ -29,7 +29,7 @@ This release involves a major refactor of the earlier Flink ML library and intro
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/17/apache-flink-1.14.3-release-announcement/index.html
+++ b/content/2022/01/17/apache-flink-1.14.3-release-announcement/index.html
@@ -29,7 +29,7 @@ This release includes 164 fixes and minor improvements for Flink 1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/20/pravega-flink-connector-101/index.html
+++ b/content/2022/01/20/pravega-flink-connector-101/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/01/31/stateful-functions-3.2.0-release-announcement/index.html
+++ b/content/2022/01/31/stateful-functions-3.2.0-release-announcement/index.html
@@ -29,7 +29,7 @@ The binary distribution and source artifacts are now available on the updated Do
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/02/18/apache-flink-1.13.6-release-announcement/index.html
+++ b/content/2022/02/18/apache-flink-1.13.6-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users to upgrade to Flink 1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/02/22/scala-free-in-one-fifteen/index.html
+++ b/content/2022/02/22/scala-free-in-one-fifteen/index.html
@@ -31,7 +31,7 @@ TLDR: All Scala dependencies are now isolated to the flink-scala jar." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/03/11/apache-flink-1.14.4-release-announcement/index.html
+++ b/content/2022/03/11/apache-flink-1.14.4-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Artifacts # Maven Dependencies # &lt;dependency&gt; &lt;groupId&gt;org."
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/03/16/the-generic-asynchronous-base-sink/index.html
+++ b/content/2022/03/16/the-generic-asynchronous-base-sink/index.html
@@ -31,7 +31,7 @@ This is a base implementation for asynchronous sinks, which you should use whene
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/04/03/apache-flink-kubernetes-operator-0.1.0-release-announcement/index.html
+++ b/content/2022/04/03/apache-flink-kubernetes-operator-0.1.0-release-announcement/index.html
@@ -31,7 +31,7 @@ The operator takes care of submitting, savepointing, upgrading and generally man
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/05/announcing-the-release-of-apache-flink-1.15/index.html
+++ b/content/2022/05/05/announcing-the-release-of-apache-flink-1.15/index.html
@@ -29,7 +29,7 @@ One of the main concepts that makes Apache Flink stand out is the unification of
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/06/exploring-the-thread-mode-in-pyflink/index.html
+++ b/content/2022/05/06/exploring-the-thread-mode-in-pyflink/index.html
@@ -29,7 +29,7 @@ Before Flink 1.15, Python user-defined functions will be executed in separate Py
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/06/improvements-to-flink-operations-snapshots-ownership-and-savepoint-formats/index.html
+++ b/content/2022/05/06/improvements-to-flink-operations-snapshots-ownership-and-savepoint-formats/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/11/apache-flink-table-store-0.1.0-release-announcement/index.html
+++ b/content/2022/05/11/apache-flink-table-store-0.1.0-release-announcement/index.html
@@ -33,7 +33,7 @@ What is Flink Table Store # In the past years, thanks to our numerous contributo
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/18/getting-into-low-latency-gears-with-apache-flink-part-one/index.html
+++ b/content/2022/05/18/getting-into-low-latency-gears-with-apache-flink-part-one/index.html
@@ -29,7 +29,7 @@ In this multi-part series, we will present a collection of low-latency technique
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/23/getting-into-low-latency-gears-with-apache-flink-part-two/index.html
+++ b/content/2022/05/23/getting-into-low-latency-gears-with-apache-flink-part-two/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/05/30/improving-speed-and-stability-of-checkpointing-with-generic-log-based-incremental-checkpoints/index.html
+++ b/content/2022/05/30/improving-speed-and-stability-of-checkpointing-with-generic-log-based-incremental-checkpoints/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/06/05/apache-flink-kubernetes-operator-1.0.0-release-announcement/index.html
+++ b/content/2022/06/05/apache-flink-kubernetes-operator-1.0.0-release-announcement/index.html
@@ -31,7 +31,7 @@ New v1beta1 API version &amp; compatibility guarantees Session Job Management su
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/06/17/adaptive-batch-scheduler-automatically-decide-parallelism-of-flink-batch-jobs/index.html
+++ b/content/2022/06/17/adaptive-batch-scheduler-automatically-decide-parallelism-of-flink-batch-jobs/index.html
@@ -29,7 +29,7 @@ To decide a proper parallelism, one needs to know how much data each operator ne
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/06/22/apache-flink-1.14.5-release-announcement/index.html
+++ b/content/2022/06/22/apache-flink-1.14.5-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Artifacts # Maven Dependencies # &lt;dependency&gt; &lt;groupId&gt;org."
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/07/06/apache-flink-1.15.1-release-announcement/index.html
+++ b/content/2022/07/06/apache-flink-1.15.1-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.15.1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/07/11/flip-147-support-checkpoints-after-tasks-finished-part-one/index.html
+++ b/content/2022/07/11/flip-147-support-checkpoints-after-tasks-finished-part-one/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/07/11/flip-147-support-checkpoints-after-tasks-finished-part-two/index.html
+++ b/content/2022/07/11/flip-147-support-checkpoints-after-tasks-finished-part-two/index.html
@@ -29,7 +29,7 @@ Implementation of support Checkpointing with Finished Tasks # As described in pa
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/07/12/apache-flink-ml-2.1.0-release-announcement/index.html
+++ b/content/2022/07/12/apache-flink-ml-2.1.0-release-announcement/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/07/25/apache-flink-kubernetes-operator-1.1.0-release-announcement/index.html
+++ b/content/2022/07/25/apache-flink-kubernetes-operator-1.1.0-release-announcement/index.html
@@ -31,7 +31,7 @@ Release Highlights # A non-exhaustive list of some of the more exciting features
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/08/24/apache-flink-1.15.2-release-announcement/index.html
+++ b/content/2022/08/24/apache-flink-1.15.2-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.15.2." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/08/29/apache-flink-table-store-0.2.0-release-announcement/index.html
+++ b/content/2022/08/29/apache-flink-table-store-0.2.0-release-announcement/index.html
@@ -33,7 +33,7 @@ As a new type of updatable data lake, Flink Table Store has the following featur
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/09/08/regarding-akkas-licensing-change/index.html
+++ b/content/2022/09/08/regarding-akkas-licensing-change/index.html
@@ -31,7 +31,7 @@ The purpose of this blogpost is to clarify our position on the matter." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/09/28/apache-flink-1.14.6-release-announcement/index.html
+++ b/content/2022/09/28/apache-flink-1.14.6-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Artifacts # Maven Dependencies # &lt;dependency&gt; &lt;groupId&gt;org."
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/10/07/apache-flink-kubernetes-operator-1.2.0-release-announcement/index.html
+++ b/content/2022/10/07/apache-flink-kubernetes-operator-1.2.0-release-announcement/index.html
@@ -29,7 +29,7 @@ Release Highlights # Standalone deployment mode support Improved upgrade flow Re
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/10/13/apache-flink-table-store-0.2.1-release-announcement/index.html
+++ b/content/2022/10/13/apache-flink-table-store-0.2.1-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Artifacts # Binaries # You can find the binaries on the updated Download
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/10/28/announcing-the-release-of-apache-flink-1.16/index.html
+++ b/content/2022/10/28/announcing-the-release-of-apache-flink-1.16/index.html
@@ -29,7 +29,7 @@ Flink has become the leading role and factual standard of stream processing, and
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/11/10/apache-flink-1.15.3-release-announcement/index.html
+++ b/content/2022/11/10/apache-flink-1.15.3-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.15.3." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/11/25/optimising-the-throughput-of-async-sinks-using-a-custom-ratelimitingstrategy/index.html
+++ b/content/2022/11/25/optimising-the-throughput-of-async-sinks-using-a-custom-ratelimitingstrategy/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2022/12/14/apache-flink-kubernetes-operator-1.3.0-release-announcement/index.html
+++ b/content/2022/12/14/apache-flink-kubernetes-operator-1.3.0-release-announcement/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/01/10/apache-flink-kubernetes-operator-1.3.1-release-announcement/index.html
+++ b/content/2023/01/10/apache-flink-kubernetes-operator-1.3.1-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Notes # Bug # [FLINK-30329] - flink-kubernetes-operator helm chart does 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/01/13/apache-flink-table-store-0.3.0-release-announcement/index.html
+++ b/content/2023/01/13/apache-flink-table-store-0.3.0-release-announcement/index.html
@@ -33,7 +33,7 @@ Flink Table Store 0.3 completes many exciting features, enhances its ability as 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/01/20/delegation-token-framework-obtain-distribute-and-use-temporary-credentials-automatically/index.html
+++ b/content/2023/01/20/delegation-token-framework-obtain-distribute-and-use-temporary-credentials-automatically/index.html
@@ -29,7 +29,7 @@ Introduction # Authentication in distributed systems is not an easy task. Previo
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/01/30/apache-flink-1.16.1-release-announcement/index.html
+++ b/content/2023/01/30/apache-flink-1.16.1-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.16.1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/02/27/apache-flink-kubernetes-operator-1.4.0-release-announcement/index.html
+++ b/content/2023/02/27/apache-flink-kubernetes-operator-1.4.0-release-announcement/index.html
@@ -29,7 +29,7 @@ Flink Streaming Job Autoscaler # A highly requested feature for Flink applicatio
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/03/15/apache-flink-1.15.4-release-announcement/index.html
+++ b/content/2023/03/15/apache-flink-1.15.4-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.15.4." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/03/23/announcing-the-release-of-apache-flink-1.17/index.html
+++ b/content/2023/03/23/announcing-the-release-of-apache-flink-1.17/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/04/19/apache-flink-ml-2.2.0-release-announcement/index.html
+++ b/content/2023/04/19/apache-flink-ml-2.2.0-release-announcement/index.html
@@ -29,7 +29,7 @@ With the addition of these algorithms, we believe Flink ML library is ready for 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/03/howto-create-a-batch-source-with-the-new-source-framework/index.html
+++ b/content/2023/05/03/howto-create-a-batch-source-with-the-new-source-framework/index.html
@@ -29,7 +29,7 @@ Implementing the source components # The source architecture is depicted in the 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/09/howto-migrate-a-real-life-batch-pipeline-from-the-dataset-api-to-the-datastream-api/index.html
+++ b/content/2023/05/09/howto-migrate-a-real-life-batch-pipeline-from-the-dataset-api-to-the-datastream-api/index.html
@@ -27,7 +27,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/12/howto-test-a-batch-source-with-the-new-source-framework/index.html
+++ b/content/2023/05/12/howto-test-a-batch-source-with-the-new-source-framework/index.html
@@ -29,7 +29,7 @@ Unit testing the source # Testing the serializers # Example Cassandra SplitSeria
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/17/apache-flink-kubernetes-operator-1.5.0-release-announcement/index.html
+++ b/content/2023/05/17/apache-flink-kubernetes-operator-1.5.0-release-announcement/index.html
@@ -29,7 +29,7 @@ We encourage you to download the release and share your feedback with the commun
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/25/apache-flink-1.16.2-release-announcement/index.html
+++ b/content/2023/05/25/apache-flink-1.16.2-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.16.2." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/05/25/apache-flink-1.17.1-release-announcement/index.html
+++ b/content/2023/05/25/apache-flink-1.17.1-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.17.1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/07/03/sigmod-systems-award-for-apache-flink/index.html
+++ b/content/2023/07/03/sigmod-systems-award-for-apache-flink/index.html
@@ -33,7 +33,7 @@ Winning of SIGMOD Systems Award indicates the high recognition of Flink&rsquo;s 
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/08/04/announcing-three-new-apache-flink-connectors-the-new-connector-versioning-strategy-and-externalization/index.html
+++ b/content/2023/08/04/announcing-three-new-apache-flink-connectors-the-new-connector-versioning-strategy-and-externalization/index.html
@@ -29,7 +29,7 @@ Amazon DynamoDB - This connector includes a sink that provides at-least-once del
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/08/15/apache-flink-kubernetes-operator-1.6.0-release-announcement/index.html
+++ b/content/2023/08/15/apache-flink-kubernetes-operator-1.6.0-release-announcement/index.html
@@ -31,7 +31,7 @@ Highlights # Improved and simplified rollback mechanism # Previously the rollbac
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/09/19/stateful-functions-3.3.0-release-announcement/index.html
+++ b/content/2023/09/19/stateful-functions-3.3.0-release-announcement/index.html
@@ -31,7 +31,7 @@ The binary distribution and source artifacts are now available on the updated Do
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/10/24/announcing-the-release-of-apache-flink-1.18/index.html
+++ b/content/2023/10/24/announcing-the-release-of-apache-flink-1.18/index.html
@@ -31,7 +31,7 @@ Towards a Streaming Lakehouse # Flink SQL Improvements # Introduce Flink JDBC Dr
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/10/27/apache-flink-kubernetes-operator-1.6.1-release-announcement/index.html
+++ b/content/2023/10/27/apache-flink-kubernetes-operator-1.6.1-release-announcement/index.html
@@ -33,7 +33,7 @@ Release Notes # Bug # [FLINK-32890] Correct HA patch check for zookeeper metadat
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/11/22/apache-flink-kubernetes-operator-1.7.0-release-announcement/index.html
+++ b/content/2023/11/22/apache-flink-kubernetes-operator-1.7.0-release-announcement/index.html
@@ -29,7 +29,7 @@ We encourage you to download the release and share your feedback with the commun
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/11/29/apache-flink-1.16.3-release-announcement/index.html
+++ b/content/2023/11/29/apache-flink-1.16.3-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.16.3." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2023/11/29/apache-flink-1.17.2-release-announcement/index.html
+++ b/content/2023/11/29/apache-flink-1.17.2-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.17.2." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/2024/01/19/apache-flink-1.18.1-release-announcement/index.html
+++ b/content/2024/01/19/apache-flink-1.18.1-release-announcement/index.html
@@ -31,7 +31,7 @@ We highly recommend all users upgrade to Flink 1.18.1." />
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -476,7 +476,7 @@ Below you will find a list of all bugfixes and improvements (excluding improveme
 <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&amp;version=12353640">JIRA</a>.</p>
 <p>We highly recommend all users upgrade to Flink 1.18.1.</p>
 <p><strong>Note: Users that have <a href="https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/ops/state/large_state_tuning/#compression">state compression</a>
-should not migrated to 1.18.1 (nor 1.18.0) due to a critical bug that could lead to data loss. Please refer to <a href="https://issues.apache.org/jira/browse/FLINK-34063">FLINK-34063</a> for more information.</strong></p>
+should not migrate to 1.18.1 (nor 1.18.0) due to a critical bug that could lead to data loss. Please refer to <a href="https://issues.apache.org/jira/browse/FLINK-34063">FLINK-34063</a> for more information.</strong></p>
 <h1 id="release-artifacts">
   Release Artifacts
   <a class="anchor" href="#release-artifacts">#</a>

--- a/content/404.html
+++ b/content/404.html
@@ -14,7 +14,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/categories/index.html
+++ b/content/categories/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/categories/" title="Categories">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/categories/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/documentation/flink-kubernetes-operator-master/index.html
+++ b/content/documentation/flink-kubernetes-operator-master/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-kubernetes-operator-master/" title="Kubernetes Operator Main (snapshot)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flink-kubernetes-operator-stable/index.html
+++ b/content/documentation/flink-kubernetes-operator-stable/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-kubernetes-operator-stable/" title="Kubernetes Operator 1.7 (latest)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flink-master/index.html
+++ b/content/documentation/flink-master/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-master/" title="Flink Master (snapshot)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flink-stable/index.html
+++ b/content/documentation/flink-stable/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-stable/" title="Flink 1.18 (stable)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flink-stateful-functions-master/index.html
+++ b/content/documentation/flink-stateful-functions-master/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-stateful-functions-master/" title="Stateful Functions Master (snapshot)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flink-stateful-functions-stable/index.html
+++ b/content/documentation/flink-stateful-functions-stable/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flink-stateful-functions-stable/" title="Stateful Functions 3.3 (stable)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flinkml-master/index.html
+++ b/content/documentation/flinkml-master/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flinkml-master/" title="ML Master (snapshot)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/flinkml-stable/index.html
+++ b/content/documentation/flinkml-stable/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/flinkml-stable/" title="ML 2.3 (stable)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/documentation/index.html
+++ b/content/documentation/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/" title="Documentation">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/documentation/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/documentation/paimon-incubating-master/index.html
+++ b/content/documentation/paimon-incubating-master/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/documentation/paimon-incubating-master/" title="Paimon(incubating) (formely Flink Table Store) Master">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/downloads/index.html
+++ b/content/downloads/index.html
@@ -39,7 +39,7 @@ Apache Flink 1." />
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/downloads/" title="Downloads">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/flink-packages/index.html
+++ b/content/flink-packages/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/flink-packages/" title="flink-packages.org">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/index.html
+++ b/content/getting-started/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/" title="教程">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/getting-started/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/getting-started/training-course/index.html
+++ b/content/getting-started/training-course/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/training-course/" title="Training Course">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/with-flink-kubernetes-operator/index.html
+++ b/content/getting-started/with-flink-kubernetes-operator/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/with-flink-kubernetes-operator/" title="With Flink Kubernetes Operator">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/with-flink-ml/index.html
+++ b/content/getting-started/with-flink-ml/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/with-flink-ml/" title="With Flink ML">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/with-flink-stateful-functions/index.html
+++ b/content/getting-started/with-flink-stateful-functions/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/with-flink-stateful-functions/" title="With Flink Stateful Functions">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/with-flink/index.html
+++ b/content/getting-started/with-flink/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/with-flink/" title="With Flink">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/getting-started/with-paimon-incubating/index.html
+++ b/content/getting-started/with-paimon-incubating/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/getting-started/with-paimon-incubating/" title="With Paimon(incubating) (formerly Flink Table Store)">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/code-style-and-quality-common/index.html
+++ b/content/how-to-contribute/code-style-and-quality-common/index.html
@@ -31,7 +31,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-common/" title="Code Style and Quality Guide — Common Rules">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -456,33 +456,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Common Rules
   <a class="anchor" href="#code-style-and-quality-guide--common-rules">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode64s0hbhb">
+<h4 id="preamblehahahugoshortcode60s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode64s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode60s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode64s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode60s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode64s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode60s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode64s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode60s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode64s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode60s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode64s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode60s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode64s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode60s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode64s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode60s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode64s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode60s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode64s5hbhb">
+<h4 id="components-guidehahahugoshortcode60s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode64s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode60s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode64s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode60s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode64s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode60s6hbhb">#</a>
 </h4>
 <hr>
 <h2 id="1-copyright">

--- a/content/how-to-contribute/code-style-and-quality-components/index.html
+++ b/content/how-to-contribute/code-style-and-quality-components/index.html
@@ -33,7 +33,7 @@ Configuration Changes # Where should the config option go?
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-components/" title="Apache Flink 代码样式和质量指南 — 组件">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -458,33 +458,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Components Guide
   <a class="anchor" href="#code-style-and-quality-guide--components-guide">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode67s0hbhb">
+<h4 id="preamblehahahugoshortcode62s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode67s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode62s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode67s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode62s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode67s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode62s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode67s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode62s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode67s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode62s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode67s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode62s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode67s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode62s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode67s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode62s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode67s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode62s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode67s5hbhb">
+<h4 id="components-guidehahahugoshortcode62s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode67s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode62s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode67s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode62s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode67s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode62s6hbhb">#</a>
 </h4>
 <h2 id="component-specific-guidelines">
   Component Specific Guidelines

--- a/content/how-to-contribute/code-style-and-quality-formatting/index.html
+++ b/content/how-to-contribute/code-style-and-quality-formatting/index.html
@@ -31,7 +31,7 @@ License # Apache license headers." />
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-formatting/" title="Code Style and Quality Guide — Formatting Guide">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -456,33 +456,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Formatting Guide
   <a class="anchor" href="#code-style-and-quality-guide--formatting-guide">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode69s0hbhb">
+<h4 id="preamblehahahugoshortcode64s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode69s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode64s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode69s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode64s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode69s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode64s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode69s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode64s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode69s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode64s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode69s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode64s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode69s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode64s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode69s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode64s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode69s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode64s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode69s5hbhb">
+<h4 id="components-guidehahahugoshortcode64s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode69s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode64s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode69s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode64s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode69s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode64s6hbhb">#</a>
 </h4>
 <h2 id="java-code-formatting-style">
   Java Code Formatting Style

--- a/content/how-to-contribute/code-style-and-quality-java/index.html
+++ b/content/how-to-contribute/code-style-and-quality-java/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-java/" title="Code Style and Quality Guide — Java">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -454,33 +454,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Java
   <a class="anchor" href="#code-style-and-quality-guide--java">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode70s0hbhb">
+<h4 id="preamblehahahugoshortcode66s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode70s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode66s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode70s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode66s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode70s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode66s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode70s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode66s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode70s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode66s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode70s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode66s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode70s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode66s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode70s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode66s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode70s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode66s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode70s5hbhb">
+<h4 id="components-guidehahahugoshortcode66s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode70s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode66s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode70s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode66s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode70s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode66s6hbhb">#</a>
 </h4>
 <h2 id="java-language-features-and-libraries">
   Java Language Features and Libraries

--- a/content/how-to-contribute/code-style-and-quality-preamble/index.html
+++ b/content/how-to-contribute/code-style-and-quality-preamble/index.html
@@ -31,7 +31,7 @@ A code contribution (or any piece of code) can be evaluated in various ways: One
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-preamble/" title="代码样式与质量指南">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -456,33 +456,33 @@ https://github.com/alex-shpak/hugo-book
   Apache Flink Code Style and Quality Guide
   <a class="anchor" href="#apache-flink-code-style-and-quality-guide">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode72s0hbhb">
+<h4 id="preamblehahahugoshortcode68s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode72s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode68s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode72s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode68s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode72s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode68s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode72s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode68s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode72s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode68s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode72s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode68s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode72s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode68s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode72s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode68s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode72s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode68s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode72s5hbhb">
+<h4 id="components-guidehahahugoshortcode68s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode72s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode68s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode72s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode68s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode72s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode68s6hbhb">#</a>
 </h4>
 <hr>
 <p>This is an attempt to capture the code and quality standard that we want to maintain.</p>

--- a/content/how-to-contribute/code-style-and-quality-pull-requests/index.html
+++ b/content/how-to-contribute/code-style-and-quality-pull-requests/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-pull-requests/" title="Code Style and Quality Guide — Pull Requests & Changes">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -454,33 +454,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Pull Requests &amp; Changes
   <a class="anchor" href="#code-style-and-quality-guide--pull-requests--changes">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode74s0hbhb">
+<h4 id="preamblehahahugoshortcode69s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode74s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode69s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode74s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode69s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode74s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode69s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode74s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode69s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode74s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode69s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode74s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode69s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode74s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode69s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode74s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode69s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode74s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode69s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode74s5hbhb">
+<h4 id="components-guidehahahugoshortcode69s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode74s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode69s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode74s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode69s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode74s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode69s6hbhb">#</a>
 </h4>
 <hr>
 <p><strong>Rationale:</strong> We ask contributors to put in a little bit of extra effort to bring pull requests into a state that they can be more easily and more thoroughly reviewed. This helps the community in many ways:</p>

--- a/content/how-to-contribute/code-style-and-quality-scala/index.html
+++ b/content/how-to-contribute/code-style-and-quality-scala/index.html
@@ -31,7 +31,7 @@ We do not use Scala in the core APIs and runtime components. We aim to remove ex
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/code-style-and-quality-scala/" title="Code Style and Quality Guide — Scala">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book
@@ -456,33 +456,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Scala
   <a class="anchor" href="#code-style-and-quality-guide--scala">#</a>
 </h1>
-<h4 id="preamblehahahugoshortcode76s0hbhb">
+<h4 id="preamblehahahugoshortcode71s0hbhb">
   <a href="/how-to-contribute/code-style-and-quality-preamble/">Preamble</a>
-  <a class="anchor" href="#preamblehahahugoshortcode76s0hbhb">#</a>
+  <a class="anchor" href="#preamblehahahugoshortcode71s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode76s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode71s1hbhb">
   <a href="/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode76s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode71s1hbhb">#</a>
 </h4>
-<h4 id="common-coding-guidehahahugoshortcode76s2hbhb">
+<h4 id="common-coding-guidehahahugoshortcode71s2hbhb">
   <a href="/how-to-contribute/code-style-and-quality-common/">Common Coding Guide</a>
-  <a class="anchor" href="#common-coding-guidehahahugoshortcode76s2hbhb">#</a>
+  <a class="anchor" href="#common-coding-guidehahahugoshortcode71s2hbhb">#</a>
 </h4>
-<h4 id="java-language-guidehahahugoshortcode76s3hbhb">
+<h4 id="java-language-guidehahahugoshortcode71s3hbhb">
   <a href="/how-to-contribute/code-style-and-quality-java/">Java Language Guide</a>
-  <a class="anchor" href="#java-language-guidehahahugoshortcode76s3hbhb">#</a>
+  <a class="anchor" href="#java-language-guidehahahugoshortcode71s3hbhb">#</a>
 </h4>
-<h4 id="scala-language-guidehahahugoshortcode76s4hbhb">
+<h4 id="scala-language-guidehahahugoshortcode71s4hbhb">
   <a href="/how-to-contribute/code-style-and-quality-scala/">Scala Language Guide</a>
-  <a class="anchor" href="#scala-language-guidehahahugoshortcode76s4hbhb">#</a>
+  <a class="anchor" href="#scala-language-guidehahahugoshortcode71s4hbhb">#</a>
 </h4>
-<h4 id="components-guidehahahugoshortcode76s5hbhb">
+<h4 id="components-guidehahahugoshortcode71s5hbhb">
   <a href="/how-to-contribute/code-style-and-quality-components/">Components Guide</a>
-  <a class="anchor" href="#components-guidehahahugoshortcode76s5hbhb">#</a>
+  <a class="anchor" href="#components-guidehahahugoshortcode71s5hbhb">#</a>
 </h4>
-<h4 id="formatting-guidehahahugoshortcode76s6hbhb">
+<h4 id="formatting-guidehahahugoshortcode71s6hbhb">
   <a href="/how-to-contribute/code-style-and-quality-formatting/">Formatting Guide</a>
-  <a class="anchor" href="#formatting-guidehahahugoshortcode76s6hbhb">#</a>
+  <a class="anchor" href="#formatting-guidehahahugoshortcode71s6hbhb">#</a>
 </h4>
 <h2 id="scala-language-features">
   Scala Language Features

--- a/content/how-to-contribute/contribute-code/index.html
+++ b/content/how-to-contribute/contribute-code/index.html
@@ -31,7 +31,7 @@ Please feel free to ask questions at any time. Either send a mail to the Dev mai
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/contribute-code/" title="贡献代码">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/contribute-documentation/index.html
+++ b/content/how-to-contribute/contribute-documentation/index.html
@@ -31,7 +31,7 @@ Obtain the documentation sources # Apache Flink&rsquo;s documentation is maintai
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/contribute-documentation/" title="贡献文档">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/documentation-style-guide/index.html
+++ b/content/how-to-contribute/documentation-style-guide/index.html
@@ -31,7 +31,7 @@ Language # The Flink documentation is maintained in US English and Chinese — w
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/documentation-style-guide/" title="文档样式指南">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/getting-help/index.html
+++ b/content/how-to-contribute/getting-help/index.html
@@ -33,7 +33,7 @@ Before posting to the mailing list, you can search the mailing list archives for
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/getting-help/" title="获取帮助">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/improve-website/index.html
+++ b/content/how-to-contribute/improve-website/index.html
@@ -33,7 +33,7 @@ Obtain the website sources # The website of Apache Flink is hosted in a dedicate
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/improve-website/" title="贡献网站">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/index.html
+++ b/content/how-to-contribute/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/" title="How to Contribute">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/how-to-contribute/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/how-to-contribute/overview/index.html
+++ b/content/how-to-contribute/overview/index.html
@@ -31,7 +31,7 @@ What do you want to do?" />
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/overview/" title="如何参与贡献">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/how-to-contribute/reviewing-prs/index.html
+++ b/content/how-to-contribute/reviewing-prs/index.html
@@ -31,7 +31,7 @@ Contributors have a good contribution experience. Our reviews are structured and
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/how-to-contribute/reviewing-prs/" title="审核 Pull Request">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/index.html
+++ b/content/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/" title="Apache Flink Documentation">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/material/index.html
+++ b/content/material/index.html
@@ -33,7 +33,7 @@ Sizes (px): 50x50, 100x100, 200x200, 500x500, 1000x1000 You can find more varian
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/material/" title="素材">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/posts/index.html
+++ b/content/posts/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/10/index.html
+++ b/content/posts/page/10/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/11/index.html
+++ b/content/posts/page/11/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/12/index.html
+++ b/content/posts/page/12/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/13/index.html
+++ b/content/posts/page/13/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/14/index.html
+++ b/content/posts/page/14/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/15/index.html
+++ b/content/posts/page/15/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/16/index.html
+++ b/content/posts/page/16/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/17/index.html
+++ b/content/posts/page/17/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/18/index.html
+++ b/content/posts/page/18/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/19/index.html
+++ b/content/posts/page/19/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/2/index.html
+++ b/content/posts/page/2/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/20/index.html
+++ b/content/posts/page/20/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/21/index.html
+++ b/content/posts/page/21/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/22/index.html
+++ b/content/posts/page/22/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/23/index.html
+++ b/content/posts/page/23/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/3/index.html
+++ b/content/posts/page/3/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/4/index.html
+++ b/content/posts/page/4/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/5/index.html
+++ b/content/posts/page/5/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/6/index.html
+++ b/content/posts/page/6/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/7/index.html
+++ b/content/posts/page/7/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/8/index.html
+++ b/content/posts/page/8/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/posts/page/9/index.html
+++ b/content/posts/page/9/index.html
@@ -25,7 +25,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.png" type="image/x-icon">
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/posts/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/tags/index.html
+++ b/content/tags/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/tags/" title="Tags">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/tags/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/what-is-flink-ml/index.html
+++ b/content/what-is-flink-ml/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink-ml/" title="What is Flink ML?">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink-table-store/index.html
+++ b/content/what-is-flink-table-store/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink-table-store/" title="What is Paimon(incubating) (formerly Flink Table Store)?">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/community/index.html
+++ b/content/what-is-flink/community/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/community/" title="社区 & 项目信息">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/flink-applications/index.html
+++ b/content/what-is-flink/flink-applications/index.html
@@ -33,7 +33,7 @@ Building Blocks for Streaming Applications # The types of applications that can 
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/flink-applications/" title="应用">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/flink-architecture/index.html
+++ b/content/what-is-flink/flink-architecture/index.html
@@ -33,7 +33,7 @@ Process Unbounded and Bounded Data # Any kind of data is produced as a stream of
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/flink-architecture/" title="架构">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/flink-operations/index.html
+++ b/content/what-is-flink/flink-operations/index.html
@@ -31,7 +31,7 @@ Apache Flink puts a strong focus on the operational aspects of stream processing
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/flink-operations/" title="运维">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/index.html
+++ b/content/what-is-flink/index.html
@@ -27,7 +27,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/" title="About">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <link rel="alternate" type="application/rss+xml" href="https://flink.apache.org/what-is-flink/index.xml" title="Apache Flink" />
 <!--
 Made with Book Theme

--- a/content/what-is-flink/powered-by/index.html
+++ b/content/what-is-flink/powered-by/index.html
@@ -31,7 +31,7 @@ More Flink users are listed in the Powered by Flink directory in the project wik
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/powered-by/" title="Flink 用户">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/roadmap/index.html
+++ b/content/what-is-flink/roadmap/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/roadmap/" title="开发计划">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/security/index.html
+++ b/content/what-is-flink/security/index.html
@@ -31,7 +31,7 @@ CVE ID Affected Flink versions Notes CVE-2020-1960 1.1.0 to 1.1.5, 1.2.0 to 1.2.
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/security/" title="Security">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-flink/use-cases/index.html
+++ b/content/what-is-flink/use-cases/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-flink/use-cases/" title="应用场景">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-stateful-functions/index.html
+++ b/content/what-is-stateful-functions/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-stateful-functions/" title="What is Stateful Functions?">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/what-is-the-flink-kubernetes-operator/index.html
+++ b/content/what-is-the-flink-kubernetes-operator/index.html
@@ -29,7 +29,7 @@
 <link rel="alternate" hreflang="zh" href="https://flink.apache.org/zh/what-is-the-flink-kubernetes-operator/" title="What is the Flink Kubernetes Operator?">
 
 <link rel="stylesheet" href="/book.min.22eceb4d17baa9cdc0f57345edd6f215a40474022dfee39b63befb5fb3c596b5.css" integrity="sha256-IuzrTRe6qc3A9XNF7dbyFaQEdAIt/uObY777X7PFlrU=">
-<script defer src="/en.search.min.63c84dc2f0d6c34d9051e5db0b2c6c91eb96240f6f36621deff1107931cc680c.js" integrity="sha256-Y8hNwvDWw02QUeXbCyxskeuWJA9vNmId7/EQeTHMaAw="></script>
+<script defer src="/en.search.min.54f31e780f4da3b370af7de57cdb9ff799e74e7571f20639ad80ed6ecfc6d464.js" integrity="sha256-VPMeeA9No7Nwr33lfNuf95nnTnVx8gY5rYDtbs/G1GQ="></script>
 <!--
 Made with Book Theme
 https://github.com/alex-shpak/hugo-book

--- a/content/zh/how-to-contribute/code-style-and-quality-common/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-common/index.html
@@ -453,33 +453,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Common Rules
   <a class="anchor" href="#code-style-and-quality-guide--common-rules">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode49s0hbhb">
+<h4 id="序言hahahugoshortcode52s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode49s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode52s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode49s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode52s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode49s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode52s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode49s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode52s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode49s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode52s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode49s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode52s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode49s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode52s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode49s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode52s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode49s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode52s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode49s5hbhb">
+<h4 id="组件指南hahahugoshortcode52s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode49s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode52s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode49s6hbhb">
+<h4 id="格式指南hahahugoshortcode52s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode49s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode52s6hbhb">#</a>
 </h4>
 <hr>
 <h2 id="1-copyright">

--- a/content/zh/how-to-contribute/code-style-and-quality-components/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-components/index.html
@@ -459,33 +459,33 @@ https://github.com/alex-shpak/hugo-book
   Apache Flink 代码样式和质量指南 — 组件
   <a class="anchor" href="#apache-flink-%e4%bb%a3%e7%a0%81%e6%a0%b7%e5%bc%8f%e5%92%8c%e8%b4%a8%e9%87%8f%e6%8c%87%e5%8d%97--%e7%bb%84%e4%bb%b6">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode52s0hbhb">
+<h4 id="序言hahahugoshortcode56s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode52s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode56s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode52s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode56s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode52s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode56s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode52s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode56s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode52s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode56s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode52s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode56s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode52s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode56s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode52s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode56s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode52s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode56s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode52s5hbhb">
+<h4 id="组件指南hahahugoshortcode56s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode52s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode56s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode52s6hbhb">
+<h4 id="格式指南hahahugoshortcode56s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode52s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode56s6hbhb">#</a>
 </h4>
 <h2 id="组件特定指南">
   组件特定指南

--- a/content/zh/how-to-contribute/code-style-and-quality-formatting/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-formatting/index.html
@@ -453,33 +453,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Formatting Guide
   <a class="anchor" href="#code-style-and-quality-guide--formatting-guide">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode54s0hbhb">
+<h4 id="序言hahahugoshortcode59s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode54s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode59s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode54s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode59s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode54s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode59s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode54s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode59s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode54s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode59s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode54s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode59s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode54s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode59s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode54s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode59s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode54s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode59s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode54s5hbhb">
+<h4 id="组件指南hahahugoshortcode59s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode54s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode59s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode54s6hbhb">
+<h4 id="格式指南hahahugoshortcode59s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode54s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode59s6hbhb">#</a>
 </h4>
 <h2 id="java-code-formatting-style">
   Java Code Formatting Style

--- a/content/zh/how-to-contribute/code-style-and-quality-java/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-java/index.html
@@ -451,33 +451,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Java
   <a class="anchor" href="#code-style-and-quality-guide--java">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode56s0hbhb">
+<h4 id="序言hahahugoshortcode61s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode56s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode61s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode56s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode61s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode56s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode61s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode56s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode61s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode56s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode61s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode56s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode61s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode56s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode61s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode56s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode61s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode56s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode61s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode56s5hbhb">
+<h4 id="组件指南hahahugoshortcode61s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode56s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode61s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode56s6hbhb">
+<h4 id="格式指南hahahugoshortcode61s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode56s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode61s6hbhb">#</a>
 </h4>
 <h2 id="java-language-features-and-libraries">
   Java Language Features and Libraries

--- a/content/zh/how-to-contribute/code-style-and-quality-preamble/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-preamble/index.html
@@ -463,33 +463,33 @@ https://github.com/alex-shpak/hugo-book
   Apache Flink Code Style and Quality Guide
   <a class="anchor" href="#apache-flink-code-style-and-quality-guide">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode58s0hbhb">
+<h4 id="序言hahahugoshortcode63s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode58s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode63s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode58s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode63s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode58s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode63s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode58s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode63s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode58s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode63s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode58s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode63s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode58s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode63s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode58s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode63s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode58s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode63s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode58s5hbhb">
+<h4 id="组件指南hahahugoshortcode63s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode58s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode63s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode58s6hbhb">
+<h4 id="格式指南hahahugoshortcode63s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode58s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode63s6hbhb">#</a>
 </h4>
 <hr>
 <p>这是对我们想要维护的代码和质量标准的一种尝试。</p>

--- a/content/zh/how-to-contribute/code-style-and-quality-pull-requests/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-pull-requests/index.html
@@ -453,33 +453,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Pull Requests &amp; Changes
   <a class="anchor" href="#code-style-and-quality-guide--pull-requests--changes">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode60s0hbhb">
+<h4 id="序言hahahugoshortcode65s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode60s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode65s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode60s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode65s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode60s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode65s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode60s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode65s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode60s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode65s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode60s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode65s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode60s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode65s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode60s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode65s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode60s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode65s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode60s5hbhb">
+<h4 id="组件指南hahahugoshortcode65s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode60s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode65s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode60s6hbhb">
+<h4 id="格式指南hahahugoshortcode65s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode60s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode65s6hbhb">#</a>
 </h4>
 <hr>
 <p><strong>Rationale:</strong> We ask contributors to put in a little bit of extra effort to bring pull requests into a state that they can be more easily and more thoroughly reviewed. This helps the community in many ways:</p>

--- a/content/zh/how-to-contribute/code-style-and-quality-scala/index.html
+++ b/content/zh/how-to-contribute/code-style-and-quality-scala/index.html
@@ -459,33 +459,33 @@ https://github.com/alex-shpak/hugo-book
   Code Style and Quality Guide — Scala
   <a class="anchor" href="#code-style-and-quality-guide--scala">#</a>
 </h1>
-<h4 id="序言hahahugoshortcode63s0hbhb">
+<h4 id="序言hahahugoshortcode67s0hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-preamble/">序言</a>
-  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode63s0hbhb">#</a>
+  <a class="anchor" href="#%e5%ba%8f%e8%a8%80hahahugoshortcode67s0hbhb">#</a>
 </h4>
-<h4 id="pull-requests--changeshahahugoshortcode63s1hbhb">
+<h4 id="pull-requests--changeshahahugoshortcode67s1hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-pull-requests/">Pull Requests &amp; Changes</a>
-  <a class="anchor" href="#pull-requests--changeshahahugoshortcode63s1hbhb">#</a>
+  <a class="anchor" href="#pull-requests--changeshahahugoshortcode67s1hbhb">#</a>
 </h4>
-<h4 id="常用编码指南hahahugoshortcode63s2hbhb">
+<h4 id="常用编码指南hahahugoshortcode67s2hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-common/">常用编码指南</a>
-  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode63s2hbhb">#</a>
+  <a class="anchor" href="#%e5%b8%b8%e7%94%a8%e7%bc%96%e7%a0%81%e6%8c%87%e5%8d%97hahahugoshortcode67s2hbhb">#</a>
 </h4>
-<h4 id="java-语言指南hahahugoshortcode63s3hbhb">
+<h4 id="java-语言指南hahahugoshortcode67s3hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-java/">Java 语言指南</a>
-  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode63s3hbhb">#</a>
+  <a class="anchor" href="#java-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode67s3hbhb">#</a>
 </h4>
-<h4 id="scala-语言指南hahahugoshortcode63s4hbhb">
+<h4 id="scala-语言指南hahahugoshortcode67s4hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-scala/">Scala 语言指南</a>
-  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode63s4hbhb">#</a>
+  <a class="anchor" href="#scala-%e8%af%ad%e8%a8%80%e6%8c%87%e5%8d%97hahahugoshortcode67s4hbhb">#</a>
 </h4>
-<h4 id="组件指南hahahugoshortcode63s5hbhb">
+<h4 id="组件指南hahahugoshortcode67s5hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-components/">组件指南</a>
-  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode63s5hbhb">#</a>
+  <a class="anchor" href="#%e7%bb%84%e4%bb%b6%e6%8c%87%e5%8d%97hahahugoshortcode67s5hbhb">#</a>
 </h4>
-<h4 id="格式指南hahahugoshortcode63s6hbhb">
+<h4 id="格式指南hahahugoshortcode67s6hbhb">
   <a href="/zh/how-to-contribute/code-style-and-quality-formatting/">格式指南</a>
-  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode63s6hbhb">#</a>
+  <a class="anchor" href="#%e6%a0%bc%e5%bc%8f%e6%8c%87%e5%8d%97hahahugoshortcode67s6hbhb">#</a>
 </h4>
 <h2 id="scala-语言特性">
   Scala 语言特性

--- a/docs/content/posts/2024-01-19-release-1.18.1.md
+++ b/docs/content/posts/2024-01-19-release-1.18.1.md
@@ -18,7 +18,7 @@ Below you will find a list of all bugfixes and improvements (excluding improveme
 We highly recommend all users upgrade to Flink 1.18.1.
 
 **Note: Users that have [state compression](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/ops/state/large_state_tuning/#compression) 
-should not migrated to 1.18.1 (nor 1.18.0) due to a critical bug that could lead to data loss. Please refer to [FLINK-34063](https://issues.apache.org/jira/browse/FLINK-34063) for more information.**
+should not migrate to 1.18.1 (nor 1.18.0) due to a critical bug that could lead to data loss. Please refer to [FLINK-34063](https://issues.apache.org/jira/browse/FLINK-34063) for more information.**
 
 # Release Artifacts
 


### PR DESCRIPTION
should not `migrated `-> should not `migrate`