### PR TITLE
Update use-cases.md

### DIFF
--- a/docs/content.zh/what-is-flink/use-cases.md
+++ b/docs/content.zh/what-is-flink/use-cases.md
@@ -124,4 +124,4 @@ Flink 为持续流式分析和批量分析都提供了良好的支持。具体�
 ### 典型的数据管道应用实例
 
 * 电子商务中的<a href="https://ververica.com/blog/blink-flink-alibaba-search">实时查询索引构建</a>
-* 电子商务中的<a href="https://jobs.zalando.com/tech/blog/apache-showdown-flink-vs.-spark/">持续 ETL</a>
+* 电子商务中的<a href="https://engineering.zalando.com/posts/2016/03/apache-showdown-flink-vs.-spark.html">持续 ETL</a>


### PR DESCRIPTION
更新电子商务中持续 ETL超链接地址，原地址已失效。