### PR TITLE
corrected released version in the release doc.

### DIFF
--- a/docs/content/posts/2024-10-30-release-kubernetes-operator-1.10.0.md
+++ b/docs/content/posts/2024-10-30-release-kubernetes-operator-1.10.0.md
@@ -60,7 +60,7 @@ The release notes can be found [here](https://issues.apache.org/jira/secure/Rele
 
 ## Release Resources
 
-The source artifacts and helm chart are available on the Downloads page of the Flink website. You can easily try out the new features shipped in the official 1.8.0 release by adding the Helm chart to your own local registry:
+The source artifacts and helm chart are available on the Downloads page of the Flink website. You can easily try out the new features shipped in the official 1.10.0 release by adding the Helm chart to your own local registry:
 
 ```
 $ helm repo add flink-kubernetes-operator-1.10.0 https://archive.apache.org/dist/flink/flink-kubernetes-operator-1.10.0/


### PR DESCRIPTION
JIRA - https://issues.apache.org/jira/browse/FLINK-37451

Corrected the released version in the release documents,
https://flink.apache.org/2024/10/25/apache-flink-kubernetes-operator-1.10.0-release-announcement/#release-resources
https://flink.apache.org/2024/07/02/apache-flink-kubernetes-operator-1.9.0-release-announcement/#release-resources

from =>
The source artifacts and helm chart are available on the Downloads page of the Flink website. You can easily try out the new features shipped in the official **_`1.8.0`_** release by adding the Helm chart to your own local registry:

to =>
The source artifacts and helm chart are available on the Downloads page of the Flink website. You can easily try out the new features shipped in the official **_`1.10.0`_** release by adding the Helm chart to your own local registry:

The source artifacts and helm chart are available on the Downloads page of the Flink website. You can easily try out the new features shipped in the official **_`1.9.0`_** release by adding the Helm chart to your own local registry:
