### PR TITLE
Add Flink 1.19.1 release

### DIFF
--- a/docs/content/posts/2024-06-14-release-1.19.1.md
+++ b/docs/content/posts/2024-06-14-release-1.19.1.md
@@ -1,0 +1,128 @@
+---
+title:  "Apache Flink 1.19.1 Release Announcement"
+date: "2024-06-14T00:00:00.000Z"
+aliases:
+- /news/2024/06/14/release-1.19.1.html
+authors:
+- hong:
+  name: "Hong"
+  twitter: "hlteoh2"
+---
+
+The Apache Flink Community is pleased to announce the first bug fix release of the Flink 1.19 series.
+
+This release includes 44 bug fixes, vulnerability fixes, and minor improvements for Flink 1.19.
+Below you will find a list of all bugfixes and improvements (excluding improvements to the build infrastructure and build stability). For a complete list of all changes see:
+[JIRA](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315522&version=12354399).
+
+We highly recommend all users upgrade to Flink 1.19.1.
+
+# Release Artifacts
+
+## Maven Dependencies
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-java</artifactId>
+  <version>1.19.1</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-java</artifactId>
+  <version>1.19.1</version>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-clients</artifactId>
+  <version>1.19.1</version>
+</dependency>
+```
+
+## Binaries
+
+You can find the binaries on the updated [Downloads page]({{< relref "downloads" >}}).
+
+## Docker Images
+
+* [library/flink](https://hub.docker.com/_/flink/tags?page=1&name=1.19.1) (official images)
+* [apache/flink](https://hub.docker.com/r/apache/flink/tags?page=1&name=1.19.1) (ASF repository)
+
+## PyPi
+
+* [apache-flink==1.19.1](https://pypi.org/project/apache-flink/1.19.1/)
+
+# Release Notes
+
+
+
+        Release Notes - Flink - Version 1.19.1
+
+<h2>        Bug
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-26808'>FLINK-26808</a>] -         [flink v1.14.2] Submit jobs via REST API not working after set web.submit.enable: false
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-27741'>FLINK-27741</a>] -         Fix NPE when use dense_rank() and rank() in over aggregation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-28693'>FLINK-28693</a>] -         Codegen failed if the watermark is defined on a columnByExpression
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-31223'>FLINK-31223</a>] -         sql-client.sh fails to start with ssl enabled
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-32513'>FLINK-32513</a>] -         Job in BATCH mode with a significant number of transformations freezes on method StreamGraphGenerator.existsUnboundedSource()
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-32828'>FLINK-32828</a>] -         Partition aware watermark not handled correctly shortly after job start up from checkpoint or savepoint
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-33798'>FLINK-33798</a>] -         Automatically clean up rocksdb logs when the task failover.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34379'>FLINK-34379</a>] -         table.optimizer.dynamic-filtering.enabled lead to OutOfMemoryError
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34517'>FLINK-34517</a>] -         environment configs ignored when calling procedure operation
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34616'>FLINK-34616</a>] -         python dist doesn&#39;t clean when open method construct resource
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34725'>FLINK-34725</a>] -         Dockerfiles for release publishing has incorrect config.yaml path
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34956'>FLINK-34956</a>] -         The config type is wrong for Duration
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35089'>FLINK-35089</a>] -         Two input AbstractStreamOperator may throw NPE when receiving RecordAttributes
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35097'>FLINK-35097</a>] -         Table API Filesystem connector with &#39;raw&#39; format repeats last line
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35098'>FLINK-35098</a>] -         Incorrect results for queries like &quot;10 &gt;= y&quot; on tables using Filesystem connector and Orc format
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35112'>FLINK-35112</a>] -         Membership for Row class does not include field names
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35159'>FLINK-35159</a>] -         CreatingExecutionGraph can leak CheckpointCoordinator and cause JM crash
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35169'>FLINK-35169</a>] -         Recycle buffers to freeSegments before releasing data buffer for sort accumulator
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35217'>FLINK-35217</a>] -         Missing fsync in FileSystemCheckpointStorage
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35351'>FLINK-35351</a>] -         Restore from unaligned checkpoints with a custom partitioner fails.
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35358'>FLINK-35358</a>] -         Breaking change when loading artifacts
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35429'>FLINK-35429</a>] -         We don&#39;t need introduce getFlinkConfigurationOptions for SqlGatewayRestEndpointFactory#Context
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35554'>FLINK-35554</a>] -         usrlib is not added to classpath when using containers
+</li>
+</ul>
+
+<h2>        Improvement
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34746'>FLINK-34746</a>] -         Switching to the Apache CDN for Dockerfile
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34922'>FLINK-34922</a>] -         Exception History should support multiple Global failures
+</li>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-34955'>FLINK-34955</a>] -         Upgrade commons-compress to 1.26.0
+</li>
+</ul>
+
+<h2>        Technical Debt
+</h2>
+<ul>
+<li>[<a href='https://issues.apache.org/jira/browse/FLINK-35532'>FLINK-35532</a>] -         Prevent Cross-Site Authentication (XSA) attacks on Flink dashboard
+</li>
+</ul>

--- a/docs/data/flink.yml
+++ b/docs/data/flink.yml
@@ -16,13 +16,13 @@
 # under the License
 
 1.19:
-  name: "Apache Flink 1.19.0"
-  binary_release_url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.19.0/flink-1.19.0-bin-scala_2.12.tgz"
-  binary_release_asc_url: "https://downloads.apache.org/flink/flink-1.19.0/flink-1.19.0-bin-scala_2.12.tgz.asc"
-  binary_release_sha512_url: "https://downloads.apache.org/flink/flink-1.19.0/flink-1.19.0-bin-scala_2.12.tgz.sha512"
-  source_release_url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.19.0/flink-1.19.0-src.tgz"
-  source_release_asc_url: "https://downloads.apache.org/flink/flink-1.19.0/flink-1.19.0-src.tgz.asc"
-  source_release_sha512_url: "https://downloads.apache.org/flink/flink-1.19.0/flink-1.19.0-src.tgz.sha512"
+  name: "Apache Flink 1.19.1"
+  binary_release_url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.19.1/flink-1.19.1-bin-scala_2.12.tgz"
+  binary_release_asc_url: "https://downloads.apache.org/flink/flink-1.19.1/flink-1.19.1-bin-scala_2.12.tgz.asc"
+  binary_release_sha512_url: "https://downloads.apache.org/flink/flink-1.19.1/flink-1.19.1-bin-scala_2.12.tgz.sha512"
+  source_release_url: "https://www.apache.org/dyn/closer.lua/flink/flink-1.19.1/flink-1.19.1-src.tgz"
+  source_release_asc_url: "https://downloads.apache.org/flink/flink-1.19.1/flink-1.19.1-src.tgz.asc"
+  source_release_sha512_url: "https://downloads.apache.org/flink/flink-1.19.1/flink-1.19.1-src.tgz.sha512"
   release_notes_url: "https://nightlies.apache.org/flink/flink-docs-release-1.19/release-notes/flink-1.19"
 
 1.18:

--- a/docs/data/release_archive.yml
+++ b/docs/data/release_archive.yml
@@ -1,6 +1,11 @@
 release_archive:
   flink:
-    - version_short: "1.19"
+    -
+      version_short: "1.19"
+      version_long: 1.19.1
+      release_date: 2024-06-14
+    -
+      version_short: "1.19"
       version_long: 1.19.0
       release_date: 2024-03-18
     -


### PR DESCRIPTION
- Add Flink 1.19.1 release blog announcement scheduled for 2024-06-14.
- Add Flink 1.19.1 release to release archive.
- Change Flink 1.19 to point to Flink 1.19.1
