### PR TITLE
Fix broken link to getting started with Flink

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -171,7 +171,7 @@ https://github.com/alex-shpak/hugo-book
           <li>
             
   
-    <a class="dropdown-item" href="https://nightlies.apache.org/flink/flink-docs-stable/docs/try-flink/local_installation/">With Flink<i class="link fa fa-external-link title" aria-hidden="true"></i>
+    <a class="dropdown-item" href="https://nightlies.apache.org/flink/flink-docs-stable/docs/getting-started/local_installation/">With Flink<i class="link fa fa-external-link title" aria-hidden="true"></i>
     </a>
   
 


### PR DESCRIPTION
One-line change to fix the broken link (404 Not Found):
https://nightlies.apache.org/flink/flink-docs-stable/docs/try-flink/local_installation/ 
on https://flink.apache.org/  >  Getting Started  >  With Flink
into 
https://nightlies.apache.org/flink/flink-docs-stable/docs/getting-started/local_installation/