### PR TITLE
[hotfix] Fix typos in documentation source and templates

### DIFF
--- a/docs/content/how-to-contribute/documentation-style-guide.md
+++ b/docs/content/how-to-contribute/documentation-style-guide.md
@@ -113,7 +113,7 @@ the file and must be specified as a valid YAML set between triple-dashed lines.
 
 For every documentation file, the front matter should be immediately
 followed by the Apache License statement. For both language versions, this
-block must be stated in US English and copied in the exact same words as inthe following example.
+block must be stated in US English and copied in the exact same words as in the following example.
 
 
 ```

--- a/docs/layouts/partials/docs/footer.html
+++ b/docs/layouts/partials/docs/footer.html
@@ -34,7 +34,7 @@ under the License.
           <li>
             <a href="https://www.apache.org/licenses/">{{ i18n "footer.license" }}</a>
           </li>
-          <!-- merge languages into a single dictonary -->
+          <!-- merge languages into a single dictionary -->
           {{ $translations := dict }}
           {{ range .Site.Home.AllTranslations }}
             {{ $translations = merge $translations (dict .Language.Lang .) }}

--- a/docs/layouts/partials/docs/simple-title.html
+++ b/docs/layouts/partials/docs/simple-title.html
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <!-- 
-  Partial to generate page name without sytling
+  Partial to generate page name without styling
   from Title or File name. Accepts Page as context.
 -->
 {{ $title := "" }}

--- a/docs/layouts/shortcodes/docs_link.html
+++ b/docs/layouts/shortcodes/docs_link.html
@@ -19,7 +19,7 @@ under the License.
     Shortcode for linking to a file in the training repo github. This shortcode
     will automatically discover the repo and correct branch.
 
-    Parmeters: 
+    Parameters:
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}

--- a/docs/layouts/shortcodes/external_link.html
+++ b/docs/layouts/shortcodes/external_link.html
@@ -19,7 +19,7 @@ under the License.
     Shortcode for linking to a file in the training repo github. This shortcode
     will automatically discover the repo and correct branch.
 
-    Parmeters: 
+    Parameters:
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}

--- a/docs/layouts/shortcodes/img.html
+++ b/docs/layouts/shortcodes/img.html
@@ -21,7 +21,7 @@ under the License.
   because we can configure the HTML image tag
   properties.
 
-  Parmeters: 
+  Parameters:
       - src: The absolute path to the image file (required)
       - alt: Image alt text (optional)
       - width: Image width (optional)

--- a/docs/layouts/shortcodes/recent_posts.html
+++ b/docs/layouts/shortcodes/recent_posts.html
@@ -21,7 +21,7 @@ under the License.
   because we can configure the HTML image tag
   properties.
 
-  Parmeters: 
+  Parameters:
       - src: The absolute path to the image file (required)
       - alt: Image alt text (optional)
       - width: Image width (optional)


### PR DESCRIPTION
## What is the purpose of the change

Fixes a few spelling typos in the website source. No content or wording
changes beyond the corrections themselves.

## Brief change log

- `documentation-style-guide.md`: "copied in the exact same words as **inthe** following example" → "as **in the** following example"
- Hugo template comments:
  - `shortcodes/docs_link.html`, `shortcodes/external_link.html`, `shortcodes/img.html`, `shortcodes/recent_posts.html`: `Parmeters:` → `Parameters:`
  - `partials/docs/footer.html`: `dictonary` → `dictionary`
  - `partials/docs/simple-title.html`: `sytling` → `styling`

Only source files under `docs/` are touched. The generated `content/` is
intentionally left untouched and can be regenerated at merge time.

## AI assistance disclosure

- [x] Claude Code
