### PR TITLE
[FLINK-34654] Add Special Thanks Page on the Flink Website

### DIFF
--- a/docs/content.zh/what-is-flink/special-thanks.md
+++ b/docs/content.zh/what-is-flink/special-thanks.md
@@ -42,7 +42,7 @@ https://www.apache.org/foundation/sponsorship.html
 
 - [Alibaba](https://www.alibabagroup.com/en-US) 捐赠了 8 台机器（32vCPU,64GB）为 Flink 仓库和 Pull Reqeust 运行[持续集成的任务](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-AvailableCustomBuildMachines)。
 - [AWS](https://aws.amazon.com/opensource/) 捐赠了 AWS 服务的开销，这些 AWS 服务用在了 [flink-connector-aws](https://github.com/apache/flink-connector-aws) 项目的集成测试中。
-- [Ververica](http://ververica.com/) 捐赠了一台机器（1vCPU,2GB）用于维护 [flink-ci](https://cwiki.apache.org/confluence/display/FLINK/Continuous+Integration) 镜像仓库，以及一台机器（8vCPU,64GB）运行日常的 [Flink Benchmark](https://lists.apache.org/thread.html/41a68c775753a7841896690c75438e0a497634102e676db880f30225@%3Cdev.flink.apache.org%3E)。
+- [Ververica](http://ververica.com/) 捐赠了一台机器（1vCPU,2GB）用于维护 [flink-ci](https://cwiki.apache.org/confluence/display/FLINK/Continuous+Integration) 镜像仓库，以及一台机器（8vCPU,64GB）运行日常的 [Flink Benchmark](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=115511847)。
 
 
 

--- a/docs/content.zh/what-is-flink/special-thanks.md
+++ b/docs/content.zh/what-is-flink/special-thanks.md
@@ -1,0 +1,48 @@
+---
+title: 特殊致谢
+bookCollapseSection: false
+weight: 9
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# 特殊致谢
+
+## Apache 赞助商
+
+没有这些赞助商，ASF 将无法维持其活动：
+
+https://www.apache.org/foundation/thanks.html
+
+如果您想了解更多关于 Apache 赞助计划的信息，请查看：
+
+https://www.apache.org/foundation/sponsorship.html
+
+感谢！
+
+## 那些帮助了我们项目的公司...
+
+我们还要感谢那些赞助了机器或服务的公司，感谢他们的赞助帮助了 Apache Flink 项目的开发：
+
+- [Alibaba](https://www.alibabagroup.com/en-US) 捐赠了 8 台机器（32vCPU,64GB）为 Flink 仓库和 Pull Reqeust 运行[持续集成的任务](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-AvailableCustomBuildMachines)。
+- [AWS](https://aws.amazon.com/opensource/) 捐赠了 AWS 服务的开销，这些 AWS 服务用在了 [flink-connector-aws](https://github.com/apache/flink-connector-aws) 项目的集成测试中。
+- [Ververica](http://ververica.com/) 捐赠了一台机器（1vCPU,2GB）用于维护 [flink-ci](https://cwiki.apache.org/confluence/display/FLINK/Continuous+Integration) 镜像仓库，以及一台机器（8vCPU,64GB）运行日常的 [Flink Benchmark](https://lists.apache.org/thread.html/41a68c775753a7841896690c75438e0a497634102e676db880f30225@%3Cdev.flink.apache.org%3E)。
+
+
+

--- a/docs/content/what-is-flink/special-thanks.md
+++ b/docs/content/what-is-flink/special-thanks.md
@@ -1,0 +1,48 @@
+---
+title: Special Thanks
+bookCollapseSection: false
+weight: 9
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Special Thanks
+
+## General Apache sponsors
+Without those sponsors, the ASF would simply not exist or sustain its activities :
+
+https://www.apache.org/foundation/thanks.html
+
+For those who want to know more about the Apache Sponsorship Program, please check :
+
+https://www.apache.org/foundation/sponsorship.html
+
+Thanks !
+
+## Organizations who helped our project …
+
+We would also like to thank the companies and organizations who sponsored machines or services for helping the development of Apache Flink:
+
+- [Alibaba](https://www.alibabagroup.com/en-US) donated 8 machines (32vCPU,64GB) to run [Flink CI builds](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-AvailableCustomBuildMachines) for Flink repository and Flink pull requests.
+- [AWS](https://aws.amazon.com/opensource/) donated service costs for [flink-connector-aws](https://github.com/apache/flink-connector-aws) tests that hit real AWS services. 
+- [Ververica](http://ververica.com/) donated a machine (1vCPU,2GB) for hosting [flink-ci](https://cwiki.apache.org/confluence/display/FLINK/Continuous+Integration) 
+  repositories and a machine (8vCPU,64GB) for running [Flink benchmarks](https://lists.apache.org/thread.html/41a68c775753a7841896690c75438e0a497634102e676db880f30225@%3Cdev.flink.apache.org%3E).
+
+
+

--- a/docs/content/what-is-flink/special-thanks.md
+++ b/docs/content/what-is-flink/special-thanks.md
@@ -29,7 +29,7 @@ Without those sponsors, the ASF would simply not exist or sustain its activities
 
 https://www.apache.org/foundation/thanks.html
 
-For those who want to know more about the Apache Sponsorship Program, please check :
+For those who want to know more about the Apache Sponsorship Program, please check:
 
 https://www.apache.org/foundation/sponsorship.html
 
@@ -42,7 +42,7 @@ We would also like to thank the companies and organizations who sponsored machin
 - [Alibaba](https://www.alibabagroup.com/en-US) donated 8 machines (32vCPU,64GB) to run [Flink CI builds](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-AvailableCustomBuildMachines) for Flink repository and Flink pull requests.
 - [AWS](https://aws.amazon.com/opensource/) donated service costs for [flink-connector-aws](https://github.com/apache/flink-connector-aws) tests that hit real AWS services. 
 - [Ververica](http://ververica.com/) donated a machine (1vCPU,2GB) for hosting [flink-ci](https://cwiki.apache.org/confluence/display/FLINK/Continuous+Integration) 
-  repositories and a machine (8vCPU,64GB) for running [Flink benchmarks](https://lists.apache.org/thread.html/41a68c775753a7841896690c75438e0a497634102e676db880f30225@%3Cdev.flink.apache.org%3E).
+  repositories and a machine (8vCPU,64GB) for running [Flink benchmarks](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=115511847).
 
 
 

--- a/docs/content/what-is-flink/special-thanks.md
+++ b/docs/content/what-is-flink/special-thanks.md
@@ -25,7 +25,7 @@ under the License.
 # Special Thanks
 
 ## General Apache sponsors
-Without those sponsors, the ASF would simply not exist or sustain its activities :
+Without those sponsors, the ASF would simply not exist or sustain its activities:
 
 https://www.apache.org/foundation/thanks.html
 


### PR DESCRIPTION
The content of the "Special Thanks" page follows [ASF guidelines](https://www.apache.org/foundation/marks/linking#projectthanks). Some examples from other projects: [Apache HBase](https://hbase.apache.org/sponsors.html), [Apache Mina](https://mina.apache.org/special-thanks.html), [Apache Airflow](https://github.com/apache/airflow?tab=readme-ov-file#sponsors), [Apache ActiveMQ](https://activemq.apache.org/components/classic/documentation/thanks). 

The page image (the order of companies are in alphabet):
![image](https://github.com/apache/flink-web/assets/5378924/d4320b24-74ae-4a7c-b71e-c25353e3f73e)

The page link is at the bottom of "About" menu. 

![image](https://github.com/apache/flink-web/assets/5378924/9878204d-aca7-48f4-b024-da29ae1faf87)

