### PR TITLE
[hotfix] Fix broken links and markup in website source

### DIFF
--- a/docs/content.zh/downloads.md
+++ b/docs/content.zh/downloads.md
@@ -3,6 +3,9 @@ title: Downloads
 bookCollapseSection: false
 weight: 5
 menu_weight: 2
+aliases:
+- /zh/downloads.html
+- /zh/downloads/index.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/getting-started/_index.md
+++ b/docs/content.zh/getting-started/_index.md
@@ -23,4 +23,4 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Documentation
+# 教程

--- a/docs/content.zh/how-to-contribute/contribute-code.md
+++ b/docs/content.zh/how-to-contribute/contribute-code.md
@@ -105,7 +105,7 @@ Apache Flink 是一个通过志愿者贡献的代码来维护、改进和扩展�
     <div class="panel panel-default">
       <div class="panel-body">
         <h2><span class="number">2</span><a href="#implement">实现</a></h2>
-        <p>根据<a href="/zh/contributing/code-style-and-quality-preamble.html">代码样式和质量指南</a>，以及 Jira 工单中商定的方法去实现更改。</p> <br />
+        <p>根据<a href="{{< relref "how-to-contribute/code-style-and-quality-preamble" >}}">代码样式和质量指南</a>，以及 Jira 工单中商定的方法去实现更改。</p> <br />
         <p><b>只有在达成共识时,才开始去实现(例如已经有工单分配给你了)</b></p>
       </div>
     </div>
@@ -203,7 +203,7 @@ Apache Flink 是一个通过志愿者贡献的代码来维护、改进和扩展�
 以下是在实现时要注意的一些要点：
 
 - [设置 Flink 的开发环境](https://cwiki.apache.org/confluence/display/FLINK/Setting+up+a+Flink+development+environment)
-- 遵循 Flink 的[代码风格和质量指南](/zh/contributing/code-style-and-quality-preamble.html)
+- 遵循 Flink 的[代码风格和质量指南]({{< relref "how-to-contribute/code-style-and-quality-preamble" >}})
 - 接受来自 Jira issue 或设计文档中的任何讨论和要求。
 - 不要将不相关的问题混合到一个贡献中。
 
@@ -227,7 +227,7 @@ Apache Flink 是一个通过志愿者贡献的代码来维护、改进和扩展�
 
 Flink 中的代码更改将通过 [GitHub pull request](https://help.github.com/en/articles/creating-a-pull-request) 进行审查和合并。
 
-这里有关于[如何审查 pull request](/zh/contributing/reviewing-prs.html) 的单独指南，包括我们的 pull request 审核流程。作为代码作者，在你准备 pull request 前，应该满足以上所有要求。
+这里有关于[如何审查 pull request]({{< relref "how-to-contribute/reviewing-prs" >}}) 的单独指南，包括我们的 pull request 审核流程。作为代码作者，在你准备 pull request 前，应该满足以上所有要求。
 
 <a name="merge"></a>
 

--- a/docs/content.zh/what-is-flink-table-store.md
+++ b/docs/content.zh/what-is-flink-table-store.md
@@ -1,5 +1,5 @@
 ---
-title: What is Paimon(incubating) (formerly Flink Table Store)?
+title: What is Apache Paimon (formerly Flink Table Store)?
 bookCollapseSection: false
 bookHref: "https://paimon.apache.org/"
 ---
@@ -24,4 +24,4 @@ under the License.
 
 # What is Apache Paimon (formerly Flink Table Store)?
 
-The Flink Table Store had joined Apache Incubator as Apache Paimon(incubating). All information on the Apache Paimon(incubating) can be found on the [Paimon website.](https://paimon.apache.org/)
+Flink Table Store is now Apache Paimon, a separate top-level project at the Apache Software Foundation. All information about Apache Paimon can be found on the [Paimon website](https://paimon.apache.org/).

--- a/docs/content.zh/what-is-flink/community.md
+++ b/docs/content.zh/what-is-flink/community.md
@@ -215,10 +215,6 @@ Committer 们会关注 [Stack Overflow](http://stackoverflow.com/questions/tagge
     * ASF 仓库: [https://gitbox.apache.org/repos/asf/flink-kubernetes-operator.git](https://gitbox.apache.org/repos/asf/flink-kubernetes-operator.git)
     * GitHub 镜像: [https://github.com/apache/flink-kubernetes-operator](https://github.com/apache/flink-kubernetes-operator)
 
-* **Apache Paimon(incubating) (formerly Flink Table Store) 仓库**
-    * ASF 仓库: [https://gitbox.apache.org/repos/asf/incubator-paimon.git](https://gitbox.apache.org/repos/asf/incubator-paimon.git)
-    * GitHub 镜像: [https://github.com/apache/incubator-paimon](https://github.com/apache/incubator-paimon)
-
 * **Flink Website 仓库**
     * ASF 仓库: [https://gitbox.apache.org/repos/asf/flink-web.git](https://gitbox.apache.org/repos/asf/flink-web.git)
     * GitHub 镜像:  [https://github.com/apache/flink-web.git](https://github.com/apache/flink-web.git)

--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -3,6 +3,9 @@ title: Downloads
 bookCollapseSection: false
 weight: 5
 menu_weight: 2
+aliases:
+- /downloads.html
+- /downloads/index.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -23,4 +23,4 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Documentation
+# Getting Started

--- a/docs/content/what-is-flink-table-store.md
+++ b/docs/content/what-is-flink-table-store.md
@@ -1,5 +1,5 @@
 ---
-title: What is Paimon(incubating) (formerly Flink Table Store)?
+title: What is Apache Paimon (formerly Flink Table Store)?
 bookCollapseSection: false
 bookHref: "https://paimon.apache.org/"
 ---
@@ -24,4 +24,4 @@ under the License.
 
 # What is Apache Paimon (formerly Flink Table Store)?
 
-The Flink Table Store had joined Apache Incubator as Apache Paimon(incubating). All information on the Apache Paimon(incubating) can be found on the [Paimon website.](https://paimon.apache.org/)
+Flink Table Store is now Apache Paimon, a separate top-level project at the Apache Software Foundation. All information about Apache Paimon can be found on the [Paimon website](https://paimon.apache.org/).

--- a/docs/layouts/partials/docs/footer.html
+++ b/docs/layouts/partials/docs/footer.html
@@ -59,7 +59,7 @@ under the License.
       <div class="panel">
         <ul>
           <li>
-            <a href="{{ $.Site.LanguagePrefix }}/what-is-flink/security">{{ i18n "footer.security" }}</a-->
+            <a href="{{ $.Site.LanguagePrefix }}/what-is-flink/security">{{ i18n "footer.security" }}</a>
           </li>
           <li>
             <a href="https://www.apache.org/foundation/sponsorship.html">{{ i18n "footer.donate" }}</a>


### PR DESCRIPTION
## What is the purpose of the change

Fixes six small defects in the website sources: invalid markup, links to a URL scheme retired in the 2023 redesign, a heading copied from the wrong file, and a subproject status that changed in 2024.

## Brief change log

- `footer.html`: Security link closed with `</a-->`, emitting invalid markup in the footer of every page in both languages
- `getting-started/_index.md` (en, zh): heading rendered as "Documentation"; now matches each file's own frontmatter title
- `content.zh/how-to-contribute/contribute-code.md`: three links to `/zh/contributing/*.html` have 404'd since the 2023 redesign (FLINK-33046); replaced with the `relref` shortcodes the English page already uses
- `downloads.md` (en, zh): added `/downloads.html` aliases (~50 release blog posts link there), matching the pattern in `community.md` and `roadmap.md`
- `what-is-flink-table-store.md` (en, zh): described Paimon as incubating; it has been a top-level project since 2024-04-16
- `content.zh/what-is-flink/community.md`: removed the Paimon repo entry pointing at the retired `incubator-paimon` repos, as the English page did in 9d0761c266 (FLINK-34946)

The last item is the only judgment call; happy to repoint the URLs instead if preferred.

## Verifying this change

Built with Hugo 0.124.1 extended and checked in the generated output: both aliases redirect, the two `relref` links resolve under `/zh/how-to-contribute/`, and no `a-->` or `incubator-paimon` references remain. Source files only; `content/` left for the committer rebuild.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - Chinese pages here changed only mechanically; the remaining `content.zh` gaps need a native speaker and are headed for `chinese-translation` Jiras ([FLINK-13680](https://issues.apache.org/jira/browse/FLINK-13680) already covers the code-style page)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5)
